### PR TITLE
Use buildkite/yaml to enable anchors in stages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-vela/types
 go 1.13
 
 require (
+	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/lib/pq v1.2.0
 	gopkg.in/yaml.v2 v2.2.4
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/go-vela/types/raw"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/buildkite/yaml"
 )
 
 func TestYaml_Build_UnmarshalYAML(t *testing.T) {
@@ -206,6 +206,250 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 
 	// run test
 	b, err := ioutil.ReadFile("testdata/build.yml")
+	if err != nil {
+		t.Errorf("Reading file for UnmarshalYAML returned err: %v", err)
+	}
+
+	err = yaml.Unmarshal(b, got)
+
+	if err != nil {
+		t.Errorf("UnmarshalYAML returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UnmarshalYAML is %v, want %v", got, want)
+	}
+}
+
+func TestYaml_Build_UnmarshalYAML_AnchorStage(t *testing.T) {
+	// setup types
+	want := &Build{
+		Version: "1",
+		Metadata: Metadata{
+			Template: false,
+		},
+		Stages: StageSlice{
+			&Stage{
+				Name:  "dependencies",
+				Needs: []string{"clone"},
+				Steps: StepSlice{
+					&Step{
+						Commands: raw.StringSlice{"./gradlew downloadDependencies"},
+						Environment: raw.StringSliceMap{
+							"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+							"GRADLE_USER_HOME": ".gradle",
+						},
+						Image: "openjdk:latest",
+						Name:  "install",
+						Pull:  true,
+						Ruleset: Ruleset{
+							If:       Rules{Event: []string{"push", "pull_request"}},
+							Operator: "and",
+						},
+						Volumes: VolumeSlice{
+							&Volume{
+								Source:      "/foo",
+								Destination: "/bar",
+								AccessMode:  "ro",
+							},
+						},
+						Ulimits: UlimitSlice{
+							&Ulimit{
+								Name: "foo",
+								Soft: 1024,
+								Hard: 2048,
+							},
+						},
+					},
+				},
+			},
+			&Stage{
+				Name:  "test",
+				Needs: []string{"dependencies"},
+				Steps: StepSlice{
+					&Step{
+						Commands: raw.StringSlice{"./gradlew check"},
+						Environment: raw.StringSliceMap{
+							"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+							"GRADLE_USER_HOME": ".gradle",
+						},
+						Name:  "test",
+						Image: "openjdk:latest",
+						Pull:  true,
+						Ruleset: Ruleset{
+							If:       Rules{Event: []string{"push", "pull_request"}},
+							Operator: "and",
+						},
+						Volumes: VolumeSlice{
+							&Volume{
+								Source:      "/foo",
+								Destination: "/bar",
+								AccessMode:  "ro",
+							},
+						},
+						Ulimits: UlimitSlice{
+							&Ulimit{
+								Name: "foo",
+								Soft: 1024,
+								Hard: 2048,
+							},
+						},
+					},
+				},
+			},
+			&Stage{
+				Name:  "build",
+				Needs: []string{"dependencies"},
+				Steps: StepSlice{
+					&Step{
+						Commands: raw.StringSlice{"./gradlew build"},
+						Environment: raw.StringSliceMap{
+							"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+							"GRADLE_USER_HOME": ".gradle",
+						},
+						Name:  "build",
+						Image: "openjdk:latest",
+						Pull:  true,
+						Ruleset: Ruleset{
+							If:       Rules{Event: []string{"push", "pull_request"}},
+							Operator: "and",
+						},
+						Volumes: VolumeSlice{
+							&Volume{
+								Source:      "/foo",
+								Destination: "/bar",
+								AccessMode:  "ro",
+							},
+						},
+						Ulimits: UlimitSlice{
+							&Ulimit{
+								Name: "foo",
+								Soft: 1024,
+								Hard: 2048,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	got := new(Build)
+
+	// run test
+	b, err := ioutil.ReadFile("testdata/build_anchor_stage.yml")
+	if err != nil {
+		t.Errorf("Reading file for UnmarshalYAML returned err: %v", err)
+	}
+
+	err = yaml.Unmarshal(b, got)
+
+	if err != nil {
+		t.Errorf("UnmarshalYAML returned err: %v", err)
+	}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("UnmarshalYAML is %v, want %v", got, want)
+	}
+}
+
+func TestYaml_Build_UnmarshalYAML_AnchorSteps(t *testing.T) {
+	// setup types
+	want := &Build{
+		Version: "1",
+		Metadata: Metadata{
+			Template: false,
+		},
+		Steps: StepSlice{
+			&Step{
+				Commands: raw.StringSlice{"./gradlew downloadDependencies"},
+				Environment: raw.StringSliceMap{
+					"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+					"GRADLE_USER_HOME": ".gradle",
+				},
+				Image: "openjdk:latest",
+				Name:  "install",
+				Pull:  true,
+				Ruleset: Ruleset{
+					If:       Rules{Event: []string{"push", "pull_request"}},
+					Operator: "and",
+				},
+				Volumes: VolumeSlice{
+					&Volume{
+						Source:      "/foo",
+						Destination: "/bar",
+						AccessMode:  "ro",
+					},
+				},
+				Ulimits: UlimitSlice{
+					&Ulimit{
+						Name: "foo",
+						Soft: 1024,
+						Hard: 2048,
+					},
+				},
+			},
+			&Step{
+				Commands: raw.StringSlice{"./gradlew check"},
+				Environment: raw.StringSliceMap{
+					"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+					"GRADLE_USER_HOME": ".gradle",
+				},
+				Name:  "test",
+				Image: "openjdk:latest",
+				Pull:  true,
+				Ruleset: Ruleset{
+					If:       Rules{Event: []string{"push", "pull_request"}},
+					Operator: "and",
+				},
+				Volumes: VolumeSlice{
+					&Volume{
+						Source:      "/foo",
+						Destination: "/bar",
+						AccessMode:  "ro",
+					},
+				},
+				Ulimits: UlimitSlice{
+					&Ulimit{
+						Name: "foo",
+						Soft: 1024,
+						Hard: 2048,
+					},
+				},
+			},
+			&Step{
+				Commands: raw.StringSlice{"./gradlew build"},
+				Environment: raw.StringSliceMap{
+					"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+					"GRADLE_USER_HOME": ".gradle",
+				},
+				Name:  "build",
+				Image: "openjdk:latest",
+				Pull:  true,
+				Ruleset: Ruleset{
+					If:       Rules{Event: []string{"push", "pull_request"}},
+					Operator: "and",
+				},
+				Volumes: VolumeSlice{
+					&Volume{
+						Source:      "/foo",
+						Destination: "/bar",
+						AccessMode:  "ro",
+					},
+				},
+				Ulimits: UlimitSlice{
+					&Ulimit{
+						Name: "foo",
+						Soft: 1024,
+						Hard: 2048,
+					},
+				},
+			},
+		},
+	}
+	got := new(Build)
+
+	// run test
+	b, err := ioutil.ReadFile("testdata/build_anchor_step.yml")
 	if err != nil {
 		t.Errorf("Reading file for UnmarshalYAML returned err: %v", err)
 	}

--- a/yaml/stage.go
+++ b/yaml/stage.go
@@ -9,7 +9,8 @@ import (
 
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"
-	yaml "gopkg.in/yaml.v2"
+
+	"github.com/buildkite/yaml"
 )
 
 type (

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"
 
-	yaml "gopkg.in/yaml.v2"
+	"github.com/buildkite/yaml"
 )
 
 func TestYaml_StageSlice_ToPipeline(t *testing.T) {

--- a/yaml/testdata/build_anchor_stage.yml
+++ b/yaml/testdata/build_anchor_stage.yml
@@ -1,0 +1,56 @@
+---
+version: "1"
+
+metadata:
+  template: false
+
+stage-anchor: &stage-anchor
+  environment:
+    GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false
+    GRADLE_USER_HOME: .gradle
+  image: openjdk:latest
+
+stages:
+  dependencies:
+    steps:
+      - name: install
+        commands:
+          - ./gradlew downloadDependencies
+        <<: *stage-anchor
+        pull: true
+        ruleset:
+          event: [ push, pull_request ]
+        volumes: [ /foo:/bar:ro ]
+        ulimits: [ foo=1024:2048 ]
+
+  test:
+    needs: [ dependencies ]
+    steps:
+      - name: test
+        commands:
+          - ./gradlew check
+        <<: *stage-anchor
+        pull: true
+        ruleset:
+          event: [ push, pull_request ]
+        volumes: [ /foo:/bar:ro ]
+        ulimits: [ foo=1024:2048 ]
+
+  build:
+    needs: [ dependencies ]
+    steps:
+      - name: build
+        commands:
+          - ./gradlew build
+        <<: *stage-anchor
+        pull: true
+        ruleset:
+          event: [ push, pull_request ]
+        volumes:
+          - source: /foo
+            destination: /bar
+            access_mode: ro
+        ulimits:
+          - name: foo
+            soft: 1024
+            hard: 2048

--- a/yaml/testdata/build_anchor_step.yml
+++ b/yaml/testdata/build_anchor_step.yml
@@ -1,0 +1,48 @@
+---
+version: "1"
+
+metadata:
+  template: false
+
+step-anchor: &step-anchor
+  environment:
+    GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false
+    GRADLE_USER_HOME: .gradle
+  image: openjdk:latest
+
+steps:
+  - name: install
+    commands:
+      - ./gradlew downloadDependencies
+    <<: *step-anchor
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]
+    volumes: [ /foo:/bar:ro ]
+    ulimits: [ foo=1024:2048 ]
+
+  - name: test
+    commands:
+      - ./gradlew check
+    <<: *step-anchor
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]
+    volumes: [ /foo:/bar:ro ]
+    ulimits: [ foo=1024:2048 ]
+
+  - name: build
+    commands:
+      - ./gradlew build
+    <<: *step-anchor
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]
+    volumes:
+      - source: /foo
+        destination: /bar
+        access_mode: ro
+    ulimits:
+      - name: foo
+        soft: 1024
+        hard: 2048


### PR DESCRIPTION
Directly in relation to:

https://github.com/go-yaml/yaml/issues/184

The solution to use [buildkite/yaml](https://github.com/buildkite/yaml) is [documented in the thread](https://github.com/go-yaml/yaml/issues/184#issuecomment-439254361).

**NOTE:**

We vendor directly from the commit:

([`0caa5f0796e36057e59d6782832a9c774f457842`](https://github.com/buildkite/yaml/commit/0caa5f0796e36057e59d6782832a9c774f457842))

rather then the release:

([`v2.2.0`](https://github.com/buildkite/yaml/releases/tag/v2.2.0))

because of a Go module versioning issue:

https://github.com/golang/go/wiki/Modules#semantic-import-versioning

> If the module is version v2 or higher, the major version of the module must be included as a /vN at the end of the module paths used in go.mod files (e.g., module github.com/my/mod/v2, require github.com/my/mod/v2 v2.0.1) and in the package import path (e.g., import "github.com/my/mod/v2/mypkg"). This includes the paths used in go get commands (e.g., go get github.com/my/mod/v2@v2.0.1. Note there is both a /v2 and a @v2.0.1 in that example. One way to think about it is that the module name now includes the /v2, so include /v2 whenever you are using the module name).

```sh
$ go get -u github.com/buildkite/yaml@v2.2.0
go: finding github.com/buildkite/yaml v2.2.0
go: finding github.com/buildkite/yaml v2.2.0
go get github.com/buildkite/yaml@v2.2.0: github.com/buildkite/yaml@v2.2.0: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v2
```