### PR TITLE
feat(library): add Environment() functions

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -4,7 +4,12 @@
 
 package library
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/go-vela/types/constants"
+)
 
 // Build is the library representation of a build for a pipeline.
 type Build struct {
@@ -35,6 +40,97 @@ type Build struct {
 	Host         *string `json:"host,omitempty"`
 	Runtime      *string `json:"runtime,omitempty"`
 	Distribution *string `json:"distribution,omitempty"`
+}
+
+// Environment returns a list of environment variables
+// provided from the fields of the Build type.
+func (b *Build) Environment() map[string]string {
+	envs := map[string]string{
+		"VELA_BUILD_AUTHOR":       ToString(b.GetAuthor()),
+		"VELA_BUILD_AUTHOR_EMAIL": ToString(b.GetEmail()),
+		"VELA_BUILD_BASE_REF":     ToString(b.GetBaseRef()),
+		"VELA_BUILD_BRANCH":       ToString(b.GetBranch()),
+		"VELA_BUILD_CHANNEL":      ToString("TODO"),
+		"VELA_BUILD_CLONE":        ToString(b.GetClone()),
+		"VELA_BUILD_COMMIT":       ToString(b.GetCommit()),
+		"VELA_BUILD_CREATED":      ToString(b.GetCreated()),
+		"VELA_BUILD_DISTRIBUTION": ToString(b.GetDistribution()),
+		"VELA_BUILD_ENQUEUED":     ToString(b.GetEnqueued()),
+		"VELA_BUILD_EVENT":        ToString(b.GetEvent()),
+		"VELA_BUILD_FINISHED":     ToString(b.GetFinished()),
+		"VELA_BUILD_HOST":         ToString(b.GetHost()),
+		"VELA_BUILD_LINK":         ToString(b.GetLink()),
+		"VELA_BUILD_MESSAGE":      ToString(b.GetMessage()),
+		"VELA_BUILD_NUMBER":       ToString(b.GetNumber()),
+		"VELA_BUILD_PARENT":       ToString(b.GetParent()),
+		"VELA_BUILD_REF":          ToString(b.GetRef()),
+		"VELA_BUILD_RUNTIME":      ToString(b.GetRuntime()),
+		"VELA_BUILD_SENDER":       ToString(b.GetSender()),
+		"VELA_BUILD_STARTED":      ToString(b.GetStarted()),
+		"VELA_BUILD_SOURCE":       ToString(b.GetSource()),
+		"VELA_BUILD_STATUS":       ToString(b.GetStatus()),
+		"VELA_BUILD_TITLE":        ToString(b.GetTitle()),
+		"VELA_BUILD_WORKSPACE":    ToString("TODO"),
+
+		// deprecated environment variables
+		"BUILD_AUTHOR":       ToString(b.GetAuthor()),
+		"BUILD_AUTHOR_EMAIL": ToString(b.GetEmail()),
+		"BUILD_BASE_REF":     ToString(b.GetBaseRef()),
+		"BUILD_BRANCH":       ToString(b.GetBranch()),
+		"BUILD_CHANNEL":      ToString("TODO"),
+		"BUILD_CLONE":        ToString(b.GetClone()),
+		"BUILD_COMMIT":       ToString(b.GetCommit()),
+		"BUILD_CREATED":      ToString(b.GetCreated()),
+		"BUILD_ENQUEUED":     ToString(b.GetEnqueued()),
+		"BUILD_EVENT":        ToString(b.GetEvent()),
+		"BUILD_FINISHED":     ToString(b.GetFinished()),
+		"BUILD_HOST":         ToString(b.GetHost()),
+		"BUILD_LINK":         ToString(b.GetLink()),
+		"BUILD_MESSAGE":      ToString(b.GetMessage()),
+		"BUILD_NUMBER":       ToString(b.GetNumber()),
+		"BUILD_PARENT":       ToString(b.GetParent()),
+		"BUILD_REF":          ToString(b.GetRef()),
+		"BUILD_SENDER":       ToString(b.GetSender()),
+		"BUILD_STARTED":      ToString(b.GetStarted()),
+		"BUILD_SOURCE":       ToString(b.GetSource()),
+		"BUILD_STATUS":       ToString(b.GetStatus()),
+		"BUILD_TITLE":        ToString(b.GetTitle()),
+		"BUILD_WORKSPACE":    ToString("TODO"),
+	}
+
+	// check if the Build event is comment
+	if strings.EqualFold(b.GetEvent(), constants.EventComment) {
+		// capture the pull request number
+		number := ToString(strings.SplitN(b.GetRef(), "/", 4)[2])
+
+		// add the pull request number to the list
+		envs["BUILD_PULL_REQUEST_NUMBER"] = number
+		envs["VELA_BUILD_PULL_REQUEST"] = number
+		envs["VELA_PULL_REQUEST"] = number
+	}
+
+	// check if the Build event is pull_request
+	if strings.EqualFold(b.GetEvent(), constants.EventPull) {
+		// capture the pull request number
+		number := ToString(strings.SplitN(b.GetRef(), "/", 4)[2])
+
+		// add the pull request number to the list
+		envs["BUILD_PULL_REQUEST_NUMBER"] = number
+		envs["VELA_BUILD_PULL_REQUEST"] = number
+		envs["VELA_PULL_REQUEST"] = number
+	}
+
+	// check if the Build event is tag
+	if strings.EqualFold(b.GetEvent(), constants.EventTag) {
+		// capture the tag reference
+		tag := ToString(strings.TrimPrefix(b.GetRef(), "refs/tags/"))
+
+		// add the tag reference to the list
+		envs["BUILD_TAG"] = tag
+		envs["VELA_BUILD_TAG"] = tag
+	}
+
+	return envs
 }
 
 // GetID returns the ID field.

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -10,6 +10,257 @@ import (
 	"testing"
 )
 
+func TestLibrary_Build_Environment(t *testing.T) {
+	// setup types
+	_comment := testBuild()
+	_comment.SetEvent("comment")
+	_comment.SetRef("refs/pulls/1/head")
+
+	_pull := testBuild()
+	_pull.SetEvent("pull_request")
+	_pull.SetRef("refs/pulls/1/head")
+
+	_tag := testBuild()
+	_tag.SetEvent("tag")
+	_tag.SetRef("refs/tags/v0.1.0")
+
+	// setup tests
+	tests := []struct {
+		build *Build
+		want  map[string]string
+	}{
+		{
+			build: testBuild(),
+			want: map[string]string{
+				"VELA_BUILD_AUTHOR":       "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL": "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":     "",
+				"VELA_BUILD_BRANCH":       "master",
+				"VELA_BUILD_CHANNEL":      "TODO",
+				"VELA_BUILD_CLONE":        "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":       "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":      "1563474076",
+				"VELA_BUILD_DISTRIBUTION": "linux",
+				"VELA_BUILD_ENQUEUED":     "1563474077",
+				"VELA_BUILD_EVENT":        "push",
+				"VELA_BUILD_FINISHED":     "1563474079",
+				"VELA_BUILD_HOST":         "example.company.com",
+				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":      "First commit...",
+				"VELA_BUILD_NUMBER":       "1",
+				"VELA_BUILD_PARENT":       "1",
+				"VELA_BUILD_REF":          "refs/heads/master",
+				"VELA_BUILD_RUNTIME":      "docker",
+				"VELA_BUILD_SENDER":       "OctoKitty",
+				"VELA_BUILD_STARTED":      "1563474078",
+				"VELA_BUILD_SOURCE":       "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":       "running",
+				"VELA_BUILD_TITLE":        "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":    "TODO",
+				"BUILD_AUTHOR":            "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":      "OctoKitty@github.com",
+				"BUILD_BASE_REF":          "",
+				"BUILD_BRANCH":            "master",
+				"BUILD_CHANNEL":           "TODO",
+				"BUILD_CLONE":             "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":            "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":           "1563474076",
+				"BUILD_ENQUEUED":          "1563474077",
+				"BUILD_EVENT":             "push",
+				"BUILD_FINISHED":          "1563474079",
+				"BUILD_HOST":              "example.company.com",
+				"BUILD_LINK":              "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":           "First commit...",
+				"BUILD_NUMBER":            "1",
+				"BUILD_PARENT":            "1",
+				"BUILD_REF":               "refs/heads/master",
+				"BUILD_SENDER":            "OctoKitty",
+				"BUILD_STARTED":           "1563474078",
+				"BUILD_SOURCE":            "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":            "running",
+				"BUILD_TITLE":             "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":         "TODO",
+			},
+		},
+		{
+			build: _comment,
+			want: map[string]string{
+				"VELA_BUILD_AUTHOR":         "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL":   "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":       "",
+				"VELA_BUILD_BRANCH":         "master",
+				"VELA_BUILD_CHANNEL":        "TODO",
+				"VELA_BUILD_CLONE":          "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":         "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":        "1563474076",
+				"VELA_BUILD_DISTRIBUTION":   "linux",
+				"VELA_BUILD_ENQUEUED":       "1563474077",
+				"VELA_BUILD_EVENT":          "comment",
+				"VELA_BUILD_FINISHED":       "1563474079",
+				"VELA_BUILD_HOST":           "example.company.com",
+				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":        "First commit...",
+				"VELA_BUILD_NUMBER":         "1",
+				"VELA_BUILD_PARENT":         "1",
+				"VELA_BUILD_PULL_REQUEST":   "1",
+				"VELA_BUILD_REF":            "refs/pulls/1/head",
+				"VELA_BUILD_RUNTIME":        "docker",
+				"VELA_BUILD_SENDER":         "OctoKitty",
+				"VELA_BUILD_STARTED":        "1563474078",
+				"VELA_BUILD_SOURCE":         "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":         "running",
+				"VELA_BUILD_TITLE":          "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":      "TODO",
+				"VELA_PULL_REQUEST":         "1",
+				"BUILD_AUTHOR":              "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":        "OctoKitty@github.com",
+				"BUILD_BASE_REF":            "",
+				"BUILD_BRANCH":              "master",
+				"BUILD_CHANNEL":             "TODO",
+				"BUILD_CLONE":               "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":              "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":             "1563474076",
+				"BUILD_ENQUEUED":            "1563474077",
+				"BUILD_EVENT":               "comment",
+				"BUILD_FINISHED":            "1563474079",
+				"BUILD_HOST":                "example.company.com",
+				"BUILD_LINK":                "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":             "First commit...",
+				"BUILD_NUMBER":              "1",
+				"BUILD_PARENT":              "1",
+				"BUILD_PULL_REQUEST_NUMBER": "1",
+				"BUILD_REF":                 "refs/pulls/1/head",
+				"BUILD_SENDER":              "OctoKitty",
+				"BUILD_STARTED":             "1563474078",
+				"BUILD_SOURCE":              "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":              "running",
+				"BUILD_TITLE":               "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":           "TODO",
+			},
+		},
+		{
+			build: _pull,
+			want: map[string]string{
+				"VELA_BUILD_AUTHOR":         "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL":   "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":       "",
+				"VELA_BUILD_BRANCH":         "master",
+				"VELA_BUILD_CHANNEL":        "TODO",
+				"VELA_BUILD_CLONE":          "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":         "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":        "1563474076",
+				"VELA_BUILD_DISTRIBUTION":   "linux",
+				"VELA_BUILD_ENQUEUED":       "1563474077",
+				"VELA_BUILD_EVENT":          "pull_request",
+				"VELA_BUILD_FINISHED":       "1563474079",
+				"VELA_BUILD_HOST":           "example.company.com",
+				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":        "First commit...",
+				"VELA_BUILD_NUMBER":         "1",
+				"VELA_BUILD_PARENT":         "1",
+				"VELA_BUILD_PULL_REQUEST":   "1",
+				"VELA_BUILD_REF":            "refs/pulls/1/head",
+				"VELA_BUILD_RUNTIME":        "docker",
+				"VELA_BUILD_SENDER":         "OctoKitty",
+				"VELA_BUILD_STARTED":        "1563474078",
+				"VELA_BUILD_SOURCE":         "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":         "running",
+				"VELA_BUILD_TITLE":          "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":      "TODO",
+				"VELA_PULL_REQUEST":         "1",
+				"BUILD_AUTHOR":              "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":        "OctoKitty@github.com",
+				"BUILD_BASE_REF":            "",
+				"BUILD_BRANCH":              "master",
+				"BUILD_CHANNEL":             "TODO",
+				"BUILD_CLONE":               "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":              "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":             "1563474076",
+				"BUILD_ENQUEUED":            "1563474077",
+				"BUILD_EVENT":               "pull_request",
+				"BUILD_FINISHED":            "1563474079",
+				"BUILD_HOST":                "example.company.com",
+				"BUILD_LINK":                "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":             "First commit...",
+				"BUILD_NUMBER":              "1",
+				"BUILD_PARENT":              "1",
+				"BUILD_PULL_REQUEST_NUMBER": "1",
+				"BUILD_REF":                 "refs/pulls/1/head",
+				"BUILD_SENDER":              "OctoKitty",
+				"BUILD_STARTED":             "1563474078",
+				"BUILD_SOURCE":              "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":              "running",
+				"BUILD_TITLE":               "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":           "TODO",
+			},
+		},
+		{
+			build: _tag,
+			want: map[string]string{
+				"VELA_BUILD_AUTHOR":       "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL": "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":     "",
+				"VELA_BUILD_BRANCH":       "master",
+				"VELA_BUILD_CHANNEL":      "TODO",
+				"VELA_BUILD_CLONE":        "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":       "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":      "1563474076",
+				"VELA_BUILD_DISTRIBUTION": "linux",
+				"VELA_BUILD_ENQUEUED":     "1563474077",
+				"VELA_BUILD_EVENT":        "tag",
+				"VELA_BUILD_FINISHED":     "1563474079",
+				"VELA_BUILD_HOST":         "example.company.com",
+				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":      "First commit...",
+				"VELA_BUILD_NUMBER":       "1",
+				"VELA_BUILD_PARENT":       "1",
+				"VELA_BUILD_REF":          "refs/tags/v0.1.0",
+				"VELA_BUILD_RUNTIME":      "docker",
+				"VELA_BUILD_SENDER":       "OctoKitty",
+				"VELA_BUILD_STARTED":      "1563474078",
+				"VELA_BUILD_SOURCE":       "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":       "running",
+				"VELA_BUILD_TAG":          "v0.1.0",
+				"VELA_BUILD_TITLE":        "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":    "TODO",
+				"BUILD_AUTHOR":            "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":      "OctoKitty@github.com",
+				"BUILD_BASE_REF":          "",
+				"BUILD_BRANCH":            "master",
+				"BUILD_CHANNEL":           "TODO",
+				"BUILD_CLONE":             "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":            "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":           "1563474076",
+				"BUILD_ENQUEUED":          "1563474077",
+				"BUILD_EVENT":             "tag",
+				"BUILD_FINISHED":          "1563474079",
+				"BUILD_HOST":              "example.company.com",
+				"BUILD_LINK":              "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":           "First commit...",
+				"BUILD_NUMBER":            "1",
+				"BUILD_PARENT":            "1",
+				"BUILD_REF":               "refs/tags/v0.1.0",
+				"BUILD_SENDER":            "OctoKitty",
+				"BUILD_STARTED":           "1563474078",
+				"BUILD_SOURCE":            "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":            "running",
+				"BUILD_TAG":               "v0.1.0",
+				"BUILD_TITLE":             "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":         "TODO",
+			},
+		},
+	}
+
+	// run test
+	for _, test := range tests {
+		got := test.build.Environment()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Environment is %v, want %v", got, test.want)
+		}
+	}
+}
+
 func TestLibrary_Build_Getters(t *testing.T) {
 	// setup types
 	num := 1
@@ -605,4 +856,40 @@ func TestLibrary_Build_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testBuild is a test helper function to create a Build
+// type with all fields set to a fake value.
+func testBuild() *Build {
+	b := new(Build)
+
+	b.SetID(1)
+	b.SetRepoID(1)
+	b.SetNumber(1)
+	b.SetParent(1)
+	b.SetEvent("push")
+	b.SetStatus("running")
+	b.SetError("")
+	b.SetEnqueued(1563474077)
+	b.SetCreated(1563474076)
+	b.SetStarted(1563474078)
+	b.SetFinished(1563474079)
+	b.SetDeploy("")
+	b.SetClone("https://github.com/github/octocat.git")
+	b.SetSource("https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163")
+	b.SetTitle("push received from https://github.com/github/octocat")
+	b.SetMessage("First commit...")
+	b.SetCommit("48afb5bdc41ad69bf22588491333f7cf71135163")
+	b.SetSender("OctoKitty")
+	b.SetAuthor("OctoKitty")
+	b.SetEmail("OctoKitty@github.com")
+	b.SetLink("https://example.company.com/github/octocat/1")
+	b.SetBranch("master")
+	b.SetRef("refs/heads/master")
+	b.SetBaseRef("")
+	b.SetHost("example.company.com")
+	b.SetRuntime("docker")
+	b.SetDistribution("linux")
+
+	return b
 }

--- a/library/repo.go
+++ b/library/repo.go
@@ -29,6 +29,47 @@ type Repo struct {
 	AllowComment *bool   `json:"allow_comment,omitempty"`
 }
 
+// Environment returns a list of environment variables
+// provided from the fields of the Repo type.
+func (r *Repo) Environment() map[string]string {
+	return map[string]string{
+		"VELA_REPO_ACTIVE":        ToString(r.GetActive()),
+		"VELA_REPO_ALLOW_COMMENT": ToString(r.GetAllowComment()),
+		"VELA_REPO_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
+		"VELA_REPO_ALLOW_PULL":    ToString(r.GetAllowPull()),
+		"VELA_REPO_ALLOW_PUSH":    ToString(r.GetAllowPush()),
+		"VELA_REPO_ALLOW_TAG":     ToString(r.GetAllowTag()),
+		"VELA_REPO_BRANCH":        ToString(r.GetBranch()),
+		"VELA_REPO_CLONE":         ToString(r.GetClone()),
+		"VELA_REPO_FULL_NAME":     ToString(r.GetFullName()),
+		"VELA_REPO_LINK":          ToString(r.GetLink()),
+		"VELA_REPO_NAME":          ToString(r.GetName()),
+		"VELA_REPO_ORG":           ToString(r.GetOrg()),
+		"VELA_REPO_PRIVATE":       ToString(r.GetPrivate()),
+		"VELA_REPO_TIMEOUT":       ToString(r.GetTimeout()),
+		"VELA_REPO_TRUSTED":       ToString(r.GetTrusted()),
+		"VELA_REPO_VISIBILITY":    ToString(r.GetVisibility()),
+
+		// deprecated environment variables
+		"REPOSITORY_ACTIVE":        ToString(r.GetActive()),
+		"REPOSITORY_ALLOW_COMMENT": ToString(r.GetAllowComment()),
+		"REPOSITORY_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
+		"REPOSITORY_ALLOW_PULL":    ToString(r.GetAllowPull()),
+		"REPOSITORY_ALLOW_PUSH":    ToString(r.GetAllowPush()),
+		"REPOSITORY_ALLOW_TAG":     ToString(r.GetAllowTag()),
+		"REPOSITORY_BRANCH":        ToString(r.GetBranch()),
+		"REPOSITORY_CLONE":         ToString(r.GetClone()),
+		"REPOSITORY_FULL_NAME":     ToString(r.GetFullName()),
+		"REPOSITORY_LINK":          ToString(r.GetLink()),
+		"REPOSITORY_NAME":          ToString(r.GetName()),
+		"REPOSITORY_ORG":           ToString(r.GetOrg()),
+		"REPOSITORY_PRIVATE":       ToString(r.GetPrivate()),
+		"REPOSITORY_TIMEOUT":       ToString(r.GetTimeout()),
+		"REPOSITORY_TRUSTED":       ToString(r.GetTrusted()),
+		"REPOSITORY_VISIBILITY":    ToString(r.GetVisibility()),
+	}
+}
+
 // GetID returns the ID field.
 //
 // When the provided Repo type is nil, or the field within

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -10,6 +10,51 @@ import (
 	"testing"
 )
 
+func TestLibrary_Repo_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_REPO_ACTIVE":         "true",
+		"VELA_REPO_ALLOW_COMMENT":  "false",
+		"VELA_REPO_ALLOW_DEPLOY":   "false",
+		"VELA_REPO_ALLOW_PULL":     "false",
+		"VELA_REPO_ALLOW_PUSH":     "true",
+		"VELA_REPO_ALLOW_TAG":      "false",
+		"VELA_REPO_BRANCH":         "master",
+		"VELA_REPO_CLONE":          "https://github.com/github/octocat.git",
+		"VELA_REPO_FULL_NAME":      "github/octocat",
+		"VELA_REPO_LINK":           "https://github.com/github/octocat",
+		"VELA_REPO_NAME":           "octocat",
+		"VELA_REPO_ORG":            "github",
+		"VELA_REPO_PRIVATE":        "false",
+		"VELA_REPO_TIMEOUT":        "30",
+		"VELA_REPO_TRUSTED":        "false",
+		"VELA_REPO_VISIBILITY":     "public",
+		"REPOSITORY_ACTIVE":        "true",
+		"REPOSITORY_ALLOW_COMMENT": "false",
+		"REPOSITORY_ALLOW_DEPLOY":  "false",
+		"REPOSITORY_ALLOW_PULL":    "false",
+		"REPOSITORY_ALLOW_PUSH":    "true",
+		"REPOSITORY_ALLOW_TAG":     "false",
+		"REPOSITORY_BRANCH":        "master",
+		"REPOSITORY_CLONE":         "https://github.com/github/octocat.git",
+		"REPOSITORY_FULL_NAME":     "github/octocat",
+		"REPOSITORY_LINK":          "https://github.com/github/octocat",
+		"REPOSITORY_NAME":          "octocat",
+		"REPOSITORY_ORG":           "github",
+		"REPOSITORY_PRIVATE":       "false",
+		"REPOSITORY_TIMEOUT":       "30",
+		"REPOSITORY_TRUSTED":       "false",
+		"REPOSITORY_VISIBILITY":    "public",
+	}
+
+	// run test
+	got := testRepo().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
 func TestLibrary_Repo_Getters(t *testing.T) {
 	// setup types
 	booL := false
@@ -520,4 +565,30 @@ func TestLibrary_Repo_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testRepo is a test helper function to create a Repo
+// type with all fields set to a fake value.
+func testRepo() *Repo {
+	r := new(Repo)
+
+	r.SetID(1)
+	r.SetOrg("github")
+	r.SetName("octocat")
+	r.SetFullName("github/octocat")
+	r.SetLink("https://github.com/github/octocat")
+	r.SetClone("https://github.com/github/octocat.git")
+	r.SetBranch("master")
+	r.SetTimeout(30)
+	r.SetVisibility("public")
+	r.SetPrivate(false)
+	r.SetTrusted(false)
+	r.SetActive(true)
+	r.SetAllowPull(false)
+	r.SetAllowPush(true)
+	r.SetAllowDeploy(false)
+	r.SetAllowTag(false)
+	r.SetAllowComment(false)
+
+	return r
 }

--- a/library/service.go
+++ b/library/service.go
@@ -25,6 +25,24 @@ type Service struct {
 	Distribution *string `json:"distribution,omitempty"`
 }
 
+// Environment returns a list of environment variables
+// provided from the fields of the Service type.
+func (s *Service) Environment() map[string]string {
+	return map[string]string{
+		"VELA_SERVICE_CREATED":      ToString(s.GetCreated()),
+		"VELA_SERVICE_DISTRIBUTION": ToString(s.GetDistribution()),
+		"VELA_SERVICE_EXIT_CODE":    ToString(s.GetExitCode()),
+		"VELA_SERVICE_FINISHED":     ToString(s.GetFinished()),
+		"VELA_SERVICE_HOST":         ToString(s.GetHost()),
+		"VELA_SERVICE_IMAGE":        ToString(s.GetImage()),
+		"VELA_SERVICE_NAME":         ToString(s.GetName()),
+		"VELA_SERVICE_NUMBER":       ToString(s.GetNumber()),
+		"VELA_SERVICE_RUNTIME":      ToString(s.GetRuntime()),
+		"VELA_SERVICE_STARTED":      ToString(s.GetStarted()),
+		"VELA_SERVICE_STATUS":       ToString(s.GetStatus()),
+	}
+}
+
 // GetID returns the ID field.
 //
 // When the provided Service type is nil, or the field within

--- a/library/service_test.go
+++ b/library/service_test.go
@@ -10,6 +10,30 @@ import (
 	"testing"
 )
 
+func TestLibrary_Service_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_SERVICE_CREATED":      "1563474076",
+		"VELA_SERVICE_DISTRIBUTION": "linux",
+		"VELA_SERVICE_EXIT_CODE":    "0",
+		"VELA_SERVICE_FINISHED":     "1563474079",
+		"VELA_SERVICE_HOST":         "example.company.com",
+		"VELA_SERVICE_IMAGE":        "postgres:12-alpine",
+		"VELA_SERVICE_NAME":         "postgres",
+		"VELA_SERVICE_NUMBER":       "1",
+		"VELA_SERVICE_RUNTIME":      "docker",
+		"VELA_SERVICE_STARTED":      "1563474078",
+		"VELA_SERVICE_STATUS":       "running",
+	}
+
+	// run test
+	got := testService().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
 func TestService_Getters(t *testing.T) {
 	// setup types
 	num := 1
@@ -422,4 +446,27 @@ func TestService_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testService is a test helper function to create a Service
+// type with all fields set to a fake value.
+func testService() *Service {
+	s := new(Service)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("postgres")
+	s.SetImage("postgres:12-alpine")
+	s.SetStatus("running")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+
+	return s
 }

--- a/library/step.go
+++ b/library/step.go
@@ -26,6 +26,25 @@ type Step struct {
 	Distribution *string `json:"distribution,omitempty"`
 }
 
+// Environment returns a list of environment variables
+// provided from the fields of the Step type.
+func (s *Step) Environment() map[string]string {
+	return map[string]string{
+		"VELA_STEP_CREATED":      ToString(s.GetCreated()),
+		"VELA_STEP_DISTRIBUTION": ToString(s.GetDistribution()),
+		"VELA_STEP_EXIT_CODE":    ToString(s.GetExitCode()),
+		"VELA_STEP_FINISHED":     ToString(s.GetFinished()),
+		"VELA_STEP_HOST":         ToString(s.GetHost()),
+		"VELA_STEP_IMAGE":        ToString(s.GetImage()),
+		"VELA_STEP_NAME":         ToString(s.GetName()),
+		"VELA_STEP_NUMBER":       ToString(s.GetNumber()),
+		"VELA_STEP_RUNTIME":      ToString(s.GetRuntime()),
+		"VELA_STEP_STAGE":        ToString(s.GetStage()),
+		"VELA_STEP_STARTED":      ToString(s.GetStarted()),
+		"VELA_STEP_STATUS":       ToString(s.GetStatus()),
+	}
+}
+
 // GetID returns the ID field.
 //
 // When the provided Step type is nil, or the field within

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -10,6 +10,31 @@ import (
 	"testing"
 )
 
+func TestLibrary_Step_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_STEP_CREATED":      "1563474076",
+		"VELA_STEP_DISTRIBUTION": "linux",
+		"VELA_STEP_EXIT_CODE":    "0",
+		"VELA_STEP_FINISHED":     "1563474079",
+		"VELA_STEP_HOST":         "example.company.com",
+		"VELA_STEP_IMAGE":        "target/vela-git:v0.3.0",
+		"VELA_STEP_NAME":         "clone",
+		"VELA_STEP_NUMBER":       "1",
+		"VELA_STEP_RUNTIME":      "docker",
+		"VELA_STEP_STAGE":        "",
+		"VELA_STEP_STARTED":      "1563474078",
+		"VELA_STEP_STATUS":       "running",
+	}
+
+	// run test
+	got := testStep().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
 func TestStep_Getters(t *testing.T) {
 	// setup types
 	num := 1
@@ -385,4 +410,27 @@ func TestStep_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testStep is a test helper function to create a Step
+// type with all fields set to a fake value.
+func testStep() *Step {
+	s := new(Step)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("clone")
+	s.SetImage("target/vela-git:v0.3.0")
+	s.SetStatus("running")
+	s.SetExitCode(0)
+	s.SetCreated(1563474076)
+	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+
+	return s
 }

--- a/library/user.go
+++ b/library/user.go
@@ -17,6 +17,17 @@ type User struct {
 	Admin     *bool     `json:"admin,omitempty"`
 }
 
+// Environment returns a list of environment variables
+// provided from the fields of the User type.
+func (u *User) Environment() map[string]string {
+	return map[string]string{
+		"VELA_USER_ACTIVE":    ToString(u.GetActive()),
+		"VELA_USER_ADMIN":     ToString(u.GetAdmin()),
+		"VELA_USER_FAVORITES": ToString(u.GetFavorites()),
+		"VELA_USER_NAME":      ToString(u.GetName()),
+	}
+}
+
 // GetID returns the ID field.
 //
 // When the provided User type is nil, or the field within

--- a/library/user_test.go
+++ b/library/user_test.go
@@ -10,6 +10,23 @@ import (
 	"testing"
 )
 
+func TestLibrary_User_Environment(t *testing.T) {
+	// setup types
+	want := map[string]string{
+		"VELA_USER_ACTIVE":    "true",
+		"VELA_USER_ADMIN":     "false",
+		"VELA_USER_FAVORITES": "[\"github/octocat\"]",
+		"VELA_USER_NAME":      "octocat",
+	}
+
+	// run test
+	got := testUser().Environment()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("Environment is %v, want %v", got, want)
+	}
+}
+
 func TestLibrary_User_Getters(t *testing.T) {
 	// setup types
 	booL := false
@@ -232,4 +249,20 @@ func TestLibrary_User_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testUser is a test helper function to create a User
+// type with all fields set to a fake value.
+func testUser() *User {
+	u := new(User)
+
+	u.SetID(1)
+	u.SetName("octocat")
+	u.SetToken("superSecretToken")
+	u.SetHash("MzM4N2MzMDAtNmY4Mi00OTA5LWFhZDAtNWIzMTlkNTJkODMy")
+	u.SetFavorites([]string{"github/octocat"})
+	u.SetActive(true)
+	u.SetAdmin(false)
+
+	return u
 }


### PR DESCRIPTION
I noticed our [`environment()`](https://github.com/go-vela/compiler/blob/master/compiler/native/environment.go#L71-L149) function in the [go-vela/compiler](https://github.com/go-vela/compiler) is quite lengthy and difficult to digest:

```go
// helper function that creates the standard set of environment variables for a pipeline.
func environment(b *library.Build, m *types.Metadata, r *library.Repo, u *library.User) map[string]string {
	workspace := fmt.Sprintf("/home/%s/%s", r.GetOrg(), r.GetName())

	env := map[string]string{
		// build specific environment variables
		"BUILD_AUTHOR":       b.GetAuthor(),
		"BUILD_AUTHOR_EMAIL": b.GetEmail(),
		"BUILD_BRANCH":       b.GetBranch(),
		"BUILD_CHANNEL":      "TODO",
		"BUILD_COMMIT":       b.GetCommit(),
		"BUILD_CREATED":      unmarshal(b.GetCreated()),
		"BUILD_ENQUEUED":     unmarshal(b.GetEnqueued()),
		"BUILD_EVENT":        b.GetEvent(),
		"BUILD_FINISHED":     unmarshal(b.GetFinished()),
		"BUILD_HOST":         "TODO",
		"BUILD_LINK":         b.GetLink(),
		"BUILD_MESSAGE":      b.GetMessage(),
		"BUILD_NUMBER":       unmarshal(b.GetNumber()),
		"BUILD_PARENT":       unmarshal(b.GetParent()),
		"BUILD_REF":          b.GetRef(),
		"BUILD_STARTED":      unmarshal(b.GetStarted()),
		"BUILD_SOURCE":       b.GetSource(),
		"BUILD_TITLE":        b.GetTitle(),
		"BUILD_WORKSPACE":    workspace,

		// vela specific environment variables
		"VELA":                unmarshal(true),
		"VELA_ADDR":           "TODO",
		"VELA_CHANNEL":        "TODO",
		"VELA_DATABASE":       "TODO",
		"VELA_DISTRIBUTION":   "TODO",
		"VELA_HOST":           "TODO",
		"VELA_NETRC_MACHINE":  "TODO",
		"VELA_NETRC_PASSWORD": u.GetToken(),
		"VELA_NETRC_USERNAME": "x-oauth-basic",
		"VELA_QUEUE":          "TODO",
		"VELA_RUNTIME":        "TODO",
		"VELA_SOURCE":         "TODO",
		"VELA_VERSION":        "TODO",
		"VELA_WORKSPACE":      workspace,
		"CI":                  "vela",

		// repo specific environment variables
		"REPOSITORY_BRANCH":    r.GetBranch(),
		"REPOSITORY_CLONE":     r.GetClone(),
		"REPOSITORY_FULL_NAME": r.GetFullName(),
		"REPOSITORY_LINK":      r.GetLink(),
		"REPOSITORY_NAME":      r.GetName(),
		"REPOSITORY_ORG":       r.GetOrg(),
		"REPOSITORY_PRIVATE":   unmarshal(r.GetPrivate()),
		"REPOSITORY_TIMEOUT":   unmarshal(r.GetTimeout()),
		"REPOSITORY_TRUSTED":   unmarshal(r.GetTrusted()),
	}

	// set tag environment variable if proper build event
	if b.GetEvent() == constants.EventTag {
		env["BUILD_TAG"] = strings.SplitN(b.GetRef(), "refs/tags/", 2)[1]
	}

	// set pull request number variable if proper build event
	if b.GetEvent() == constants.EventPull {
		env["BUILD_PULL_REQUEST_NUMBER"] = strings.SplitN(b.GetRef(), "/", 4)[2]
	}

	// populate environment variables from metadata
	if m != nil {
		env["BUILD_CHANNEL"] = m.Queue.Channel
		env["VELA_ADDR"] = m.Vela.WebAddress
		env["VELA_CHANNEL"] = m.Queue.Channel
		env["VELA_DATABASE"] = m.Database.Driver
		env["VELA_HOST"] = m.Vela.Address
		env["VELA_NETRC_MACHINE"] = m.Source.Host
		env["VELA_QUEUE"] = m.Queue.Driver
		env["VELA_SOURCE"] = m.Source.Driver
	}

	return env
}
```

The hope or goal of this change is to improve the readability of the code in the compiler, but also, to help address a lack of consistency in how the variables can/will be set throughout the Vela codebase 👍 

This will also give us a way to inject a set of "standard environment variables" for the build/step/service running in the [go-vela/worker](https://github.com/go-vela/worker) too!