### PR TITLE
feat(library): add AppendData() for Log

### DIFF
--- a/library/log.go
+++ b/library/log.go
@@ -16,6 +16,23 @@ type Log struct {
 	Data      *[]byte `json:"data,omitempty"`
 }
 
+// AppendData adds the provided data to the end of
+// the Data field for the Log type. If the Data
+// field is empty, then the function overwrites
+// the entire Data field.
+func (l *Log) AppendData(data []byte) {
+	// check if Data field is empty
+	if len(l.GetData()) == 0 {
+		// overwrite the Data field
+		l.SetData(data)
+
+		return
+	}
+
+	// add the data to the Data field
+	l.SetData(append(l.GetData(), data...))
+}
+
 // GetID returns the ID field.
 //
 // When the provided Log type is nil, or the field within

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -10,6 +10,53 @@ import (
 	"testing"
 )
 
+func TestLibrary_Log_Append(t *testing.T) {
+	// setup types
+	wantOne := new(Log)
+	wantOne.SetID(1)
+	wantOne.SetServiceID(1)
+	wantOne.SetStepID(1)
+	wantOne.SetBuildID(1)
+	wantOne.SetRepoID(1)
+	wantOne.SetData([]byte("bar"))
+
+	wantTwo := new(Log)
+	wantTwo.SetID(1)
+	wantTwo.SetServiceID(1)
+	wantTwo.SetStepID(1)
+	wantTwo.SetBuildID(1)
+	wantTwo.SetRepoID(1)
+	wantTwo.SetData([]byte("foobar"))
+
+	gotOne := new(Log)
+	gotOne.SetID(1)
+	gotOne.SetServiceID(1)
+	gotOne.SetStepID(1)
+	gotOne.SetBuildID(1)
+	gotOne.SetRepoID(1)
+
+	gotTwo := new(Log)
+	gotTwo.SetID(1)
+	gotTwo.SetServiceID(1)
+	gotTwo.SetStepID(1)
+	gotTwo.SetBuildID(1)
+	gotTwo.SetRepoID(1)
+	gotTwo.SetData([]byte("foo"))
+
+	// run test
+	gotOne.AppendData([]byte("bar"))
+
+	gotTwo.AppendData([]byte("bar"))
+
+	if !reflect.DeepEqual(gotOne, wantOne) {
+		t.Errorf("Append is %v, want %v", gotOne, wantOne)
+	}
+
+	if !reflect.DeepEqual(gotTwo, wantTwo) {
+		t.Errorf("Append is %v, want %v", gotTwo, wantTwo)
+	}
+}
+
 func TestLibrary_Log_Getters(t *testing.T) {
 	// setup types
 	num64 := int64(1)


### PR DESCRIPTION
This is intended to help improve where we're attempting to append logs to an existing log entry.

I believe this will help with code maintainability, code readability as well as reduce lines of code 👍 

[Here is an example](https://github.com/go-vela/pkg-executor/blob/be67a37fccbb68b660084a69961bc230e3c8e8e5/executor/linux/build.go#L227-L234) of the code we use to accomplish this:

```go
		// TODO: remove hardcoded reference
		// update the init log with progress
		l.SetData(
			append(
				l.GetData(),
				[]byte(fmt.Sprintf("  $ docker image inspect %s\n", s.Image))...,
			),
		)
```