### PR TITLE
fix: update status to be an no-op

### DIFF
--- a/pipeline/ruleset.go
+++ b/pipeline/ruleset.go
@@ -117,7 +117,6 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 					r.Event.MatchOr(from.Event) ||
 					r.Path.MatchOr(p) ||
 					r.Repo.MatchOr(from.Repo) ||
-					r.Status.MatchOr(from.Status) ||
 					r.Tag.MatchOr(from.Tag) {
 					return true
 				}
@@ -136,7 +135,6 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 				r.Event.MatchAnd(from.Event) &&
 				r.Path.MatchAnd(p) &&
 				r.Repo.MatchAnd(from.Repo) &&
-				r.Status.MatchAnd(from.Status) &&
 				r.Tag.MatchAnd(from.Tag) {
 				return true
 			}
@@ -155,7 +153,6 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 			r.Event.MatchOr(from.Event) ||
 			r.Path.MatchOr("") ||
 			r.Repo.MatchOr(from.Repo) ||
-			r.Status.MatchOr(from.Status) ||
 			r.Tag.MatchOr(from.Tag) {
 			return true
 		}
@@ -170,7 +167,6 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 		r.Event.MatchAnd(from.Event) &&
 		r.Path.MatchAnd("") &&
 		r.Repo.MatchAnd(from.Repo) &&
-		r.Status.MatchAnd(from.Status) &&
 		r.Tag.MatchAnd(from.Tag) {
 		return true
 	}

--- a/pipeline/ruleset_test.go
+++ b/pipeline/ruleset_test.go
@@ -53,6 +53,11 @@ func TestPipeline_Ruleset_Match(t *testing.T) {
 			data:    &RuleData{Branch: "dev", Comment: "ok to test", Event: "push", Repo: "octocat/hello-world", Status: "pending", Tag: "refs/heads/master"},
 			want:    false,
 		},
+		{
+			ruleset: &Ruleset{If: Rules{Status: []string{"success", "failure"}}},
+			data:    &RuleData{Branch: "dev", Comment: "ok to test", Event: "push", Repo: "octocat/hello-world", Status: "pending", Tag: "refs/heads/master"},
+			want:    true,
+		},
 		// If with or operator
 		{
 			ruleset: &Ruleset{If: Rules{Branch: []string{"master"}, Event: []string{"push"}}, Operator: "or"},
@@ -252,6 +257,12 @@ func TestPipeline_Rules_Match(t *testing.T) {
 			data:     &RuleData{Branch: "master", Event: "pull_request", Path: []string{"foo.txt", "/foo/bar.txt"}, Repo: "octocat/hello-world", Status: "pending", Tag: "refs/heads/master"},
 			operator: "and",
 			want:     false,
+		},
+		{
+			rules:    &Rules{Status: []string{"success", "failure"}},
+			data:     &RuleData{Branch: "master", Event: "pull_request", Path: []string{"foo.txt", "/foo/bar.txt"}, Repo: "octocat/hello-world", Status: "pending", Tag: "refs/heads/master"},
+			operator: "and",
+			want:     true,
 		},
 		// or operator
 		{


### PR DESCRIPTION
This change allows the `status:` YAML tag in a ruleset to be treated as a no-op.

There was a big discovered when a user passed a pipeline:
```yaml
ruleset:
  status: [ success, failure ]
```

When this was compiled the ruleset was removed because at compile time the build status is always pending. 

