### PR TITLE
feat: add masked value when sanitizing secrets

### DIFF
--- a/constants/secret.go
+++ b/constants/secret.go
@@ -14,4 +14,7 @@ const (
 
 	// SecretShared defines the secret type for a secret shared across the installation.
 	SecretShared = "shared"
+
+	// SecretMask defines the secret mask to be used in place of secret values returned to users.
+	SecretMask = "[secure]"
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.13
 require (
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/lib/pq v1.2.0
-	gopkg.in/yaml.v2 v2.2.4
+	gopkg.in/yaml.v2 v2.2.7
 )

--- a/go.sum
+++ b/go.sum
@@ -4,5 +4,5 @@ github.com/lib/pq v1.2.0 h1:LXpIM/LZ5xGFhOpXAQUIMM1HdyqzVYM13zNdjCEEcA0=
 github.com/lib/pq v1.2.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v2 v2.2.4 h1:/eiJrUcujPVeJ3xlSWaiNi3uSVmDGBK1pDHUHAnao1I=
-gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.7 h1:VUgggvou5XRW9mHwD/yXxIYSMtY0zoKQf/v226p2nyo=
+gopkg.in/yaml.v2 v2.2.7/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/library/secret.go
+++ b/library/secret.go
@@ -28,12 +28,18 @@ type Secret struct {
 
 // Sanitize creates a duplicate of the Secret without the value.
 func (s *Secret) Sanitize() *Secret {
+	// create a variable since constants can not be addressable
+	//
+	// https://golang.org/ref/spec#Address_operators
+	value := constants.SecretMask
+
 	return &Secret{
 		ID:           s.ID,
 		Org:          s.Org,
 		Repo:         s.Repo,
 		Team:         s.Team,
 		Name:         s.Name,
+		Value:        &value,
 		Type:         s.Type,
 		Images:       s.Images,
 		Events:       s.Events,

--- a/library/secret_test.go
+++ b/library/secret_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -21,6 +22,7 @@ func TestLibrary_Secret_Sanitize(t *testing.T) {
 	images := []string{"foo"}
 	events := []string{"bar"}
 	cmd := true
+	value := constants.SecretMask
 	s := &Secret{
 		ID:           &one,
 		Org:          &foo,
@@ -38,6 +40,7 @@ func TestLibrary_Secret_Sanitize(t *testing.T) {
 		Org:          &foo,
 		Repo:         &bar,
 		Name:         &foo,
+		Value:        &value,
 		Type:         &repo,
 		Images:       &images,
 		Events:       &events,


### PR DESCRIPTION
This change is to address when a user tries to view secret values via the API ( [GetSecrets](https://github.com/go-vela/server/blob/master/api/secret.go#L156) and[GetSecrets](https://github.com/go-vela/server/blob/master/api/secret.go#L191) ).

The value is when a user view's their secret they don't see `null` in place of the value. The mask is designed to communicate to the user that the API will not return secret values.