### PR TITLE
fix(yaml): create done channel for stages

### DIFF
--- a/yaml/stage.go
+++ b/yaml/stage.go
@@ -37,6 +37,7 @@ func (s *StageSlice) ToPipeline() *pipeline.StageSlice {
 	for _, stage := range *s {
 		// append the element to the pipeline stage slice
 		*stageSlice = append(*stageSlice, &pipeline.Stage{
+			Done:  make(chan error, 1),
 			Name:  stage.Name,
 			Needs: stage.Needs,
 			Steps: *stage.Steps.ToPipeline(),

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -21,6 +21,7 @@ func TestYaml_StageSlice_ToPipeline(t *testing.T) {
 	str := "foo"
 	slice := []string{"foo"}
 	mapp := map[string]string{"foo": "bar"}
+
 	want := &pipeline.StageSlice{
 		&pipeline.Stage{
 			Name:  str,
@@ -141,6 +142,18 @@ func TestYaml_StageSlice_ToPipeline(t *testing.T) {
 
 	// run test
 	got := s.ToPipeline()
+
+	// WARNING: hack to compare stages
+	//
+	// Channel values can only be compared for equality.
+	// Two channel values are considered equal if they
+	// originated from the same make call meaning they
+	// refer to the same channel value in memory.
+	for i, stage := range *got {
+		tmp := *want
+
+		tmp[i].Done = stage.Done
+	}
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ToPipeline is %v, want %v", got, want)


### PR DESCRIPTION
I should have completed this when I first added the `Done` channel to stages:

https://github.com/go-vela/types/pull/41

Unfortunately, I missed it so that's why I added a `bug` label.