### PR TITLE
test(library): refactor for table tests

### DIFF
--- a/library/build_test.go
+++ b/library/build_test.go
@@ -262,592 +262,296 @@ func TestLibrary_Build_Environment(t *testing.T) {
 }
 
 func TestLibrary_Build_Getters(t *testing.T) {
-	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	b := &Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
+	// setup tests
+	tests := []struct {
+		build *Build
+		want  *Build
+	}{
+		{
+			build: testBuild(),
+			want:  testBuild(),
+		},
+		{
+			build: new(Build),
+			want:  new(Build),
+		},
 	}
-	wantID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantParent := num
-	wantEvent := str
-	wantStatus := str
-	wantError := str
-	wantEnqueued := num64
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantDeploy := str
-	wantClone := str
-	wantSource := str
-	wantTitle := str
-	wantMessage := str
-	wantCommit := str
-	wantSender := str
-	wantAuthor := str
-	wantEmail := str
-	wantLink := str
-	wantBranch := str
-	wantRef := str
-	wantBaseRef := str
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
 
-	// run test
-	gotID := b.GetID()
-	gotRepoID := b.GetRepoID()
-	gotNumber := b.GetNumber()
-	gotParent := b.GetParent()
-	gotEvent := b.GetEvent()
-	gotStatus := b.GetStatus()
-	gotError := b.GetError()
-	gotEnqueued := b.GetEnqueued()
-	gotCreated := b.GetCreated()
-	gotStarted := b.GetStarted()
-	gotFinished := b.GetFinished()
-	gotDeploy := b.GetDeploy()
-	gotClone := b.GetClone()
-	gotSource := b.GetSource()
-	gotTitle := b.GetTitle()
-	gotMessage := b.GetMessage()
-	gotCommit := b.GetCommit()
-	gotSender := b.GetSender()
-	gotAuthor := b.GetAuthor()
-	gotEmail := b.GetEmail()
-	gotLink := b.GetLink()
-	gotBranch := b.GetBranch()
-	gotRef := b.GetRef()
-	gotBaseRef := b.GetBaseRef()
-	gotHost := b.GetHost()
-	gotRuntime := b.GetRuntime()
-	gotDistribution := b.GetDistribution()
+	// run tests
+	for _, test := range tests {
+		if test.build.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.build.GetID(), test.want.GetID())
+		}
 
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotRepoID != wantRepoID {
-		t.Errorf("GetRepoID is %v, want %v", gotRepoID, wantRepoID)
-	}
-	if gotNumber != wantNumber {
-		t.Errorf("GetNumber is %v, want %v", gotNumber, wantNumber)
-	}
-	if gotParent != wantParent {
-		t.Errorf("GetParent is %v, want %v", gotParent, wantParent)
-	}
-	if gotEvent != wantEvent {
-		t.Errorf("GetEvent is %v, want %v", gotEvent, wantEvent)
-	}
-	if gotStatus != wantStatus {
-		t.Errorf("GetStatus is %v, want %v", gotStatus, wantStatus)
-	}
-	if gotError != wantError {
-		t.Errorf("GetError is %v, want %v", gotError, wantError)
-	}
-	if gotEnqueued != wantEnqueued {
-		t.Errorf("GetEnqueued is %v, want %v", gotEnqueued, wantEnqueued)
-	}
-	if gotCreated != wantCreated {
-		t.Errorf("GetCreated is %v, want %v", gotCreated, wantCreated)
-	}
-	if gotStarted != wantStarted {
-		t.Errorf("GetStarted is %v, want %v", gotStarted, wantStarted)
-	}
-	if gotFinished != wantFinished {
-		t.Errorf("GetFinished is %v, want %v", gotFinished, wantFinished)
-	}
-	if gotDeploy != wantDeploy {
-		t.Errorf("GetDeploy is %v, want %v", gotDeploy, wantDeploy)
-	}
-	if gotClone != wantClone {
-		t.Errorf("GetClone is %v, want %v", gotClone, wantClone)
-	}
-	if gotSource != wantSource {
-		t.Errorf("GetSource is %v, want %v", gotSource, wantSource)
-	}
-	if gotTitle != wantTitle {
-		t.Errorf("GetTitle is %v, want %v", gotTitle, wantTitle)
-	}
-	if gotMessage != wantMessage {
-		t.Errorf("GetMessage is %v, want %v", gotMessage, wantMessage)
-	}
-	if gotCommit != wantCommit {
-		t.Errorf("GetCommit is %v, want %v", gotCommit, wantCommit)
-	}
-	if gotSender != wantSender {
-		t.Errorf("GetSender is %v, want %v", gotSender, wantSender)
-	}
-	if gotAuthor != wantAuthor {
-		t.Errorf("GetAuthor is %v, want %v", gotAuthor, wantAuthor)
-	}
-	if gotEmail != wantEmail {
-		t.Errorf("GetEmail is %v, want %v", gotEmail, wantEmail)
-	}
-	if gotLink != wantLink {
-		t.Errorf("GetLink is %v, want %v", gotLink, wantLink)
-	}
-	if gotBranch != wantBranch {
-		t.Errorf("GetBranch is %v, want %v", gotBranch, wantBranch)
-	}
-	if gotRef != wantRef {
-		t.Errorf("GetRef is %v, want %v", gotRef, wantRef)
-	}
-	if gotBaseRef != wantBaseRef {
-		t.Errorf("GetBaseRef is %v, want %v", gotBaseRef, wantBaseRef)
-	}
-	if gotHost != wantHost {
-		t.Errorf("GetHost is %v, want %v", gotHost, wantHost)
-	}
-	if gotRuntime != wantRuntime {
-		t.Errorf("GetRuntime is %v, want %v", gotRuntime, wantRuntime)
-	}
-	if gotDistribution != wantDistribution {
-		t.Errorf("GetDistribution is %v, want %v", gotDistribution, wantDistribution)
-	}
-}
+		if test.build.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.build.GetRepoID(), test.want.GetRepoID())
+		}
 
-func TestLibrary_Build_Getters_Empty(t *testing.T) {
-	// setup types
-	var b *Build
+		if test.build.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.build.GetNumber(), test.want.GetNumber())
+		}
 
-	// run test
-	gotID := b.GetID()
-	gotRepoID := b.GetRepoID()
-	gotNumber := b.GetNumber()
-	gotParent := b.GetParent()
-	gotEvent := b.GetEvent()
-	gotStatus := b.GetStatus()
-	gotError := b.GetError()
-	gotEnqueued := b.GetEnqueued()
-	gotCreated := b.GetCreated()
-	gotStarted := b.GetStarted()
-	gotFinished := b.GetFinished()
-	gotDeploy := b.GetDeploy()
-	gotClone := b.GetClone()
-	gotSource := b.GetSource()
-	gotTitle := b.GetTitle()
-	gotMessage := b.GetMessage()
-	gotCommit := b.GetCommit()
-	gotSender := b.GetSender()
-	gotAuthor := b.GetAuthor()
-	gotEmail := b.GetEmail()
-	gotLink := b.GetLink()
-	gotBranch := b.GetBranch()
-	gotRef := b.GetRef()
-	gotBaseRef := b.GetBaseRef()
-	gotHost := b.GetHost()
-	gotRuntime := b.GetRuntime()
-	gotDistribution := b.GetDistribution()
+		if test.build.GetParent() != test.want.GetParent() {
+			t.Errorf("GetParent is %v, want %v", test.build.GetParent(), test.want.GetParent())
+		}
 
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotRepoID != 0 {
-		t.Errorf("GetRepoID is %v, want 0", gotRepoID)
-	}
-	if gotNumber != 0 {
-		t.Errorf("GetNumber is %v, want 0", gotNumber)
-	}
-	if gotParent != 0 {
-		t.Errorf("GetParent is %v, want 0", gotParent)
-	}
-	if gotEvent != "" {
-		t.Errorf("GetEvent is %v, want \"\"", gotEvent)
-	}
-	if gotStatus != "" {
-		t.Errorf("GetStatus is %v, want \"\"", gotStatus)
-	}
-	if gotError != "" {
-		t.Errorf("GetError is %v, want \"\"", gotError)
-	}
-	if gotEnqueued != 0 {
-		t.Errorf("GetEnqueued is %v, want 0", gotEnqueued)
-	}
-	if gotCreated != 0 {
-		t.Errorf("GetCreated is %v, want 0", gotCreated)
-	}
-	if gotStarted != 0 {
-		t.Errorf("GetStarted is %v, want 0", gotStarted)
-	}
-	if gotFinished != 0 {
-		t.Errorf("GetFinished is %v, want 0", gotFinished)
-	}
-	if gotDeploy != "" {
-		t.Errorf("GetDeploy is %v, want \"\"", gotDeploy)
-	}
-	if gotClone != "" {
-		t.Errorf("GetClone is %v, want \"\"", gotClone)
-	}
-	if gotSource != "" {
-		t.Errorf("GetSource is %v, want \"\"", gotSource)
-	}
-	if gotTitle != "" {
-		t.Errorf("GetTitle is %v, want \"\"", gotTitle)
-	}
-	if gotMessage != "" {
-		t.Errorf("GetMessage is %v, want \"\"", gotMessage)
-	}
-	if gotCommit != "" {
-		t.Errorf("GetCommit is %v, want \"\"", gotCommit)
-	}
-	if gotSender != "" {
-		t.Errorf("GetSender is %v, want \"\"", gotSender)
-	}
-	if gotAuthor != "" {
-		t.Errorf("GetAuthor is %v, want \"\"", gotAuthor)
-	}
-	if gotEmail != "" {
-		t.Errorf("GetEmail is %v, want \"\"", gotEmail)
-	}
-	if gotLink != "" {
-		t.Errorf("GetLink is %v, want \"\"", gotLink)
-	}
-	if gotBranch != "" {
-		t.Errorf("GetBranch is %v, want \"\"", gotBranch)
-	}
-	if gotRef != "" {
-		t.Errorf("GetRef is %v, want \"\"", gotRef)
-	}
-	if gotBaseRef != "" {
-		t.Errorf("GetBaseRef is %v, want \"\"", gotBaseRef)
-	}
-	if gotHost != "" {
-		t.Errorf("GetBaseRef is %v, want \"\"", gotHost)
-	}
-	if gotRuntime != "" {
-		t.Errorf("GetBaseRef is %v, want \"\"", gotRuntime)
-	}
-	if gotDistribution != "" {
-		t.Errorf("GetBaseRef is %v, want \"\"", gotDistribution)
+		if test.build.GetEvent() != test.want.GetEvent() {
+			t.Errorf("GetEvent is %v, want %v", test.build.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.build.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.build.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.build.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.build.GetError(), test.want.GetError())
+		}
+
+		if test.build.GetEnqueued() != test.want.GetEnqueued() {
+			t.Errorf("GetEnqueued is %v, want %v", test.build.GetEnqueued(), test.want.GetEnqueued())
+		}
+
+		if test.build.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.build.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.build.GetStarted() != test.want.GetStarted() {
+			t.Errorf("GetStarted is %v, want %v", test.build.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.build.GetFinished() != test.want.GetFinished() {
+			t.Errorf("GetFinished is %v, want %v", test.build.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.build.GetDeploy() != test.want.GetDeploy() {
+			t.Errorf("GetDeploy is %v, want %v", test.build.GetDeploy(), test.want.GetDeploy())
+		}
+
+		if test.build.GetClone() != test.want.GetClone() {
+			t.Errorf("GetClone is %v, want %v", test.build.GetClone(), test.want.GetClone())
+		}
+
+		if test.build.GetSource() != test.want.GetSource() {
+			t.Errorf("GetSource is %v, want %v", test.build.GetSource(), test.want.GetSource())
+		}
+
+		if test.build.GetTitle() != test.want.GetTitle() {
+			t.Errorf("GetTitle is %v, want %v", test.build.GetTitle(), test.want.GetTitle())
+		}
+
+		if test.build.GetMessage() != test.want.GetMessage() {
+			t.Errorf("GetMessage is %v, want %v", test.build.GetMessage(), test.want.GetMessage())
+		}
+
+		if test.build.GetCommit() != test.want.GetCommit() {
+			t.Errorf("GetCommit is %v, want %v", test.build.GetCommit(), test.want.GetCommit())
+		}
+
+		if test.build.GetSender() != test.want.GetSender() {
+			t.Errorf("GetSender is %v, want %v", test.build.GetSender(), test.want.GetSender())
+		}
+
+		if test.build.GetAuthor() != test.want.GetAuthor() {
+			t.Errorf("GetAuthor is %v, want %v", test.build.GetAuthor(), test.want.GetAuthor())
+		}
+
+		if test.build.GetEmail() != test.want.GetEmail() {
+			t.Errorf("GetEmail is %v, want %v", test.build.GetEmail(), test.want.GetEmail())
+		}
+
+		if test.build.GetLink() != test.want.GetLink() {
+			t.Errorf("GetLink is %v, want %v", test.build.GetLink(), test.want.GetLink())
+		}
+
+		if test.build.GetBranch() != test.want.GetBranch() {
+			t.Errorf("GetBranch is %v, want %v", test.build.GetBranch(), test.want.GetBranch())
+		}
+
+		if test.build.GetRef() != test.want.GetRef() {
+			t.Errorf("GetRef is %v, want %v", test.build.GetRef(), test.want.GetRef())
+		}
+
+		if test.build.GetBaseRef() != test.want.GetBaseRef() {
+			t.Errorf("GetBaseRef is %v, want %v", test.build.GetBaseRef(), test.want.GetBaseRef())
+		}
+
+		if test.build.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.build.GetHost(), test.want.GetHost())
+		}
+
+		if test.build.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.build.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.build.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.build.GetDistribution(), test.want.GetDistribution())
+		}
 	}
 }
 
 func TestLibrary_Build_Setters(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	b := new(Build)
-
-	wantID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantParent := num
-	wantEvent := str
-	wantStatus := str
-	wantError := str
-	wantEnqueued := num64
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantDeploy := str
-	wantClone := str
-	wantSource := str
-	wantTitle := str
-	wantMessage := str
-	wantCommit := str
-	wantSender := str
-	wantAuthor := str
-	wantEmail := str
-	wantLink := str
-	wantBranch := str
-	wantRef := str
-	wantBaseRef := str
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-
-	// Run tests
-	b.SetID(wantID)
-	b.SetRepoID(wantRepoID)
-	b.SetNumber(wantNumber)
-	b.SetParent(wantParent)
-	b.SetEvent(wantEvent)
-	b.SetStatus(wantStatus)
-	b.SetError(wantError)
-	b.SetEnqueued(wantEnqueued)
-	b.SetCreated(wantCreated)
-	b.SetStarted(wantStarted)
-	b.SetFinished(wantFinished)
-	b.SetDeploy(wantDeploy)
-	b.SetClone(wantClone)
-	b.SetSource(wantSource)
-	b.SetTitle(wantTitle)
-	b.SetMessage(wantMessage)
-	b.SetCommit(wantCommit)
-	b.SetSender(wantSender)
-	b.SetAuthor(wantAuthor)
-	b.SetEmail(wantEmail)
-	b.SetLink(wantLink)
-	b.SetBranch(wantBranch)
-	b.SetRef(wantRef)
-	b.SetBaseRef(wantBaseRef)
-	b.SetHost(wantHost)
-	b.SetRuntime(wantRuntime)
-	b.SetDistribution(wantDistribution)
-
-	if b.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", b.GetID(), wantID)
-	}
-	if b.GetRepoID() != wantRepoID {
-		t.Errorf("SetRepoID is %v, want %v", b.GetRepoID(), wantRepoID)
-	}
-	if b.GetNumber() != wantNumber {
-		t.Errorf("SetNumber is %v, want %v", b.GetNumber(), wantNumber)
-	}
-	if b.GetParent() != wantParent {
-		t.Errorf("SetParent is %v, want %v", b.GetParent(), wantParent)
-	}
-	if b.GetEvent() != wantEvent {
-		t.Errorf("SetEvent is %v, want %v", b.GetEvent(), wantEvent)
-	}
-	if b.GetStatus() != wantStatus {
-		t.Errorf("SetStatus is %v, want %v", b.GetStatus(), wantStatus)
-	}
-	if b.GetError() != wantError {
-		t.Errorf("SetError is %v, want %v", b.GetError(), wantError)
-	}
-	if b.GetEnqueued() != wantEnqueued {
-		t.Errorf("SetEnqueued is %v, want %v", b.GetEnqueued(), wantEnqueued)
-	}
-	if b.GetCreated() != wantCreated {
-		t.Errorf("SetCreated is %v, want %v", b.GetCreated(), wantCreated)
-	}
-	if b.GetStarted() != wantStarted {
-		t.Errorf("SetStarted is %v, want %v", b.GetStarted(), wantStarted)
-	}
-	if b.GetFinished() != wantFinished {
-		t.Errorf("SetFinished is %v, want %v", b.GetFinished(), wantFinished)
-	}
-	if b.GetDeploy() != wantDeploy {
-		t.Errorf("SetDeploy is %v, want %v", b.GetDeploy(), wantDeploy)
-	}
-	if b.GetClone() != wantClone {
-		t.Errorf("SetClone is %v, want %v", b.GetClone(), wantClone)
-	}
-	if b.GetSource() != wantSource {
-		t.Errorf("SetSource is %v, want %v", b.GetSource(), wantSource)
-	}
-	if b.GetTitle() != wantTitle {
-		t.Errorf("SetTitle is %v, want %v", b.GetTitle(), wantTitle)
-	}
-	if b.GetMessage() != wantMessage {
-		t.Errorf("SetMessage is %v, want %v", b.GetMessage(), wantMessage)
-	}
-	if b.GetCommit() != wantCommit {
-		t.Errorf("SetCommit is %v, want %v", b.GetCommit(), wantCommit)
-	}
-	if b.GetSender() != wantSender {
-		t.Errorf("SetSender is %v, want %v", b.GetSender(), wantSender)
-	}
-	if b.GetAuthor() != wantAuthor {
-		t.Errorf("SetAuthor is %v, want %v", b.GetAuthor(), wantAuthor)
-	}
-	if b.GetEmail() != wantEmail {
-		t.Errorf("SetEmail is %v, want %v", b.GetEmail(), wantEmail)
-	}
-	if b.GetLink() != wantLink {
-		t.Errorf("SetLink is %v, want %v", b.GetLink(), wantLink)
-	}
-	if b.GetBranch() != wantBranch {
-		t.Errorf("SetBranch is %v, want %v", b.GetBranch(), wantBranch)
-	}
-	if b.GetRef() != wantRef {
-		t.Errorf("SetRef is %v, want %v", b.GetRef(), wantRef)
-	}
-	if b.GetBaseRef() != wantBaseRef {
-		t.Errorf("SetBaseRef is %v, want %v", b.GetBaseRef(), wantBaseRef)
-	}
-	if b.GetHost() != wantHost {
-		t.Errorf("SetHost is %v, want %v", b.GetHost(), wantHost)
-	}
-	if b.GetRuntime() != wantRuntime {
-		t.Errorf("SetRuntime is %v, want %v", b.GetRuntime(), wantRuntime)
-	}
-	if b.GetDistribution() != wantDistribution {
-		t.Errorf("SetDistribution is %v, want %v", b.GetDistribution(), wantDistribution)
-	}
-}
-
-func TestLibrary_Build_Setters_Empty(t *testing.T) {
-	// setup types
 	var b *Build
 
-	// Run tests
-	b.SetID(0)
-	b.SetRepoID(0)
-	b.SetNumber(0)
-	b.SetParent(0)
-	b.SetEvent("")
-	b.SetStatus("")
-	b.SetError("")
-	b.SetEnqueued(0)
-	b.SetCreated(0)
-	b.SetStarted(0)
-	b.SetFinished(0)
-	b.SetDeploy("")
-	b.SetClone("")
-	b.SetSource("")
-	b.SetTitle("")
-	b.SetMessage("")
-	b.SetCommit("")
-	b.SetSender("")
-	b.SetAuthor("")
-	b.SetEmail("")
-	b.SetLink("")
-	b.SetBranch("")
-	b.SetRef("")
-	b.SetBaseRef("")
-	b.SetHost("")
-	b.SetRuntime("")
-	b.SetDistribution("")
+	// setup tests
+	tests := []struct {
+		build *Build
+		want  *Build
+	}{
+		{
+			build: testBuild(),
+			want:  testBuild(),
+		},
+		{
+			build: b,
+			want:  new(Build),
+		},
+	}
 
-	if b.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", b.GetID())
-	}
-	if b.GetRepoID() != 0 {
-		t.Errorf("SetRepoID is %v, want 0", b.GetRepoID())
-	}
-	if b.GetNumber() != 0 {
-		t.Errorf("SetNumber is %v, want 0", b.GetNumber())
-	}
-	if b.GetParent() != 0 {
-		t.Errorf("SetParent is %v, want 0", b.GetParent())
-	}
-	if b.GetEvent() != "" {
-		t.Errorf("SetEvent is %v, want \"\"", b.GetEvent())
-	}
-	if b.GetStatus() != "" {
-		t.Errorf("SetStatus is %v, want \"\"", b.GetStatus())
-	}
-	if b.GetError() != "" {
-		t.Errorf("SetError is %v, want \"\"", b.GetError())
-	}
-	if b.GetEnqueued() != 0 {
-		t.Errorf("SetEnqueued is %v, want 0", b.GetEnqueued())
-	}
-	if b.GetCreated() != 0 {
-		t.Errorf("SetCreated is %v, want 0", b.GetCreated())
-	}
-	if b.GetStarted() != 0 {
-		t.Errorf("SetStarted is %v, want 0", b.GetStarted())
-	}
-	if b.GetFinished() != 0 {
-		t.Errorf("SetFinished is %v, want 0", b.GetFinished())
-	}
-	if b.GetDeploy() != "" {
-		t.Errorf("SetDeploy is %v, want \"\"", b.GetDeploy())
-	}
-	if b.GetClone() != "" {
-		t.Errorf("SetClone is %v, want \"\"", b.GetClone())
-	}
-	if b.GetSource() != "" {
-		t.Errorf("SetSource is %v, want \"\"", b.GetSource())
-	}
-	if b.GetTitle() != "" {
-		t.Errorf("SetTitle is %v, want \"\"", b.GetTitle())
-	}
-	if b.GetMessage() != "" {
-		t.Errorf("SetMessage is %v, want \"\"", b.GetMessage())
-	}
-	if b.GetCommit() != "" {
-		t.Errorf("SetCommit is %v, want \"\"", b.GetCommit())
-	}
-	if b.GetSender() != "" {
-		t.Errorf("SetSender is %v, want \"\"", b.GetSender())
-	}
-	if b.GetAuthor() != "" {
-		t.Errorf("SetAuthor is %v, want \"\"", b.GetAuthor())
-	}
-	if b.GetEmail() != "" {
-		t.Errorf("SetEmail is %v, want \"\"", b.GetEmail())
-	}
-	if b.GetLink() != "" {
-		t.Errorf("SetLink is %v, want \"\"", b.GetLink())
-	}
-	if b.GetBranch() != "" {
-		t.Errorf("SetBranch is %v, want \"\"", b.GetBranch())
-	}
-	if b.GetRef() != "" {
-		t.Errorf("SetRef is %v, want \"\"", b.GetRef())
-	}
-	if b.GetBaseRef() != "" {
-		t.Errorf("SetBaseRef is %v, want \"\"", b.GetBaseRef())
-	}
-	if b.GetHost() != "" {
-		t.Errorf("SetHost is %v, want \"\"", b.GetHost())
-	}
-	if b.GetRuntime() != "" {
-		t.Errorf("SetRuntime is %v, want \"\"", b.GetRuntime())
-	}
-	if b.GetDistribution() != "" {
-		t.Errorf("SetDistribution is %v, want \"\"", b.GetDistribution())
+	// run tests
+	for _, test := range tests {
+		test.build.SetID(test.want.GetID())
+		test.build.SetRepoID(test.want.GetRepoID())
+		test.build.SetNumber(test.want.GetNumber())
+		test.build.SetParent(test.want.GetParent())
+		test.build.SetEvent(test.want.GetEvent())
+		test.build.SetStatus(test.want.GetStatus())
+		test.build.SetError(test.want.GetError())
+		test.build.SetEnqueued(test.want.GetEnqueued())
+		test.build.SetCreated(test.want.GetCreated())
+		test.build.SetStarted(test.want.GetStarted())
+		test.build.SetFinished(test.want.GetFinished())
+		test.build.SetDeploy(test.want.GetDeploy())
+		test.build.SetClone(test.want.GetClone())
+		test.build.SetSource(test.want.GetSource())
+		test.build.SetTitle(test.want.GetTitle())
+		test.build.SetMessage(test.want.GetMessage())
+		test.build.SetCommit(test.want.GetCommit())
+		test.build.SetSender(test.want.GetSender())
+		test.build.SetAuthor(test.want.GetAuthor())
+		test.build.SetEmail(test.want.GetEmail())
+		test.build.SetLink(test.want.GetLink())
+		test.build.SetBranch(test.want.GetBranch())
+		test.build.SetRef(test.want.GetRef())
+		test.build.SetBaseRef(test.want.GetBaseRef())
+		test.build.SetHost(test.want.GetHost())
+		test.build.SetRuntime(test.want.GetRuntime())
+		test.build.SetDistribution(test.want.GetDistribution())
+
+		if test.build.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.build.GetID(), test.want.GetID())
+		}
+
+		if test.build.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.build.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.build.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.build.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.build.GetParent() != test.want.GetParent() {
+			t.Errorf("SetParent is %v, want %v", test.build.GetParent(), test.want.GetParent())
+		}
+
+		if test.build.GetEvent() != test.want.GetEvent() {
+			t.Errorf("SetEvent is %v, want %v", test.build.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.build.GetStatus() != test.want.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.build.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.build.GetError() != test.want.GetError() {
+			t.Errorf("SetError is %v, want %v", test.build.GetError(), test.want.GetError())
+		}
+
+		if test.build.GetEnqueued() != test.want.GetEnqueued() {
+			t.Errorf("SetEnqueued is %v, want %v", test.build.GetEnqueued(), test.want.GetEnqueued())
+		}
+
+		if test.build.GetCreated() != test.want.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.build.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.build.GetStarted() != test.want.GetStarted() {
+			t.Errorf("SetStarted is %v, want %v", test.build.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.build.GetFinished() != test.want.GetFinished() {
+			t.Errorf("SetFinished is %v, want %v", test.build.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.build.GetDeploy() != test.want.GetDeploy() {
+			t.Errorf("SetDeploy is %v, want %v", test.build.GetDeploy(), test.want.GetDeploy())
+		}
+
+		if test.build.GetClone() != test.want.GetClone() {
+			t.Errorf("SetClone is %v, want %v", test.build.GetClone(), test.want.GetClone())
+		}
+
+		if test.build.GetSource() != test.want.GetSource() {
+			t.Errorf("SetSource is %v, want %v", test.build.GetSource(), test.want.GetSource())
+		}
+
+		if test.build.GetTitle() != test.want.GetTitle() {
+			t.Errorf("SetTitle is %v, want %v", test.build.GetTitle(), test.want.GetTitle())
+		}
+
+		if test.build.GetMessage() != test.want.GetMessage() {
+			t.Errorf("SetMessage is %v, want %v", test.build.GetMessage(), test.want.GetMessage())
+		}
+
+		if test.build.GetCommit() != test.want.GetCommit() {
+			t.Errorf("SetCommit is %v, want %v", test.build.GetCommit(), test.want.GetCommit())
+		}
+
+		if test.build.GetSender() != test.want.GetSender() {
+			t.Errorf("SetSender is %v, want %v", test.build.GetSender(), test.want.GetSender())
+		}
+
+		if test.build.GetAuthor() != test.want.GetAuthor() {
+			t.Errorf("SetAuthor is %v, want %v", test.build.GetAuthor(), test.want.GetAuthor())
+		}
+
+		if test.build.GetEmail() != test.want.GetEmail() {
+			t.Errorf("SetEmail is %v, want %v", test.build.GetEmail(), test.want.GetEmail())
+		}
+
+		if test.build.GetLink() != test.want.GetLink() {
+			t.Errorf("SetLink is %v, want %v", test.build.GetLink(), test.want.GetLink())
+		}
+
+		if test.build.GetBranch() != test.want.GetBranch() {
+			t.Errorf("SetBranch is %v, want %v", test.build.GetBranch(), test.want.GetBranch())
+		}
+
+		if test.build.GetRef() != test.want.GetRef() {
+			t.Errorf("SetRef is %v, want %v", test.build.GetRef(), test.want.GetRef())
+		}
+
+		if test.build.GetBaseRef() != test.want.GetBaseRef() {
+			t.Errorf("SetBaseRef is %v, want %v", test.build.GetBaseRef(), test.want.GetBaseRef())
+		}
+
+		if test.build.GetHost() != test.want.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.build.GetHost(), test.want.GetHost())
+		}
+
+		if test.build.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.build.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.build.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.build.GetDistribution(), test.want.GetDistribution())
+		}
 	}
 }
 
 func TestLibrary_Build_String(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	b := &Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
+	b := testBuild()
+
 	want := fmt.Sprintf("%+v", *b)
 
 	// run test

--- a/library/context_test.go
+++ b/library/context_test.go
@@ -11,57 +11,43 @@ import (
 
 func TestLibrary_BuildFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Build{ID: &id}
+	b := testBuild()
 
-	// setup context
-	ctx = context.WithValue(ctx, buildKey, want)
-
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != want {
-		t.Errorf("BuildFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Build
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), buildKey, b),
+			want: b,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), buildKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_BuildFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := BuildFromContext(test.ctx)
 
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("BuildFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_BuildFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, buildKey, id)
-
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("BuildFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("BuildFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_BuildWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Build{ID: &id}
+	want := testBuild()
 
 	// setup context
-	ctx = BuildWithContext(ctx, want)
+	ctx := BuildWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(buildKey)
@@ -73,57 +59,43 @@ func TestLibrary_BuildWithContext(t *testing.T) {
 
 func TestLibrary_LogFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Log{ID: &id}
+	l := testLog()
 
-	// setup context
-	ctx = context.WithValue(ctx, logKey, want)
-
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != want {
-		t.Errorf("LogFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Log
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), logKey, l),
+			want: l,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), logKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_LogFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := LogFromContext(test.ctx)
 
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("LogFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_LogFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, logKey, id)
-
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("LogFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("LogFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_LogWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Log{ID: &id}
+	want := testLog()
 
 	// setup context
-	ctx = LogWithContext(ctx, want)
+	ctx := LogWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(logKey)
@@ -135,57 +107,43 @@ func TestLibrary_LogWithContext(t *testing.T) {
 
 func TestLibrary_RepoFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Repo{ID: &id}
+	r := testRepo()
 
-	// setup context
-	ctx = context.WithValue(ctx, repoKey, want)
-
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != want {
-		t.Errorf("RepoFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Repo
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), repoKey, r),
+			want: r,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), repoKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_RepoFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := RepoFromContext(test.ctx)
 
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("RepoFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_RepoFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, repoKey, id)
-
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("RepoFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("RepoFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_RepoWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Repo{ID: &id}
+	want := testRepo()
 
 	// setup context
-	ctx = RepoWithContext(ctx, want)
+	ctx := RepoWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(repoKey)
@@ -197,57 +155,43 @@ func TestLibrary_RepoWithContext(t *testing.T) {
 
 func TestLibrary_SecretFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Secret{ID: &id}
+	s := testSecret()
 
-	// setup context
-	ctx = context.WithValue(ctx, secretKey, want)
-
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != want {
-		t.Errorf("SecretFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Secret
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), secretKey, s),
+			want: s,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), secretKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_SecretFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := SecretFromContext(test.ctx)
 
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("SecretFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_SecretFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, secretKey, id)
-
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("SecretFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("SecretFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_SecretWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Secret{ID: &id}
+	want := testSecret()
 
 	// setup context
-	ctx = SecretWithContext(ctx, want)
+	ctx := SecretWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(secretKey)
@@ -259,57 +203,43 @@ func TestLibrary_SecretWithContext(t *testing.T) {
 
 func TestLibrary_StepFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Step{ID: &id}
+	s := testStep()
 
-	// setup context
-	ctx = context.WithValue(ctx, stepKey, want)
-
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != want {
-		t.Errorf("StepFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Step
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), stepKey, s),
+			want: s,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), stepKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_StepFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := StepFromContext(test.ctx)
 
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("StepFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_StepFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, stepKey, id)
-
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("StepFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("StepFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_StepWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &Step{ID: &id}
+	want := testStep()
 
 	// setup context
-	ctx = StepWithContext(ctx, want)
+	ctx := StepWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(stepKey)
@@ -321,57 +251,43 @@ func TestLibrary_StepWithContext(t *testing.T) {
 
 func TestLibrary_UserFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &User{ID: &id}
+	u := testUser()
 
-	// setup context
-	ctx = context.WithValue(ctx, userKey, want)
-
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != want {
-		t.Errorf("UserFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *User
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), userKey, u),
+			want: u,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), userKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestLibrary_UserFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := UserFromContext(test.ctx)
 
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("UserFromContext is %v, want nil", got)
-	}
-}
-
-func TestLibrary_UserFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, userKey, id)
-
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("UserFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("UserFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestLibrary_UserWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	id := int64(1)
-	want := &User{ID: &id}
+	want := testUser()
 
 	// setup context
-	ctx = UserWithContext(ctx, want)
+	ctx := UserWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(userKey)

--- a/library/executor_test.go
+++ b/library/executor_test.go
@@ -13,471 +13,116 @@ import (
 )
 
 func TestLibrary_Executor_Getters(t *testing.T) {
-	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	booL := true
-	b := &Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-	r := &Repo{
-		ID:          &num64,
-		UserID:      &num64,
-		Org:         &str,
-		Name:        &str,
-		FullName:    &str,
-		Link:        &str,
-		Clone:       &str,
-		Branch:      &str,
-		Timeout:     &num64,
-		Visibility:  &str,
-		Private:     &booL,
-		Trusted:     &booL,
-		Active:      &booL,
-		AllowPull:   &booL,
-		AllowPush:   &booL,
-		AllowDeploy: &booL,
-		AllowTag:    &booL,
-	}
-	p := &pipeline.Build{
-		Services: pipeline.ContainerSlice{
-			&pipeline.Container{
-				Image:  "postgres:latest",
-				Name:   "postgres",
-				Number: 1,
-			}},
-		Worker: pipeline.Worker{
-			Flavor:   "16cpu8gb",
-			Platform: "gcp",
+	// setup tests
+	tests := []struct {
+		executor *Executor
+		want     *Executor
+	}{
+		{
+			executor: testExecutor(),
+			want:     testExecutor(),
 		},
-		Stages: pipeline.StageSlice{
-			&pipeline.Stage{
-				Name:  "install",
-				Needs: []string{"clone"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew downloadDependencies"},
-						Image:    "openjdk:latest",
-						Name:     "install",
-						Number:   1,
-						Pull:     true,
-					},
-				},
-			},
-			&pipeline.Stage{
-				Name:  "test",
-				Needs: []string{"install"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew check"},
-						Image:    "openjdk:latest",
-						Name:     "test",
-						Number:   2,
-						Pull:     true,
-						Ruleset: pipeline.Ruleset{
-							If: pipeline.Rules{
-								Event: []string{"push"},
-							},
-							Operator: "and",
-						},
-					},
-				},
-			},
+		{
+			executor: new(Executor),
+			want:     new(Executor),
 		},
 	}
-	e := &Executor{
-		ID:           &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-		Build:        b,
-		Repo:         r,
-		Pipeline:     p,
-	}
-	wantID := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-	wantBuild := *e.Build
-	wantRepo := *e.Repo
-	wantPipeline := *e.Pipeline
 
-	// run test
-	gotID := e.GetID()
-	gotHost := e.GetHost()
-	gotRuntime := e.GetRuntime()
-	gotDistribution := e.GetDistribution()
-	gotBuild := e.GetBuild()
-	gotRepo := e.GetRepo()
-	gotPipeline := e.GetPipeline()
+	// run tests
+	for _, test := range tests {
+		if test.executor.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.executor.GetID(), test.want.GetID())
+		}
 
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotHost != wantHost {
-		t.Errorf("GetHost is %v, want %v", gotHost, wantHost)
-	}
-	if gotRuntime != wantRuntime {
-		t.Errorf("GetRuntime is %v, want %v", gotRuntime, wantRuntime)
-	}
-	if gotDistribution != wantDistribution {
-		t.Errorf("GetDistribution is %v, want %v", gotDistribution, wantDistribution)
-	}
-	if !reflect.DeepEqual(gotBuild, wantBuild) {
-		t.Errorf("GetBuild is %v, want %v", gotBuild, wantBuild)
-	}
-	if !reflect.DeepEqual(gotRepo, wantRepo) {
-		t.Errorf("GetRepo is %v, want %v", gotRepo, wantRepo)
-	}
-	if !reflect.DeepEqual(gotPipeline, wantPipeline) {
-		t.Errorf("GetPipeline is %v, want %v", gotPipeline, wantPipeline)
-	}
-}
+		if test.executor.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.executor.GetHost(), test.want.GetHost())
+		}
 
-func TestLibrary_Executor_Getters_Empty(t *testing.T) {
-	// setup types
-	e := new(Executor)
+		if test.executor.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.executor.GetRuntime(), test.want.GetRuntime())
+		}
 
-	// run test
-	gotID := e.GetID()
-	gotHost := e.GetHost()
-	gotRuntime := e.GetRuntime()
-	gotDistribution := e.GetDistribution()
-	gotBuild := e.GetBuild()
-	gotRepo := e.GetRepo()
-	gotPipeline := e.GetPipeline()
+		if test.executor.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.executor.GetDistribution(), test.want.GetDistribution())
+		}
 
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotHost != "" {
-		t.Errorf("GetHost is %v, want \"\"", gotHost)
-	}
-	if gotRuntime != "" {
-		t.Errorf("GetRuntime is %v, want \"\"", gotRuntime)
-	}
-	if gotDistribution != "" {
-		t.Errorf("GetDistribution is %v, want \"\"", gotDistribution)
-	}
-	if !reflect.DeepEqual(gotBuild, Build{}) {
-		t.Errorf("GetBuild is %v, want \"\"", gotBuild)
-	}
-	if !reflect.DeepEqual(gotRepo, Repo{}) {
-		t.Errorf("GetRepo is %v, want \"\"", gotRepo)
-	}
-	if !reflect.DeepEqual(gotPipeline, pipeline.Build{}) {
-		t.Errorf("GetPipeline is %v, want \"\"", gotPipeline)
+		if !reflect.DeepEqual(test.executor.GetBuild(), test.want.GetBuild()) {
+			t.Errorf("GetBuild is %v, want %v", test.executor.GetBuild(), test.want.GetBuild())
+		}
+
+		if !reflect.DeepEqual(test.executor.GetRepo(), test.want.GetRepo()) {
+			t.Errorf("GetRepo is %v, want %v", test.executor.GetRepo(), test.want.GetRepo())
+		}
+
+		if !reflect.DeepEqual(test.executor.GetPipeline(), test.want.GetPipeline()) {
+			t.Errorf("GetPipeline is %v, want %v", test.executor.GetPipeline(), test.want.GetPipeline())
+		}
 	}
 }
 
 func TestLibrary_Executor_Setters(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	booL := true
-	b := Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-	r := Repo{
-		ID:          &num64,
-		UserID:      &num64,
-		Org:         &str,
-		Name:        &str,
-		FullName:    &str,
-		Link:        &str,
-		Clone:       &str,
-		Branch:      &str,
-		Timeout:     &num64,
-		Visibility:  &str,
-		Private:     &booL,
-		Trusted:     &booL,
-		Active:      &booL,
-		AllowPull:   &booL,
-		AllowPush:   &booL,
-		AllowDeploy: &booL,
-		AllowTag:    &booL,
-	}
-	p := pipeline.Build{
-		Services: pipeline.ContainerSlice{
-			&pipeline.Container{
-				Image:  "postgres:latest",
-				Name:   "postgres",
-				Number: 1,
-			}},
-		Worker: pipeline.Worker{
-			Flavor:   "16cpu8gb",
-			Platform: "gcp",
-		},
-		Stages: pipeline.StageSlice{
-			&pipeline.Stage{
-				Name:  "install",
-				Needs: []string{"clone"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew downloadDependencies"},
-						Image:    "openjdk:latest",
-						Name:     "install",
-						Number:   1,
-						Pull:     true,
-					},
-				},
-			},
-			&pipeline.Stage{
-				Name:  "test",
-				Needs: []string{"install"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew check"},
-						Image:    "openjdk:latest",
-						Name:     "test",
-						Number:   2,
-						Pull:     true,
-						Ruleset: pipeline.Ruleset{
-							If: pipeline.Rules{
-								Event: []string{"push"},
-							},
-							Operator: "and",
-						},
-					},
-				},
-			},
-		},
-	}
-	e := new(Executor)
-
-	wantID := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-	wantBuild := b
-	wantRepo := r
-	wantPipeline := p
-
-	// Run tests
-	e.SetID(wantID)
-	e.SetHost(wantHost)
-	e.SetRuntime(wantRuntime)
-	e.SetDistribution(wantDistribution)
-	e.SetBuild(wantBuild)
-	e.SetRepo(wantRepo)
-	e.SetPipeline(wantPipeline)
-
-	if e.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", e.GetID(), wantID)
-	}
-	if e.GetHost() != wantHost {
-		t.Errorf("SetHost is %v, want %v", e.GetHost(), wantHost)
-	}
-	if e.GetRuntime() != wantRuntime {
-		t.Errorf("SetRuntime is %v, want %v", e.GetRuntime(), wantRuntime)
-	}
-	if e.GetDistribution() != wantDistribution {
-		t.Errorf("SetDistribution is %v, want %v", e.GetDistribution(), wantDistribution)
-	}
-	if !reflect.DeepEqual(e.GetBuild(), wantBuild) {
-		t.Errorf("SetBuild is %v, want %v", e.GetBuild(), wantBuild)
-	}
-	if !reflect.DeepEqual(e.GetRepo(), wantRepo) {
-		t.Errorf("SetRepo is %v, want %v", e.GetRepo(), wantRepo)
-	}
-	if !reflect.DeepEqual(e.GetPipeline(), wantPipeline) {
-		t.Errorf("SetPipeline is %v, want %v", e.GetPipeline(), wantPipeline)
-	}
-}
-
-func TestLibrary_Executor_Setters_Empty(t *testing.T) {
-	// setup types
 	var e *Executor
 
-	// Run tests
-	e.SetID(0)
-	e.SetHost("")
-	e.SetRuntime("")
-	e.SetDistribution("")
-	e.SetBuild(Build{})
-	e.SetRepo(Repo{})
-	e.SetPipeline(pipeline.Build{})
+	// setup tests
+	tests := []struct {
+		executor *Executor
+		want     *Executor
+	}{
+		{
+			executor: testExecutor(),
+			want:     testExecutor(),
+		},
+		{
+			executor: e,
+			want:     new(Executor),
+		},
+	}
 
-	if e.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", e.GetID())
-	}
-	if e.GetHost() != "" {
-		t.Errorf("SetHost is %v, want \"\"", e.GetHost())
-	}
-	if e.GetRuntime() != "" {
-		t.Errorf("SetRuntime is %v, want \"\"", e.GetRuntime())
-	}
-	if e.GetDistribution() != "" {
-		t.Errorf("SetDistribution is %v, want \"\"", e.GetDistribution())
-	}
-	if !reflect.DeepEqual(e.GetBuild(), Build{}) {
-		t.Errorf("GetBuild is %v, want \"\"", e.GetBuild())
-	}
-	if !reflect.DeepEqual(e.GetRepo(), Repo{}) {
-		t.Errorf("GetRepo is %v, want \"\"", e.GetRepo())
-	}
-	if !reflect.DeepEqual(e.GetPipeline(), pipeline.Build{}) {
-		t.Errorf("GetPipeline is %v, want \"\"", e.GetPipeline())
+	// run tests
+	for _, test := range tests {
+		test.executor.SetID(test.want.GetID())
+		test.executor.SetHost(test.want.GetHost())
+		test.executor.SetRuntime(test.want.GetRuntime())
+		test.executor.SetDistribution(test.want.GetDistribution())
+		test.executor.SetBuild(test.want.GetBuild())
+		test.executor.SetRepo(test.want.GetRepo())
+		test.executor.SetPipeline(test.want.GetPipeline())
+
+		if test.executor.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.executor.GetID(), test.want.GetID())
+		}
+
+		if test.executor.GetHost() != test.want.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.executor.GetHost(), test.want.GetHost())
+		}
+
+		if test.executor.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.executor.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.executor.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.executor.GetDistribution(), test.want.GetDistribution())
+		}
+
+		if !reflect.DeepEqual(test.executor.GetBuild(), test.want.GetBuild()) {
+			t.Errorf("SetBuild is %v, want %v", test.executor.GetBuild(), test.want.GetBuild())
+		}
+
+		if !reflect.DeepEqual(test.executor.GetRepo(), test.want.GetRepo()) {
+			t.Errorf("SetRepo is %v, want %v", test.executor.GetRepo(), test.want.GetRepo())
+		}
+
+		if !reflect.DeepEqual(test.executor.GetPipeline(), test.want.GetPipeline()) {
+			t.Errorf("SetPipeline is %v, want %v", test.executor.GetPipeline(), test.want.GetPipeline())
+		}
 	}
 }
 
 func TestLibrary_Executor_String(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	booL := true
-	b := &Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-	r := &Repo{
-		ID:          &num64,
-		UserID:      &num64,
-		Org:         &str,
-		Name:        &str,
-		FullName:    &str,
-		Link:        &str,
-		Clone:       &str,
-		Branch:      &str,
-		Timeout:     &num64,
-		Visibility:  &str,
-		Private:     &booL,
-		Trusted:     &booL,
-		Active:      &booL,
-		AllowPull:   &booL,
-		AllowPush:   &booL,
-		AllowDeploy: &booL,
-		AllowTag:    &booL,
-	}
-	p := &pipeline.Build{
-		Services: pipeline.ContainerSlice{
-			&pipeline.Container{
-				Image:  "postgres:latest",
-				Name:   "postgres",
-				Number: 1,
-			}},
-		Worker: pipeline.Worker{
-			Flavor:   "16cpu8gb",
-			Platform: "gcp",
-		},
-		Stages: pipeline.StageSlice{
-			&pipeline.Stage{
-				Name:  "install",
-				Needs: []string{"clone"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew downloadDependencies"},
-						Image:    "openjdk:latest",
-						Name:     "install",
-						Number:   1,
-						Pull:     true,
-					},
-				},
-			},
-			&pipeline.Stage{
-				Name:  "test",
-				Needs: []string{"install"},
-				Steps: pipeline.ContainerSlice{
-					&pipeline.Container{
-						Commands: []string{"./gradlew check"},
-						Image:    "openjdk:latest",
-						Name:     "test",
-						Number:   2,
-						Pull:     true,
-						Ruleset: pipeline.Ruleset{
-							If: pipeline.Rules{
-								Event: []string{"push"},
-							},
-							Operator: "and",
-						},
-					},
-				},
-			},
-		},
-	}
-	e := &Executor{
-		ID:           &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-		Build:        b,
-		Repo:         r,
-		Pipeline:     p,
-	}
+	e := testExecutor()
+
 	want := fmt.Sprintf("%+v", *e)
 
 	// run test
@@ -486,4 +131,50 @@ func TestLibrary_Executor_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testExecutor is a test helper function to create a Executor
+// type with all fields set to a fake value.
+func testExecutor() *Executor {
+	e := new(Executor)
+
+	e.SetID(1)
+	e.SetHost("company.example.com")
+	e.SetRuntime("docker")
+	e.SetDistribution("linux")
+	e.SetBuild(*testBuild())
+	e.SetRepo(*testRepo())
+	e.SetPipeline(pipeline.Build{
+		Version: "1",
+		ID:      "github_octocat_1",
+		Steps: pipeline.ContainerSlice{
+			{
+				ID:        "step_github_octocat_1_init",
+				Directory: "/home/github/octocat",
+				Image:     "#init",
+				Name:      "init",
+				Number:    1,
+				Pull:      true,
+			},
+			{
+				ID:        "step_github_octocat_1_clone",
+				Directory: "/home/github/octocat",
+				Image:     "target/vela-git:v0.3.0",
+				Name:      "clone",
+				Number:    2,
+				Pull:      true,
+			},
+			{
+				ID:        "step_github_octocat_1_echo",
+				Commands:  []string{"echo hello"},
+				Directory: "/home/github/octocat",
+				Image:     "alpine:latest",
+				Name:      "echo",
+				Number:    3,
+				Pull:      true,
+			},
+		},
+	})
+
+	return e
 }

--- a/library/hook_test.go
+++ b/library/hook_test.go
@@ -12,271 +12,176 @@ import (
 )
 
 func TestLibrary_Hook_Getters(t *testing.T) {
-	// setup types
-	wantID := int64(1)
-	wantRepoID := int64(1)
-	wantBuildID := int64(1)
-	wantNumber := 1
-	wantSourceID := "c8da1302-07d6-11ea-882f-4893bca275b8"
-	wantCreated := time.Now().UTC().Unix()
-	wantHost := "github.com"
-	wantEvent := "push"
-	wantBranch := "master"
-	wantError := ""
-	wantStatus := "success"
-	wantLink := "https://github.com/github/octocat/settings/hooks/1"
+	// setup tests
+	tests := []struct {
+		hook *Hook
+		want *Hook
+	}{
+		{
+			hook: testHook(),
+			want: testHook(),
+		},
+		{
+			hook: new(Hook),
+			want: new(Hook),
+		},
+	}
 
-	h := new(Hook)
+	// run tests
+	for _, test := range tests {
+		if test.hook.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.hook.GetID(), test.want.GetID())
+		}
 
-	h.SetID(wantID)
-	h.SetRepoID(wantRepoID)
-	h.SetBuildID(wantBuildID)
-	h.SetNumber(wantNumber)
-	h.SetSourceID(wantSourceID)
-	h.SetCreated(wantCreated)
-	h.SetHost(wantHost)
-	h.SetEvent(wantEvent)
-	h.SetBranch(wantBranch)
-	h.SetError(wantError)
-	h.SetStatus(wantStatus)
-	h.SetLink(wantLink)
+		if test.hook.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.hook.GetRepoID(), test.want.GetRepoID())
+		}
 
-	// run test
-	gotID := h.GetID()
-	gotRepoID := h.GetRepoID()
-	gotBuildID := h.GetBuildID()
-	gotNumber := h.GetNumber()
-	gotSourceID := h.GetSourceID()
-	gotCreated := h.GetCreated()
-	gotHost := h.GetHost()
-	gotEvent := h.GetEvent()
-	gotBranch := h.GetBranch()
-	gotError := h.GetError()
-	gotStatus := h.GetStatus()
-	gotLink := h.GetLink()
+		if test.hook.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.hook.GetBuildID(), test.want.GetBuildID())
+		}
 
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotRepoID != wantRepoID {
-		t.Errorf("GetRepoID is %v, want %v", gotRepoID, wantRepoID)
-	}
-	if gotBuildID != wantBuildID {
-		t.Errorf("GetBuildID is %v, want %v", gotBuildID, wantBuildID)
-	}
-	if gotNumber != wantNumber {
-		t.Errorf("GetNumber is %v, want %v", gotNumber, wantNumber)
-	}
-	if gotSourceID != wantSourceID {
-		t.Errorf("GetSourceID is %v, want %v", gotSourceID, wantSourceID)
-	}
-	if gotCreated != wantCreated {
-		t.Errorf("GetCreated is %v, want %v", gotCreated, wantCreated)
-	}
-	if gotHost != wantHost {
-		t.Errorf("GetHost is %v, want %v", gotHost, wantHost)
-	}
-	if gotEvent != wantEvent {
-		t.Errorf("GetEvent is %v, want %v", gotEvent, wantEvent)
-	}
-	if gotBranch != wantBranch {
-		t.Errorf("GetBranch is %v, want %v", gotBranch, wantBranch)
-	}
-	if gotError != wantError {
-		t.Errorf("GetError is %v, want %v", gotError, wantError)
-	}
-	if gotStatus != wantStatus {
-		t.Errorf("GetStatus is %v, want %v", gotStatus, wantStatus)
-	}
-	if gotLink != wantLink {
-		t.Errorf("GetLink is %v, want %v", gotLink, wantLink)
-	}
-}
+		if test.hook.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.hook.GetNumber(), test.want.GetNumber())
+		}
 
-func TestLibrary_Hook_Getters_Empty(t *testing.T) {
-	// setup types
-	h := new(Hook)
+		if test.hook.GetSourceID() != test.want.GetSourceID() {
+			t.Errorf("GetSourceID is %v, want %v", test.hook.GetSourceID(), test.want.GetSourceID())
+		}
 
-	// run test
-	gotID := h.GetID()
-	gotRepoID := h.GetRepoID()
-	gotBuildID := h.GetRepoID()
-	gotNumber := h.GetNumber()
-	gotSourceID := h.GetSourceID()
-	gotCreated := h.GetCreated()
-	gotHost := h.GetHost()
-	gotEvent := h.GetEvent()
-	gotBranch := h.GetBranch()
-	gotError := h.GetError()
-	gotStatus := h.GetStatus()
-	gotLink := h.GetLink()
+		if test.hook.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.hook.GetCreated(), test.want.GetCreated())
+		}
 
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotRepoID != 0 {
-		t.Errorf("GetRepoID is %v, want 0", gotRepoID)
-	}
-	if gotBuildID != 0 {
-		t.Errorf("GetBuildID is %v, want 0", gotBuildID)
-	}
-	if gotNumber != 0 {
-		t.Errorf("GetNumber is %v, want 0", gotNumber)
-	}
-	if gotSourceID != "" {
-		t.Errorf("GetSourceID is %v, want \"\"", gotSourceID)
-	}
-	if gotCreated != 0 {
-		t.Errorf("GetCreated is %v, want 0", gotCreated)
-	}
-	if gotHost != "" {
-		t.Errorf("GetHost is %v, want \"\"", gotHost)
-	}
-	if gotEvent != "" {
-		t.Errorf("GetEvent is %v, want \"\"", gotEvent)
-	}
-	if gotBranch != "" {
-		t.Errorf("GetBranch is %v, want \"\"", gotBranch)
-	}
-	if gotError != "" {
-		t.Errorf("GetError is %v, want \"\"", gotError)
-	}
-	if gotStatus != "" {
-		t.Errorf("GetStatus is %v, want \"\"", gotStatus)
-	}
-	if gotLink != "" {
-		t.Errorf("GetStatus is %v, want \"\"", gotLink)
+		if test.hook.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.hook.GetHost(), test.want.GetHost())
+		}
+
+		if test.hook.GetEvent() != test.want.GetEvent() {
+			t.Errorf("GetEvent is %v, want %v", test.hook.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.hook.GetBranch() != test.want.GetBranch() {
+			t.Errorf("GetBranch is %v, want %v", test.hook.GetBranch(), test.want.GetBranch())
+		}
+
+		if test.hook.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.hook.GetError(), test.want.GetError())
+		}
+
+		if test.hook.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.hook.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.hook.GetLink() != test.want.GetLink() {
+			t.Errorf("GetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
+		}
 	}
 }
 
 func TestLibrary_Hook_Setters(t *testing.T) {
 	// setup types
-	wantID := int64(1)
-	wantRepoID := int64(1)
-	wantBuildID := int64(1)
-	wantNumber := 1
-	wantSourceID := "c8da1302-07d6-11ea-882f-4893bca275b8"
-	wantCreated := time.Now().UTC().Unix()
-	wantHost := "github.com"
-	wantEvent := "push"
-	wantBranch := "master"
-	wantError := ""
-	wantStatus := "success"
-	wantLink := "https://github.com/github/octocat/settings/hooks/1"
-
-	h := new(Hook)
-
-	// Run tests
-	h.SetID(wantID)
-	h.SetRepoID(wantRepoID)
-	h.SetBuildID(wantBuildID)
-	h.SetNumber(wantNumber)
-	h.SetSourceID(wantSourceID)
-	h.SetCreated(wantCreated)
-	h.SetHost(wantHost)
-	h.SetEvent(wantEvent)
-	h.SetBranch(wantBranch)
-	h.SetError(wantError)
-	h.SetStatus(wantStatus)
-	h.SetLink(wantLink)
-
-	if h.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", h.GetID(), wantID)
-	}
-	if h.GetRepoID() != wantRepoID {
-		t.Errorf("SetRepoID is %v, want %v", h.GetRepoID(), wantRepoID)
-	}
-	if h.GetBuildID() != wantBuildID {
-		t.Errorf("SetBuildID is %v, want %v", h.GetBuildID(), wantBuildID)
-	}
-	if h.GetNumber() != wantNumber {
-		t.Errorf("SetNumber is %v, want %v", h.GetNumber(), wantNumber)
-	}
-	if h.GetSourceID() != wantSourceID {
-		t.Errorf("SetSourceID is %v, want %v", h.GetSourceID(), wantSourceID)
-	}
-	if h.GetCreated() != wantCreated {
-		t.Errorf("SetCreated is %v, want %v", h.GetCreated(), wantCreated)
-	}
-	if h.GetHost() != wantHost {
-		t.Errorf("SetHost is %v, want %v", h.GetHost(), wantHost)
-	}
-	if h.GetEvent() != wantEvent {
-		t.Errorf("SetEvent is %v, want %v", h.GetEvent(), wantEvent)
-	}
-	if h.GetBranch() != wantBranch {
-		t.Errorf("SetBranch is %v, want %v", h.GetBranch(), wantBranch)
-	}
-	if h.GetError() != wantError {
-		t.Errorf("SetError is %v, want %v", h.GetError(), wantError)
-	}
-	if h.GetStatus() != wantStatus {
-		t.Errorf("SetStatus is %v, want %v", h.GetStatus(), wantStatus)
-	}
-	if h.GetLink() != wantLink {
-		t.Errorf("SetLink is %v, want %v", h.GetLink(), wantLink)
-	}
-}
-
-func TestLibrary_Hook_Setters_Empty(t *testing.T) {
-	// setup types
 	var h *Hook
 
-	// Run tests
-	h.SetID(0)
-	h.SetRepoID(0)
-	h.SetBuildID(0)
-	h.SetNumber(0)
-	h.SetSourceID("")
-	h.SetCreated(0)
-	h.SetHost("")
-	h.SetEvent("")
-	h.SetBranch("")
-	h.SetError("")
-	h.SetStatus("")
-	h.SetLink("")
+	// setup tests
+	tests := []struct {
+		hook *Hook
+		want *Hook
+	}{
+		{
+			hook: testHook(),
+			want: testHook(),
+		},
+		{
+			hook: h,
+			want: new(Hook),
+		},
+	}
 
-	if h.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", h.GetID())
-	}
-	if h.GetRepoID() != 0 {
-		t.Errorf("SetRepoID is %v, want 0", h.GetRepoID())
-	}
-	if h.GetBuildID() != 0 {
-		t.Errorf("SetBuildID is %v, want 0", h.GetBuildID())
-	}
-	if h.GetNumber() != 0 {
-		t.Errorf("SetNumber is %v, want 0", h.GetNumber())
-	}
-	if h.GetSourceID() != "" {
-		t.Errorf("SetSourceID is %v, want \"\"", h.GetSourceID())
-	}
-	if h.GetCreated() != 0 {
-		t.Errorf("SetCreated is %v, want 0", h.GetCreated())
-	}
-	if h.GetHost() != "" {
-		t.Errorf("SetHost is %v, want \"\"", h.GetHost())
-	}
-	if h.GetEvent() != "" {
-		t.Errorf("SetEvent is %v, want \"\"", h.GetEvent())
-	}
-	if h.GetBranch() != "" {
-		t.Errorf("SetBranch is %v, want \"\"", h.GetBranch())
-	}
-	if h.GetError() != "" {
-		t.Errorf("SetError is %v, want \"\"", h.GetError())
-	}
-	if h.GetStatus() != "" {
-		t.Errorf("SetStatus is %v, want \"\"", h.GetStatus())
-	}
-	if h.GetLink() != "" {
-		t.Errorf("SetLink is %v, want \"\"", h.GetLink())
+	// run tests
+	for _, test := range tests {
+		test.hook.SetID(test.want.GetID())
+		test.hook.SetRepoID(test.want.GetRepoID())
+		test.hook.SetBuildID(test.want.GetBuildID())
+		test.hook.SetNumber(test.want.GetNumber())
+		test.hook.SetSourceID(test.want.GetSourceID())
+		test.hook.SetCreated(test.want.GetCreated())
+		test.hook.SetHost(test.want.GetHost())
+		test.hook.SetEvent(test.want.GetEvent())
+		test.hook.SetBranch(test.want.GetBranch())
+		test.hook.SetError(test.want.GetError())
+		test.hook.SetStatus(test.want.GetStatus())
+		test.hook.SetLink(test.want.GetLink())
+
+		if test.hook.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.hook.GetID(), test.want.GetID())
+		}
+
+		if test.hook.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.hook.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.hook.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.hook.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.hook.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.hook.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.hook.GetSourceID() != test.want.GetSourceID() {
+			t.Errorf("SetSourceID is %v, want %v", test.hook.GetSourceID(), test.want.GetSourceID())
+		}
+
+		if test.hook.GetCreated() != test.want.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.hook.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.hook.GetHost() != test.want.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.hook.GetHost(), test.want.GetHost())
+		}
+
+		if test.hook.GetEvent() != test.want.GetEvent() {
+			t.Errorf("SetEvent is %v, want %v", test.hook.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.hook.GetBranch() != test.want.GetBranch() {
+			t.Errorf("SetBranch is %v, want %v", test.hook.GetBranch(), test.want.GetBranch())
+		}
+
+		if test.hook.GetError() != test.want.GetError() {
+			t.Errorf("SetError is %v, want %v", test.hook.GetError(), test.want.GetError())
+		}
+
+		if test.hook.GetStatus() != test.want.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.hook.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.hook.GetLink() != test.want.GetLink() {
+			t.Errorf("SetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
+		}
 	}
 }
 
 func TestLibrary_Hook_String(t *testing.T) {
 	// setup types
+	h := testHook()
+
+	want := fmt.Sprintf("%+v", *h)
+
+	// run test
+	got := h.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+// testHook is a test helper function to create a Hook
+// type with all fields set to a fake value.
+func testHook() *Hook {
 	h := new(Hook)
+
 	h.SetID(1)
 	h.SetRepoID(1)
 	h.SetBuildID(1)
@@ -290,12 +195,5 @@ func TestLibrary_Hook_String(t *testing.T) {
 	h.SetStatus("success")
 	h.SetLink("https://github.com/github/octocat/settings/hooks/1")
 
-	want := fmt.Sprintf("%+v", *h)
-
-	// run test
-	got := h.String()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("String is %v, want %v", got, want)
-	}
+	return h
 }

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -10,212 +10,140 @@ import (
 	"testing"
 )
 
-func TestLibrary_Log_Append(t *testing.T) {
+func TestLibrary_Log_AppendData(t *testing.T) {
 	// setup types
-	wantOne := new(Log)
-	wantOne.SetID(1)
-	wantOne.SetServiceID(1)
-	wantOne.SetStepID(1)
-	wantOne.SetBuildID(1)
-	wantOne.SetRepoID(1)
-	wantOne.SetData([]byte("bar"))
+	data := []byte("bar")
 
-	wantTwo := new(Log)
-	wantTwo.SetID(1)
-	wantTwo.SetServiceID(1)
-	wantTwo.SetStepID(1)
-	wantTwo.SetBuildID(1)
-	wantTwo.SetRepoID(1)
-	wantTwo.SetData([]byte("foobar"))
+	want := testLog()
+	want.SetData([]byte("foobar"))
 
-	gotOne := new(Log)
-	gotOne.SetID(1)
-	gotOne.SetServiceID(1)
-	gotOne.SetStepID(1)
-	gotOne.SetBuildID(1)
-	gotOne.SetRepoID(1)
-
-	gotTwo := new(Log)
-	gotTwo.SetID(1)
-	gotTwo.SetServiceID(1)
-	gotTwo.SetStepID(1)
-	gotTwo.SetBuildID(1)
-	gotTwo.SetRepoID(1)
-	gotTwo.SetData([]byte("foo"))
-
-	// run test
-	gotOne.AppendData([]byte("bar"))
-
-	gotTwo.AppendData([]byte("bar"))
-
-	if !reflect.DeepEqual(gotOne, wantOne) {
-		t.Errorf("Append is %v, want %v", gotOne, wantOne)
+	// setup tests
+	tests := []struct {
+		log  *Log
+		want *Log
+	}{
+		{
+			log:  testLog(),
+			want: want,
+		},
+		{
+			log:  new(Log),
+			want: &Log{Data: &data},
+		},
 	}
 
-	if !reflect.DeepEqual(gotTwo, wantTwo) {
-		t.Errorf("Append is %v, want %v", gotTwo, wantTwo)
+	// run tests
+	for _, test := range tests {
+		test.log.AppendData(data)
+
+		if !reflect.DeepEqual(test.log, test.want) {
+			t.Errorf("AppendData is %v, want %v", test.log, test.want)
+		}
 	}
 }
 
 func TestLibrary_Log_Getters(t *testing.T) {
-	// setup types
-	num64 := int64(1)
-	bytes := []byte("foo")
-	l := &Log{
-		ID:        &num64,
-		ServiceID: &num64,
-		StepID:    &num64,
-		BuildID:   &num64,
-		RepoID:    &num64,
-		Data:      &bytes,
+	// setup tests
+	tests := []struct {
+		log  *Log
+		want *Log
+	}{
+		{
+			log:  testLog(),
+			want: testLog(),
+		},
+		{
+			log:  new(Log),
+			want: new(Log),
+		},
 	}
-	wantID := num64
-	wantServiceID := num64
-	wantStepID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantData := bytes
 
-	// run test
-	gotID := l.GetID()
-	gotServiceID := l.GetServiceID()
-	gotStepID := l.GetStepID()
-	gotBuildID := l.GetBuildID()
-	gotRepoID := l.GetRepoID()
-	gotData := l.GetData()
+	// run tests
+	for _, test := range tests {
+		if test.log.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.log.GetID(), test.want.GetID())
+		}
 
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotServiceID != wantServiceID {
-		t.Errorf("GetServiceID is %v, want %v", gotServiceID, wantServiceID)
-	}
-	if gotStepID != wantStepID {
-		t.Errorf("GetStepID is %v, want %v", gotStepID, wantStepID)
-	}
-	if gotBuildID != wantBuildID {
-		t.Errorf("GetBuildID is %v, want %v", gotBuildID, wantBuildID)
-	}
-	if gotRepoID != wantRepoID {
-		t.Errorf("GetRepoID is %v, want %v", gotRepoID, wantRepoID)
-	}
-	if !reflect.DeepEqual(gotData, wantData) {
-		t.Errorf("GetData is %v, want %v", gotData, wantData)
-	}
-}
+		if test.log.GetServiceID() != test.want.GetServiceID() {
+			t.Errorf("GetServiceID is %v, want %v", test.log.GetServiceID(), test.want.GetServiceID())
+		}
 
-func TestLibrary_Log_Getters_Empty(t *testing.T) {
-	// setup types
-	l := new(Log)
+		if test.log.GetStepID() != test.want.GetStepID() {
+			t.Errorf("GetStepID is %v, want %v", test.log.GetStepID(), test.want.GetStepID())
+		}
 
-	// run test
-	gotID := l.GetID()
-	gotStepID := l.GetStepID()
-	gotBuildID := l.GetBuildID()
-	gotRepoID := l.GetRepoID()
-	gotData := l.GetData()
+		if test.log.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.log.GetBuildID(), test.want.GetBuildID())
+		}
 
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotStepID != 0 {
-		t.Errorf("GetStepID is %v, want 0", gotStepID)
-	}
-	if gotBuildID != 0 {
-		t.Errorf("GetBuildID is %v, want 0", gotBuildID)
-	}
-	if gotRepoID != 0 {
-		t.Errorf("GetRepoID is %v, want 0", gotRepoID)
-	}
-	if !reflect.DeepEqual(gotData, []byte{}) {
-		t.Errorf("GetData is %v, want []byte{}", gotData)
+		if test.log.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.log.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if !reflect.DeepEqual(test.log.GetData(), test.want.GetData()) {
+			t.Errorf("GetData is %v, want %v", test.log.GetData(), test.want.GetData())
+		}
 	}
 }
 
 func TestLibrary_Log_Setters(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	bytes := []byte("foo")
-	l := new(Log)
-
-	wantID := num64
-	wantServiceID := num64
-	wantStepID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantData := bytes
-
-	// run test
-	l.SetID(wantID)
-	l.SetServiceID(wantServiceID)
-	l.SetStepID(wantStepID)
-	l.SetBuildID(wantBuildID)
-	l.SetRepoID(wantRepoID)
-	l.SetData(wantData)
-
-	if l.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", l.GetID(), wantID)
-	}
-	if l.GetServiceID() != wantServiceID {
-		t.Errorf("SetServiceID is %v, want %v", l.GetServiceID(), wantServiceID)
-	}
-	if l.GetStepID() != wantStepID {
-		t.Errorf("SetStepID is %v, want %v", l.GetStepID(), wantStepID)
-	}
-	if l.GetBuildID() != wantBuildID {
-		t.Errorf("SetBuildID is %v, want %v", l.GetBuildID(), wantBuildID)
-	}
-	if l.GetRepoID() != wantRepoID {
-		t.Errorf("SetRepoID is %v, want %v", l.GetRepoID(), wantRepoID)
-	}
-	if !reflect.DeepEqual(l.GetData(), wantData) {
-		t.Errorf("SetData is %v, want %v", l.GetData(), wantData)
-	}
-}
-
-func TestLibrary_Log_Setters_Empty(t *testing.T) {
-	// setup types
 	var l *Log
 
-	// run test
-	l.SetID(0)
-	l.SetServiceID(0)
-	l.SetStepID(0)
-	l.SetBuildID(0)
-	l.SetRepoID(0)
-	l.SetData([]byte{})
+	// setup tests
+	tests := []struct {
+		log  *Log
+		want *Log
+	}{
+		{
+			log:  testLog(),
+			want: testLog(),
+		},
+		{
+			log:  l,
+			want: new(Log),
+		},
+	}
 
-	if l.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", l.GetID())
-	}
-	if l.GetServiceID() != 0 {
-		t.Errorf("SetServiceID is %v, want 0", l.GetServiceID())
-	}
-	if l.GetStepID() != 0 {
-		t.Errorf("SetStepID is %v, want 0", l.GetStepID())
-	}
-	if l.GetBuildID() != 0 {
-		t.Errorf("SetBuildID is %v, want 0", l.GetBuildID())
-	}
-	if l.GetRepoID() != 0 {
-		t.Errorf("SetRepoID is %v, want 0", l.GetRepoID())
-	}
-	if !reflect.DeepEqual(l.GetData(), []byte{}) {
-		t.Errorf("SetData is %v, want []byte{}", l.GetData())
+	// run tests
+	for _, test := range tests {
+		test.log.SetID(test.want.GetID())
+		test.log.SetServiceID(test.want.GetServiceID())
+		test.log.SetStepID(test.want.GetStepID())
+		test.log.SetBuildID(test.want.GetBuildID())
+		test.log.SetRepoID(test.want.GetRepoID())
+		test.log.SetData(test.want.GetData())
+
+		if test.log.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.log.GetID(), test.want.GetID())
+		}
+
+		if test.log.GetServiceID() != test.want.GetServiceID() {
+			t.Errorf("SetServiceID is %v, want %v", test.log.GetServiceID(), test.want.GetServiceID())
+		}
+
+		if test.log.GetStepID() != test.want.GetStepID() {
+			t.Errorf("SetStepID is %v, want %v", test.log.GetStepID(), test.want.GetStepID())
+		}
+
+		if test.log.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.log.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.log.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.log.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if !reflect.DeepEqual(test.log.GetData(), test.want.GetData()) {
+			t.Errorf("SetData is %v, want %v", test.log.GetData(), test.want.GetData())
+		}
 	}
 }
 
 func TestLibrary_Log_String(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	bytes := []byte("foo")
-	l := &Log{
-		ID:      &num64,
-		StepID:  &num64,
-		BuildID: &num64,
-		RepoID:  &num64,
-		Data:    &bytes,
-	}
+	l := testLog()
+
 	want := fmt.Sprintf("%+v", *l)
 
 	// run test
@@ -224,4 +152,19 @@ func TestLibrary_Log_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testLog is a test helper function to create a Log
+// type with all fields set to a fake value.
+func testLog() *Log {
+	l := new(Log)
+
+	l.SetID(1)
+	l.SetServiceID(1)
+	l.SetStepID(1)
+	l.SetBuildID(1)
+	l.SetRepoID(1)
+	l.SetData([]byte("foo"))
+
+	return l
 }

--- a/library/login_test.go
+++ b/library/login_test.go
@@ -21,125 +21,86 @@ import (
 )
 
 func TestLibrary_Login_Getters(t *testing.T) {
-	// setup types
-	str := "foo"
-	l := &Login{
-		Username: &str,
-		Password: &str,
-		OTP:      &str,
-		Token:    &str,
+	// setup tests
+	tests := []struct {
+		login *Login
+		want  *Login
+	}{
+		{
+			login: testLogin(),
+			want:  testLogin(),
+		},
+		{
+			login: new(Login),
+			want:  new(Login),
+		},
 	}
-	wantUsername := str
-	wantPassword := str
-	wantOTP := str
-	wantToken := str
 
-	// run test
-	gotUsername := l.GetUsername()
-	gotPassword := l.GetPassword()
-	gotOTP := l.GetOTP()
-	gotToken := l.GetToken()
+	// run tests
+	for _, test := range tests {
+		if test.login.GetUsername() != test.want.GetUsername() {
+			t.Errorf("GetUsername is %v, want %v", test.login.GetUsername(), test.want.GetUsername())
+		}
 
-	if gotUsername != wantUsername {
-		t.Errorf("GetUsername is %v, want %v", gotUsername, wantUsername)
-	}
-	if gotPassword != wantPassword {
-		t.Errorf("GetPassword is %v, want %v", gotPassword, wantPassword)
-	}
-	if gotOTP != wantOTP {
-		t.Errorf("GetOTP is %v, want %v", gotOTP, wantOTP)
-	}
-	if gotToken != wantToken {
-		t.Errorf("GetToken is %v, want %v", gotToken, wantToken)
-	}
-}
+		if test.login.GetPassword() != test.want.GetPassword() {
+			t.Errorf("GetPassword is %v, want %v", test.login.GetPassword(), test.want.GetPassword())
+		}
 
-func TestLibrary_Login_Getters_Empty(t *testing.T) {
-	// setup types
-	l := new(Login)
+		if test.login.GetOTP() != test.want.GetOTP() {
+			t.Errorf("GetOTP is %v, want %v", test.login.GetOTP(), test.want.GetOTP())
+		}
 
-	// run test
-	gotUsername := l.GetUsername()
-	gotPassword := l.GetPassword()
-	gotOTP := l.GetOTP()
-	gotToken := l.GetToken()
-
-	if gotUsername != "" {
-		t.Errorf("GetUsername is %v, want \"\"", gotUsername)
-	}
-	if gotPassword != "" {
-		t.Errorf("GetPassword is %v, want \"\"", gotPassword)
-	}
-	if gotOTP != "" {
-		t.Errorf("GetOTP is %v, want \"\"", gotOTP)
-	}
-	if gotToken != "" {
-		t.Errorf("GetToken is %v, want \"\"", gotToken)
+		if test.login.GetToken() != test.want.GetToken() {
+			t.Errorf("GetToken is %v, want %v", test.login.GetToken(), test.want.GetToken())
+		}
 	}
 }
 
 func TestLibrary_Login_Setters(t *testing.T) {
 	// setup types
-	str := "foo"
-	l := new(Login)
-	wantUsername := str
-	wantPassword := str
-	wantOTP := str
-	wantToken := str
-
-	// run test
-	l.SetUsername(wantUsername)
-	l.SetPassword(wantPassword)
-	l.SetOTP(wantOTP)
-	l.SetToken(wantToken)
-
-	if l.GetUsername() != wantUsername {
-		t.Errorf("SetUsername is %v, want %v", l.GetUsername(), wantUsername)
-	}
-	if l.GetPassword() != wantPassword {
-		t.Errorf("SetPassword is %v, want %v", l.GetPassword(), wantPassword)
-	}
-	if l.GetOTP() != wantOTP {
-		t.Errorf("SetOTP is %v, want %v", l.GetOTP(), wantOTP)
-	}
-	if l.GetToken() != wantToken {
-		t.Errorf("SetToken is %v, want %v", l.GetToken(), wantToken)
-	}
-}
-
-func TestLibrary_Login_Setters_Empty(t *testing.T) {
-	// setup types
 	var l *Login
 
-	// run test
-	l.SetUsername("")
-	l.SetPassword("")
-	l.SetOTP("")
-	l.SetToken("")
+	// setup tests
+	tests := []struct {
+		login *Login
+		want  *Login
+	}{
+		{
+			login: testLogin(),
+			want:  testLogin(),
+		},
+		{
+			login: l,
+			want:  new(Login),
+		},
+	}
 
-	if l.GetUsername() != "" {
-		t.Errorf("SetUsername is %v, want \"\"", l.GetUsername())
-	}
-	if l.GetPassword() != "" {
-		t.Errorf("SetPassword is %v, want \"\"", l.GetPassword())
-	}
-	if l.GetOTP() != "" {
-		t.Errorf("SetOTP is %v, want \"\"", l.GetOTP())
-	}
-	if l.GetToken() != "" {
-		t.Errorf("SetToken is %v, want \"\"", l.GetToken())
+	// run tests
+	for _, test := range tests {
+		test.login.SetUsername(test.want.GetUsername())
+		test.login.SetPassword(test.want.GetPassword())
+		test.login.SetOTP(test.want.GetOTP())
+		test.login.SetToken(test.want.GetToken())
+
+		if test.login.GetUsername() != test.want.GetUsername() {
+			t.Errorf("SetUsername is %v, want %v", test.login.GetUsername(), test.want.GetUsername())
+		}
+		if test.login.GetPassword() != test.want.GetPassword() {
+			t.Errorf("SetPassword is %v, want %v", test.login.GetPassword(), test.want.GetPassword())
+		}
+		if test.login.GetOTP() != test.want.GetOTP() {
+			t.Errorf("SetOTP is %v, want %v", test.login.GetOTP(), test.want.GetOTP())
+		}
+		if test.login.GetToken() != test.want.GetToken() {
+			t.Errorf("SetToken is %v, want %v", test.login.GetToken(), test.want.GetToken())
+		}
 	}
 }
 
 func TestLogin_String(t *testing.T) {
 	// setup types
-	str := "foo"
-	l := &Login{
-		Username: &str,
-		Password: &str,
-		OTP:      &str,
-		Token:    &str,
-	}
+	l := testLogin()
+
 	want := fmt.Sprintf("%+v", *l)
 
 	// run test
@@ -148,4 +109,17 @@ func TestLogin_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testLogin is a test helper function to create a Login
+// type with all fields set to a fake value.
+func testLogin() *Login {
+	l := new(Login)
+
+	l.SetUsername("octocat")
+	l.SetPassword("superSecretPassword")
+	l.SetOTP("123456")
+	l.SetToken("superSecretToken")
+
+	return l
 }

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -56,507 +56,224 @@ func TestLibrary_Repo_Environment(t *testing.T) {
 }
 
 func TestLibrary_Repo_Getters(t *testing.T) {
-	// setup types
-	booL := false
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	r := &Repo{
-		ID:           &num64,
-		UserID:       &num64,
-		Hash:         &str,
-		Org:          &str,
-		Name:         &str,
-		FullName:     &str,
-		Link:         &str,
-		Clone:        &str,
-		Branch:       &str,
-		Timeout:      &num64,
-		Visibility:   &str,
-		Private:      &booL,
-		Trusted:      &booL,
-		Active:       &booL,
-		AllowPull:    &booL,
-		AllowPush:    &booL,
-		AllowDeploy:  &booL,
-		AllowTag:     &booL,
-		AllowComment: &booL,
-	}
-	wantID := num64
-	wantUserID := num64
-	wantHash := str
-	wantOrg := str
-	wantName := str
-	wantFullName := str
-	wantLink := str
-	wantClone := str
-	wantBranch := str
-	wantTimeout := num64
-	wantVisibility := str
-	wantPrivate := booL
-	wantTrusted := booL
-	wantActive := booL
-	wantAllowPull := booL
-	wantAllowPush := booL
-	wantAllowDeploy := booL
-	wantAllowTag := booL
-	wantAllowComment := booL
-
-	// run test
-	gotID := r.GetID()
-	gotUserID := r.GetUserID()
-	gotHash := r.GetHash()
-	gotOrg := r.GetOrg()
-	gotName := r.GetName()
-	gotFullName := r.GetFullName()
-	gotLink := r.GetLink()
-	gotClone := r.GetClone()
-	gotBranch := r.GetBranch()
-	gotTimeout := r.GetTimeout()
-	gotVisibility := r.GetVisibility()
-	gotPrivate := r.GetPrivate()
-	gotTrusted := r.GetTrusted()
-	gotActive := r.GetActive()
-	gotAllowPull := r.GetAllowPull()
-	gotAllowPush := r.GetAllowPush()
-	gotAllowDeploy := r.GetAllowDeploy()
-	gotAllowTag := r.GetAllowTag()
-	gotAllowComment := r.GetAllowComment()
-
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
+	// setup tests
+	tests := []struct {
+		repo *Repo
+		want *Repo
+	}{
+		{
+			repo: testRepo(),
+			want: testRepo(),
+		},
+		{
+			repo: new(Repo),
+			want: new(Repo),
+		},
 	}
 
-	if gotUserID != wantUserID {
-		t.Errorf("GetUserID is %v, want %v", gotUserID, wantUserID)
-	}
+	// run tests
+	for _, test := range tests {
+		if test.repo.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.repo.GetID(), test.want.GetID())
+		}
 
-	if gotHash != wantHash {
-		t.Errorf("GetHash is %v, want %v", gotHash, wantHash)
-	}
+		if test.repo.GetUserID() != test.want.GetUserID() {
+			t.Errorf("GetUserID is %v, want %v", test.repo.GetUserID(), test.want.GetUserID())
+		}
 
-	if gotOrg != wantOrg {
-		t.Errorf("GetOrg is %v, want %v", gotOrg, wantOrg)
-	}
+		if test.repo.GetHash() != test.want.GetHash() {
+			t.Errorf("GetHash is %v, want %v", test.repo.GetHash(), test.want.GetHash())
+		}
 
-	if gotName != wantName {
-		t.Errorf("GetName is %v, want %v", gotName, wantName)
-	}
+		if test.repo.GetOrg() != test.want.GetOrg() {
+			t.Errorf("GetOrg is %v, want %v", test.repo.GetOrg(), test.want.GetOrg())
+		}
 
-	if gotFullName != wantFullName {
-		t.Errorf("GetFullName is %v, want %v", gotFullName, wantFullName)
-	}
+		if test.repo.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.repo.GetName(), test.want.GetName())
+		}
 
-	if gotLink != wantLink {
-		t.Errorf("GetLink is %v, want %v", gotLink, wantLink)
-	}
+		if test.repo.GetFullName() != test.want.GetFullName() {
+			t.Errorf("GetFullName is %v, want %v", test.repo.GetFullName(), test.want.GetFullName())
+		}
 
-	if gotClone != wantClone {
-		t.Errorf("GetClone is %v, want %v", gotClone, wantClone)
-	}
+		if test.repo.GetLink() != test.want.GetLink() {
+			t.Errorf("GetLink is %v, want %v", test.repo.GetLink(), test.want.GetLink())
+		}
 
-	if gotBranch != wantBranch {
-		t.Errorf("GetBranch is %v, want %v", gotBranch, wantBranch)
-	}
+		if test.repo.GetClone() != test.want.GetClone() {
+			t.Errorf("GetClone is %v, want %v", test.repo.GetClone(), test.want.GetClone())
+		}
 
-	if gotTimeout != wantTimeout {
-		t.Errorf("GetTimeout is %v, want %v", gotTimeout, wantTimeout)
-	}
+		if test.repo.GetBranch() != test.want.GetBranch() {
+			t.Errorf("GetBranch is %v, want %v", test.repo.GetBranch(), test.want.GetBranch())
+		}
 
-	if gotVisibility != wantVisibility {
-		t.Errorf("GetVisibility is %v, want %v", gotVisibility, wantVisibility)
-	}
+		if test.repo.GetTimeout() != test.want.GetTimeout() {
+			t.Errorf("GetTimeout is %v, want %v", test.repo.GetTimeout(), test.want.GetTimeout())
+		}
 
-	if gotPrivate != wantPrivate {
-		t.Errorf("GetPrivate is %v, want %v", gotPrivate, wantPrivate)
-	}
+		if test.repo.GetVisibility() != test.want.GetVisibility() {
+			t.Errorf("GetVisibility is %v, want %v", test.repo.GetVisibility(), test.want.GetVisibility())
+		}
 
-	if gotTrusted != wantTrusted {
-		t.Errorf("GetTrusted is %v, want %v", gotTrusted, wantTrusted)
-	}
+		if test.repo.GetPrivate() != test.want.GetPrivate() {
+			t.Errorf("GetPrivate is %v, want %v", test.repo.GetPrivate(), test.want.GetPrivate())
+		}
 
-	if gotActive != wantActive {
-		t.Errorf("GetActive is %v, want %v", gotActive, wantActive)
-	}
+		if test.repo.GetTrusted() != test.want.GetTrusted() {
+			t.Errorf("GetTrusted is %v, want %v", test.repo.GetTrusted(), test.want.GetTrusted())
+		}
 
-	if gotAllowPull != wantAllowPull {
-		t.Errorf("GetAllowPull is %v, want %v", gotAllowPull, wantAllowPull)
-	}
+		if test.repo.GetActive() != test.want.GetActive() {
+			t.Errorf("GetActive is %v, want %v", test.repo.GetActive(), test.want.GetActive())
+		}
 
-	if gotAllowPush != wantAllowPush {
-		t.Errorf("GetAllowPush is %v, want %v", gotAllowPush, wantAllowPush)
-	}
+		if test.repo.GetAllowPull() != test.want.GetAllowPull() {
+			t.Errorf("GetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
+		}
 
-	if gotAllowDeploy != wantAllowDeploy {
-		t.Errorf("GetAllowDeploy is %v, want %v", gotAllowDeploy, wantAllowDeploy)
-	}
+		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
+			t.Errorf("GetAllowPush is %v, want %v", test.repo.GetAllowPush(), test.want.GetAllowPush())
+		}
 
-	if gotAllowTag != wantAllowTag {
-		t.Errorf("GetAllowTag is %v, want %v", gotAllowTag, wantAllowTag)
-	}
+		if test.repo.GetAllowDeploy() != test.want.GetAllowDeploy() {
+			t.Errorf("GetAllowDeploy is %v, want %v", test.repo.GetAllowDeploy(), test.want.GetAllowDeploy())
+		}
 
-	if gotAllowComment != wantAllowComment {
-		t.Errorf("gotAllowComment is %v, want %v", gotAllowComment, wantAllowComment)
-	}
-}
+		if test.repo.GetAllowTag() != test.want.GetAllowTag() {
+			t.Errorf("GetAllowTag is %v, want %v", test.repo.GetAllowTag(), test.want.GetAllowTag())
+		}
 
-func TestLibrary_Repo_Getters_Empty(t *testing.T) {
-	// setup types
-	r := new(Repo)
-
-	// run test
-	gotID := r.GetID()
-	gotUserID := r.GetUserID()
-	gotHash := r.GetHash()
-	gotOrg := r.GetOrg()
-	gotName := r.GetName()
-	gotFullName := r.GetFullName()
-	gotLink := r.GetLink()
-	gotClone := r.GetClone()
-	gotBranch := r.GetBranch()
-	gotTimeout := r.GetTimeout()
-	gotVisibility := r.GetVisibility()
-	gotPrivate := r.GetPrivate()
-	gotTrusted := r.GetTrusted()
-	gotActive := r.GetActive()
-	gotAllowPull := r.GetAllowPull()
-	gotAllowPush := r.GetAllowPush()
-	gotAllowDeploy := r.GetAllowDeploy()
-	gotAllowTag := r.GetAllowTag()
-	gotAllowComment := r.GetAllowComment()
-
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-
-	if gotUserID != 0 {
-		t.Errorf("GetUserID is %v, want 0", gotUserID)
-	}
-
-	if gotHash != "" {
-		t.Errorf("GetHash is %v, want \"\"", gotHash)
-	}
-
-	if gotOrg != "" {
-		t.Errorf("GetOrg is %v, want \"\"", gotOrg)
-	}
-
-	if gotName != "" {
-		t.Errorf("GetName is %v, want \"\"", gotName)
-	}
-
-	if gotFullName != "" {
-		t.Errorf("GetFullName is %v, want \"\"", gotFullName)
-	}
-
-	if gotLink != "" {
-		t.Errorf("GetLink is %v, want \"\"", gotLink)
-	}
-
-	if gotClone != "" {
-		t.Errorf("GetClone is %v, want \"\"", gotClone)
-	}
-
-	if gotBranch != "" {
-		t.Errorf("GetBranch is %v, want \"\"", gotBranch)
-	}
-
-	if gotTimeout != 0 {
-		t.Errorf("GetTimeout is %v, want 0", gotTimeout)
-	}
-
-	if gotVisibility != "" {
-		t.Errorf("GetVisibility is %v, want \"\"", gotVisibility)
-	}
-
-	if gotPrivate != false {
-		t.Errorf("GetPrivate is %v, want false", gotPrivate)
-	}
-
-	if gotTrusted != false {
-		t.Errorf("GetTrusted is %v, want false", gotTrusted)
-	}
-
-	if gotActive != false {
-		t.Errorf("GetActive is %v, want false", gotActive)
-	}
-
-	if gotAllowPull != false {
-		t.Errorf("GetAllowPull is %v, want false", gotAllowPull)
-	}
-
-	if gotAllowPush != false {
-		t.Errorf("GetAllowPush is %v, want false", gotAllowPush)
-	}
-
-	if gotAllowDeploy != false {
-		t.Errorf("GetAllowDeploy is %v, want false", gotAllowDeploy)
-	}
-
-	if gotAllowTag != false {
-		t.Errorf("GetAllowTag is %v, want false", gotAllowTag)
-	}
-
-	if gotAllowComment != false {
-		t.Errorf("GetAllowComment is %v, want false", gotAllowComment)
+		if test.repo.GetAllowComment() != test.want.GetAllowComment() {
+			t.Errorf("GetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
+		}
 	}
 }
 
 func TestLibrary_Repo_Setters(t *testing.T) {
 	// setup types
-	booL := false
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	r := new(Repo)
-
-	wantID := num64
-	wantUserID := num64
-	wantHash := str
-	wantOrg := str
-	wantName := str
-	wantFullName := str
-	wantLink := str
-	wantClone := str
-	wantBranch := str
-	wantTimeout := num64
-	wantVisibility := str
-	wantPrivate := booL
-	wantTrusted := booL
-	wantActive := booL
-	wantAllowPull := booL
-	wantAllowPush := booL
-	wantAllowDeploy := booL
-	wantAllowTag := booL
-	wantAllowComment := booL
-
-	// run test
-	r.SetID(wantID)
-	r.SetUserID(wantUserID)
-	r.SetHash(wantHash)
-	r.SetOrg(wantOrg)
-	r.SetName(wantName)
-	r.SetFullName(wantFullName)
-	r.SetLink(wantLink)
-	r.SetClone(wantClone)
-	r.SetBranch(wantBranch)
-	r.SetTimeout(wantTimeout)
-	r.SetVisibility(wantVisibility)
-	r.SetPrivate(wantPrivate)
-	r.SetTrusted(wantTrusted)
-	r.SetActive(wantActive)
-	r.SetAllowPull(wantAllowPull)
-	r.SetAllowPush(wantAllowPush)
-	r.SetAllowDeploy(wantAllowDeploy)
-	r.SetAllowTag(wantAllowTag)
-	r.SetAllowComment(wantAllowComment)
-
-	if r.GetID() != wantID {
-		t.Errorf("GetID is %v, want %v", r.GetID(), wantID)
-	}
-
-	if r.GetUserID() != wantUserID {
-		t.Errorf("GetUserID is %v, want %v", r.GetUserID(), wantUserID)
-	}
-
-	if r.GetHash() != wantHash {
-		t.Errorf("GetHash is %v, want %v", r.GetHash(), wantHash)
-	}
-
-	if r.GetOrg() != wantOrg {
-		t.Errorf("GetOrg is %v, want %v", r.GetOrg(), wantOrg)
-	}
-
-	if r.GetName() != wantName {
-		t.Errorf("GetName is %v, want %v", r.GetName(), wantName)
-	}
-
-	if r.GetFullName() != wantFullName {
-		t.Errorf("GetFullName is %v, want %v", r.GetFullName(), wantFullName)
-	}
-
-	if r.GetLink() != wantLink {
-		t.Errorf("GetLink is %v, want %v", r.GetLink(), wantLink)
-	}
-
-	if r.GetClone() != wantClone {
-		t.Errorf("GetClone is %v, want %v", r.GetClone(), wantClone)
-	}
-
-	if r.GetBranch() != wantBranch {
-		t.Errorf("GetBranch is %v, want %v", r.GetBranch(), wantBranch)
-	}
-
-	if r.GetTimeout() != wantTimeout {
-		t.Errorf("GetTimeout is %v, want %v", r.GetTimeout(), wantTimeout)
-	}
-
-	if r.GetVisibility() != wantVisibility {
-		t.Errorf("GetVisibility is %v, want %v", r.GetVisibility(), wantVisibility)
-	}
-
-	if r.GetPrivate() != wantPrivate {
-		t.Errorf("GetPrivate is %v, want %v", r.GetPrivate(), wantPrivate)
-	}
-
-	if r.GetTrusted() != wantTrusted {
-		t.Errorf("GetTrusted is %v, want %v", r.GetTrusted(), wantTrusted)
-	}
-
-	if r.GetActive() != wantActive {
-		t.Errorf("GetActive is %v, want %v", r.GetActive(), wantActive)
-	}
-
-	if r.GetAllowPull() != wantAllowPull {
-		t.Errorf("GetAllowPull is %v, want %v", r.GetAllowPull(), wantAllowPull)
-	}
-
-	if r.GetAllowPush() != wantAllowPush {
-		t.Errorf("GetAllowPush is %v, want %v", r.GetAllowPush(), wantAllowPush)
-	}
-
-	if r.GetAllowDeploy() != wantAllowDeploy {
-		t.Errorf("GetAllowDeploy is %v, want %v", r.GetAllowDeploy(), wantAllowDeploy)
-	}
-
-	if r.GetAllowTag() != wantAllowTag {
-		t.Errorf("GetAllowTag is %v, want %v", r.GetAllowTag(), wantAllowTag)
-	}
-
-	if r.GetAllowComment() != wantAllowComment {
-		t.Errorf("GetAllowComment is %v, want %v", r.GetAllowComment(), wantAllowComment)
-	}
-}
-
-func TestLibrary_Repo_Setters_Empty(t *testing.T) {
-	// setup types
 	var r *Repo
 
-	// run test
-	r.SetID(0)
-	r.SetUserID(0)
-	r.SetHash("")
-	r.SetOrg("")
-	r.SetName("")
-	r.SetFullName("")
-	r.SetLink("")
-	r.SetClone("")
-	r.SetBranch("")
-	r.SetTimeout(0)
-	r.SetVisibility("")
-	r.SetPrivate(false)
-	r.SetTrusted(false)
-	r.SetActive(false)
-	r.SetAllowPull(false)
-	r.SetAllowPush(false)
-	r.SetAllowDeploy(false)
-	r.SetAllowTag(false)
-	r.SetAllowComment(false)
-
-	if r.GetID() != 0 {
-		t.Errorf("GetID is %v, want 0", r.GetID())
+	// setup tests
+	tests := []struct {
+		repo *Repo
+		want *Repo
+	}{
+		{
+			repo: testRepo(),
+			want: testRepo(),
+		},
+		{
+			repo: r,
+			want: new(Repo),
+		},
 	}
 
-	if r.GetUserID() != 0 {
-		t.Errorf("GetUserID is %v, want 0", r.GetUserID())
-	}
+	// run tests
+	for _, test := range tests {
+		test.repo.SetID(test.want.GetID())
+		test.repo.SetUserID(test.want.GetUserID())
+		test.repo.SetHash(test.want.GetHash())
+		test.repo.SetOrg(test.want.GetOrg())
+		test.repo.SetName(test.want.GetName())
+		test.repo.SetFullName(test.want.GetFullName())
+		test.repo.SetLink(test.want.GetLink())
+		test.repo.SetClone(test.want.GetClone())
+		test.repo.SetBranch(test.want.GetBranch())
+		test.repo.SetTimeout(test.want.GetTimeout())
+		test.repo.SetVisibility(test.want.GetVisibility())
+		test.repo.SetPrivate(test.want.GetPrivate())
+		test.repo.SetTrusted(test.want.GetTrusted())
+		test.repo.SetActive(test.want.GetActive())
+		test.repo.SetAllowPull(test.want.GetAllowPull())
+		test.repo.SetAllowPush(test.want.GetAllowPush())
+		test.repo.SetAllowDeploy(test.want.GetAllowDeploy())
+		test.repo.SetAllowTag(test.want.GetAllowTag())
+		test.repo.SetAllowComment(test.want.GetAllowComment())
 
-	if r.GetHash() != "" {
-		t.Errorf("GetHash is %v, want \"\"", r.GetHash())
-	}
+		if test.repo.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.repo.GetID(), test.want.GetID())
+		}
 
-	if r.GetOrg() != "" {
-		t.Errorf("GetOrg is %v, want \"\"", r.GetOrg())
-	}
+		if test.repo.GetUserID() != test.want.GetUserID() {
+			t.Errorf("SetUserID is %v, want %v", test.repo.GetUserID(), test.want.GetUserID())
+		}
 
-	if r.GetName() != "" {
-		t.Errorf("GetName is %v, want \"\"", r.GetName())
-	}
+		if test.repo.GetHash() != test.want.GetHash() {
+			t.Errorf("SetHash is %v, want %v", test.repo.GetHash(), test.want.GetHash())
+		}
 
-	if r.GetFullName() != "" {
-		t.Errorf("GetFullName is %v, want \"\"", r.GetFullName())
-	}
+		if test.repo.GetOrg() != test.want.GetOrg() {
+			t.Errorf("SetOrg is %v, want %v", test.repo.GetOrg(), test.want.GetOrg())
+		}
 
-	if r.GetLink() != "" {
-		t.Errorf("GetLink is %v, want \"\"", r.GetLink())
-	}
+		if test.repo.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.repo.GetName(), test.want.GetName())
+		}
 
-	if r.GetClone() != "" {
-		t.Errorf("GetClone is %v, want \"\"", r.GetClone())
-	}
+		if test.repo.GetFullName() != test.want.GetFullName() {
+			t.Errorf("SetFullName is %v, want %v", test.repo.GetFullName(), test.want.GetFullName())
+		}
 
-	if r.GetBranch() != "" {
-		t.Errorf("GetBranch is %v, want \"\"", r.GetBranch())
-	}
+		if test.repo.GetLink() != test.want.GetLink() {
+			t.Errorf("SetLink is %v, want %v", test.repo.GetLink(), test.want.GetLink())
+		}
 
-	if r.GetTimeout() != 0 {
-		t.Errorf("GetTimeout is %v, want 0", r.GetTimeout())
-	}
+		if test.repo.GetClone() != test.want.GetClone() {
+			t.Errorf("SetClone is %v, want %v", test.repo.GetClone(), test.want.GetClone())
+		}
 
-	if r.GetVisibility() != "" {
-		t.Errorf("GetVisibility is %v, want \"\"", r.GetVisibility())
-	}
+		if test.repo.GetBranch() != test.want.GetBranch() {
+			t.Errorf("SetBranch is %v, want %v", test.repo.GetBranch(), test.want.GetBranch())
+		}
 
-	if r.GetPrivate() != false {
-		t.Errorf("GetPrivate is %v, want false", r.GetPrivate())
-	}
+		if test.repo.GetTimeout() != test.want.GetTimeout() {
+			t.Errorf("SetTimeout is %v, want %v", test.repo.GetTimeout(), test.want.GetTimeout())
+		}
 
-	if r.GetTrusted() != false {
-		t.Errorf("GetTrusted is %v, want false", r.GetTrusted())
-	}
+		if test.repo.GetVisibility() != test.want.GetVisibility() {
+			t.Errorf("SetVisibility is %v, want %v", test.repo.GetVisibility(), test.want.GetVisibility())
+		}
 
-	if r.GetActive() != false {
-		t.Errorf("GetActive is %v, want false", r.GetActive())
-	}
+		if test.repo.GetPrivate() != test.want.GetPrivate() {
+			t.Errorf("SetPrivate is %v, want %v", test.repo.GetPrivate(), test.want.GetPrivate())
+		}
 
-	if r.GetAllowPull() != false {
-		t.Errorf("GetAllowPull is %v, want false", r.GetAllowPull())
-	}
+		if test.repo.GetTrusted() != test.want.GetTrusted() {
+			t.Errorf("SetTrusted is %v, want %v", test.repo.GetTrusted(), test.want.GetTrusted())
+		}
 
-	if r.GetAllowPush() != false {
-		t.Errorf("GetAllowPush is %v, want false", r.GetAllowPush())
-	}
+		if test.repo.GetActive() != test.want.GetActive() {
+			t.Errorf("SetActive is %v, want %v", test.repo.GetActive(), test.want.GetActive())
+		}
 
-	if r.GetAllowDeploy() != false {
-		t.Errorf("GetAllowDeploy is %v, want false", r.GetAllowDeploy())
-	}
+		if test.repo.GetAllowPull() != test.want.GetAllowPull() {
+			t.Errorf("SetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
+		}
 
-	if r.GetAllowTag() != false {
-		t.Errorf("GetAllowTag is %v, want false", r.GetAllowTag())
-	}
+		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
+			t.Errorf("SetAllowPush is %v, want %v", test.repo.GetAllowPush(), test.want.GetAllowPush())
+		}
 
-	if r.GetAllowComment() != false {
-		t.Errorf("GetAllowComment is %v, want false", r.GetAllowComment())
+		if test.repo.GetAllowDeploy() != test.want.GetAllowDeploy() {
+			t.Errorf("SetAllowDeploy is %v, want %v", test.repo.GetAllowDeploy(), test.want.GetAllowDeploy())
+		}
+
+		if test.repo.GetAllowTag() != test.want.GetAllowTag() {
+			t.Errorf("SetAllowTag is %v, want %v", test.repo.GetAllowTag(), test.want.GetAllowTag())
+		}
+
+		if test.repo.GetAllowComment() != test.want.GetAllowComment() {
+			t.Errorf("SetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
+		}
 	}
 }
 
 func TestLibrary_Repo_String(t *testing.T) {
 	// setup types
-	booL := false
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	r := &Repo{
-		ID:           &num64,
-		UserID:       &num64,
-		Hash:         &str,
-		Org:          &str,
-		Name:         &str,
-		FullName:     &str,
-		Link:         &str,
-		Clone:        &str,
-		Branch:       &str,
-		Timeout:      &num64,
-		Visibility:   &str,
-		Private:      &booL,
-		Trusted:      &booL,
-		Active:       &booL,
-		AllowPull:    &booL,
-		AllowPush:    &booL,
-		AllowDeploy:  &booL,
-		AllowTag:     &booL,
-		AllowComment: &booL,
-	}
+	r := testRepo()
+
 	want := fmt.Sprintf("%+v", *r)
 
 	// run test

--- a/library/secret_test.go
+++ b/library/secret_test.go
@@ -15,37 +15,10 @@ import (
 
 func TestLibrary_Secret_Sanitize(t *testing.T) {
 	// setup types
-	one := int64(1)
-	foo := "foo"
-	bar := "bar"
-	repo := "repo"
-	images := []string{"foo"}
-	events := []string{"bar"}
-	cmd := true
-	value := constants.SecretMask
-	s := &Secret{
-		ID:           &one,
-		Org:          &foo,
-		Repo:         &bar,
-		Name:         &foo,
-		Value:        &bar,
-		Type:         &repo,
-		Images:       &images,
-		Events:       &events,
-		AllowCommand: &cmd,
-	}
+	s := testSecret()
 
-	want := &Secret{
-		ID:           &one,
-		Org:          &foo,
-		Repo:         &bar,
-		Name:         &foo,
-		Value:        &value,
-		Type:         &repo,
-		Images:       &images,
-		Events:       &events,
-		AllowCommand: &cmd,
-	}
+	want := testSecret()
+	want.SetValue(constants.SecretMask)
 
 	// run test
 	got := s.Sanitize()
@@ -56,12 +29,11 @@ func TestLibrary_Secret_Sanitize(t *testing.T) {
 }
 
 func TestLibrary_Secret_Match(t *testing.T) {
-
-	// name and value of secret
+	// setup types
 	v := "foo"
 	booL := false
 
-	// setup types
+	// setup tests
 	tests := []struct {
 		step *pipeline.Container
 		sec  *Secret
@@ -227,268 +199,136 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		},
 	}
 
-	// run test
+	// run tests
 	for _, test := range tests {
+		got := test.sec.Match(test.step)
 
-		inject := test.sec.Match(test.step)
-
-		if !inject == test.want {
-			t.Errorf("Match should have been %v", inject)
+		if got != test.want {
+			t.Errorf("Match is %v, want %v", got, test.want)
 		}
 	}
 }
 
 func TestLibrary_Secret_Getters(t *testing.T) {
-	// setup types
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	booL := true
-	s := &Secret{
-		ID:           &num64,
-		Org:          &str,
-		Repo:         &str,
-		Team:         &str,
-		Name:         &str,
-		Value:        &str,
-		Type:         &str,
-		Images:       &arr,
-		Events:       &arr,
-		AllowCommand: &booL,
+	// setup tests
+	tests := []struct {
+		secret *Secret
+		want   *Secret
+	}{
+		{
+			secret: testSecret(),
+			want:   testSecret(),
+		},
+		{
+			secret: new(Secret),
+			want:   new(Secret),
+		},
 	}
-	wantID := num64
-	wantOrg := str
-	wantRepo := str
-	wantTeam := str
-	wantName := str
-	wantValue := str
-	wantType := str
-	wantImages := arr
-	wantEvents := arr
-	wantAllowCommand := booL
 
-	// run test
-	gotID := s.GetID()
-	gotOrg := s.GetOrg()
-	gotRepo := s.GetRepo()
-	gotTeam := s.GetTeam()
-	gotName := s.GetName()
-	gotValue := s.GetValue()
-	gotType := s.GetType()
-	gotImages := s.GetImages()
-	gotEvents := s.GetEvents()
-	gotAllowCommand := s.GetAllowCommand()
-
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotOrg != wantOrg {
-		t.Errorf("GetOrg is %v, want %v", gotOrg, wantOrg)
-	}
-	if gotRepo != wantRepo {
-		t.Errorf("GetRepo is %v, want %v", gotRepo, wantRepo)
-	}
-	if gotTeam != wantTeam {
-		t.Errorf("GetTeam is %v, want %v", gotTeam, wantTeam)
-	}
-	if gotName != wantName {
-		t.Errorf("GetName is %v, want %v", gotName, wantName)
-	}
-	if gotValue != wantValue {
-		t.Errorf("GetValue is %v, want %v", gotValue, wantValue)
-	}
-	if gotType != wantType {
-		t.Errorf("GetType is %v, want %v", gotType, wantType)
-	}
-	if !reflect.DeepEqual(gotImages, wantImages) {
-		t.Errorf("GetImages is %v, want %v", gotImages, wantImages)
-	}
-	if !reflect.DeepEqual(gotEvents, wantEvents) {
-		t.Errorf("GetEvents is %v, want %v", gotEvents, wantEvents)
-	}
-	if gotAllowCommand != wantAllowCommand {
-		t.Errorf("GetAllowCommand is %v, want %v", gotAllowCommand, wantAllowCommand)
-	}
-}
-
-func TestLibrary_Secret_Getters_Empty(t *testing.T) {
-	// setup types
-	s := new(Secret)
-
-	// run test
-	gotID := s.GetID()
-	gotOrg := s.GetOrg()
-	gotRepo := s.GetRepo()
-	gotTeam := s.GetTeam()
-	gotName := s.GetName()
-	gotValue := s.GetValue()
-	gotType := s.GetType()
-	gotImages := s.GetImages()
-	gotEvents := s.GetEvents()
-	gotAllowCommand := s.GetAllowCommand()
-
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotOrg != "" {
-		t.Errorf("GetOrg is %v, want \"\"", gotOrg)
-	}
-	if gotRepo != "" {
-		t.Errorf("GetRepo is %v, want \"\"", gotRepo)
-	}
-	if gotTeam != "" {
-		t.Errorf("GetTeam is %v, want \"\"", gotTeam)
-	}
-	if gotName != "" {
-		t.Errorf("GetName is %v, want \"\"", gotName)
-	}
-	if gotValue != "" {
-		t.Errorf("GetValue is %v, want \"\"", gotValue)
-	}
-	if gotType != "" {
-		t.Errorf("GetType is %v, want \"\"", gotType)
-	}
-	if !reflect.DeepEqual(gotImages, []string{}) {
-		t.Errorf("GetImages is %v, want []string{}", gotImages)
-	}
-	if !reflect.DeepEqual(gotEvents, []string{}) {
-		t.Errorf("GetEvents is %v, want []string{}", gotEvents)
-	}
-	if gotAllowCommand != false {
-		t.Errorf("GetAllowCommand is %v, want false", gotAllowCommand)
+	// run tests
+	for _, test := range tests {
+		if test.secret.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.secret.GetID(), test.want.GetID())
+		}
+		if test.secret.GetOrg() != test.want.GetOrg() {
+			t.Errorf("GetOrg is %v, want %v", test.secret.GetOrg(), test.want.GetOrg())
+		}
+		if test.secret.GetRepo() != test.want.GetRepo() {
+			t.Errorf("GetRepo is %v, want %v", test.secret.GetRepo(), test.want.GetRepo())
+		}
+		if test.secret.GetTeam() != test.want.GetTeam() {
+			t.Errorf("GetTeam is %v, want %v", test.secret.GetTeam(), test.want.GetTeam())
+		}
+		if test.secret.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.secret.GetName(), test.want.GetName())
+		}
+		if test.secret.GetValue() != test.want.GetValue() {
+			t.Errorf("GetValue is %v, want %v", test.secret.GetValue(), test.want.GetValue())
+		}
+		if test.secret.GetType() != test.want.GetType() {
+			t.Errorf("GetType is %v, want %v", test.secret.GetType(), test.want.GetType())
+		}
+		if !reflect.DeepEqual(test.secret.GetImages(), test.want.GetImages()) {
+			t.Errorf("GetImages is %v, want %v", test.secret.GetImages(), test.want.GetImages())
+		}
+		if !reflect.DeepEqual(test.secret.GetEvents(), test.want.GetEvents()) {
+			t.Errorf("GetEvents is %v, want %v", test.secret.GetEvents(), test.want.GetEvents())
+		}
+		if test.secret.GetAllowCommand() != test.want.GetAllowCommand() {
+			t.Errorf("GetAllowCommand is %v, want %v", test.secret.GetAllowCommand(), test.want.GetAllowCommand())
+		}
 	}
 }
 
 func TestLibrary_Secret_Setters(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	booL := true
-
-	s := new(Secret)
-
-	wantID := num64
-	wantOrg := str
-	wantRepo := str
-	wantTeam := str
-	wantName := str
-	wantValue := str
-	wantType := str
-	wantImages := arr
-	wantEvents := arr
-	wantAllowCommand := booL
-
-	// run test
-	s.SetID(wantID)
-	s.SetOrg(wantOrg)
-	s.SetRepo(wantRepo)
-	s.SetTeam(wantTeam)
-	s.SetName(wantName)
-	s.SetValue(wantValue)
-	s.SetType(wantType)
-	s.SetImages(wantImages)
-	s.SetEvents(wantEvents)
-	s.SetAllowCommand(wantAllowCommand)
-
-	if s.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", s.GetID(), wantID)
-	}
-	if s.GetOrg() != wantOrg {
-		t.Errorf("SetOrg is %v, want %v", s.GetOrg(), wantOrg)
-	}
-	if s.GetRepo() != wantRepo {
-		t.Errorf("SetRepo is %v, want %v", s.GetRepo(), wantRepo)
-	}
-	if s.GetTeam() != wantTeam {
-		t.Errorf("SetTeam is %v, want %v", s.GetTeam(), wantTeam)
-	}
-	if s.GetName() != wantName {
-		t.Errorf("SetName is %v, want %v", s.GetName(), wantName)
-	}
-	if s.GetValue() != wantValue {
-		t.Errorf("SetValue is %v, want %v", s.GetValue(), wantValue)
-	}
-	if s.GetType() != wantType {
-		t.Errorf("SetType is %v, want %v", s.GetType(), wantType)
-	}
-	if !reflect.DeepEqual(s.GetImages(), wantImages) {
-		t.Errorf("SetImages is %v, want %v", s.GetImages(), wantImages)
-	}
-	if !reflect.DeepEqual(s.GetEvents(), wantEvents) {
-		t.Errorf("SetEvents is %v, want %v", s.GetEvents(), wantEvents)
-	}
-	if s.GetAllowCommand() != wantAllowCommand {
-		t.Errorf("SetAllowCommand is %v, want %v", s.GetAllowCommand(), wantAllowCommand)
-	}
-}
-
-func TestLibrary_Secret_Setters_Empty(t *testing.T) {
-	// setup types
 	var s *Secret
 
-	// run test
-	s.SetID(0)
-	s.SetOrg("")
-	s.SetRepo("")
-	s.SetTeam("")
-	s.SetName("")
-	s.SetValue("")
-	s.SetType("")
-	s.SetImages([]string{})
-	s.SetEvents([]string{})
-	s.SetAllowCommand(false)
+	// setup tests
+	tests := []struct {
+		secret *Secret
+		want   *Secret
+	}{
+		{
+			secret: testSecret(),
+			want:   testSecret(),
+		},
+		{
+			secret: s,
+			want:   new(Secret),
+		},
+	}
 
-	if s.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", s.GetID())
-	}
-	if s.GetOrg() != "" {
-		t.Errorf("SetOrg is %v, want \"\"", s.GetOrg())
-	}
-	if s.GetRepo() != "" {
-		t.Errorf("SetRepo is %v, want \"\"", s.GetRepo())
-	}
-	if s.GetTeam() != "" {
-		t.Errorf("SetTeam is %v, want \"\"", s.GetTeam())
-	}
-	if s.GetName() != "" {
-		t.Errorf("SetName is %v, want \"\"", s.GetName())
-	}
-	if s.GetValue() != "" {
-		t.Errorf("SetValue is %v, want \"\"", s.GetValue())
-	}
-	if s.GetType() != "" {
-		t.Errorf("SetType is %v, want \"\"", s.GetType())
-	}
-	if !reflect.DeepEqual(s.GetImages(), []string{}) {
-		t.Errorf("SetImages is %v, want []string{}", s.GetImages())
-	}
-	if !reflect.DeepEqual(s.GetEvents(), []string{}) {
-		t.Errorf("SetEvents is %v, want []string{}", s.GetEvents())
-	}
-	if s.GetAllowCommand() != false {
-		t.Errorf("SetAllowCommand is %v, want false", s.GetAllowCommand())
+	// run tests
+	for _, test := range tests {
+		test.secret.SetID(test.want.GetID())
+		test.secret.SetOrg(test.want.GetOrg())
+		test.secret.SetRepo(test.want.GetRepo())
+		test.secret.SetTeam(test.want.GetTeam())
+		test.secret.SetName(test.want.GetName())
+		test.secret.SetValue(test.want.GetValue())
+		test.secret.SetType(test.want.GetType())
+		test.secret.SetImages(test.want.GetImages())
+		test.secret.SetEvents(test.want.GetEvents())
+		test.secret.SetAllowCommand(test.want.GetAllowCommand())
+
+		if test.secret.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.secret.GetID(), test.want.GetID())
+		}
+		if test.secret.GetOrg() != test.want.GetOrg() {
+			t.Errorf("SetOrg is %v, want %v", test.secret.GetOrg(), test.want.GetOrg())
+		}
+		if test.secret.GetRepo() != test.want.GetRepo() {
+			t.Errorf("SetRepo is %v, want %v", test.secret.GetRepo(), test.want.GetRepo())
+		}
+		if test.secret.GetTeam() != test.want.GetTeam() {
+			t.Errorf("SetTeam is %v, want %v", test.secret.GetTeam(), test.want.GetTeam())
+		}
+		if test.secret.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.secret.GetName(), test.want.GetName())
+		}
+		if test.secret.GetValue() != test.want.GetValue() {
+			t.Errorf("SetValue is %v, want %v", test.secret.GetValue(), test.want.GetValue())
+		}
+		if test.secret.GetType() != test.want.GetType() {
+			t.Errorf("SetType is %v, want %v", test.secret.GetType(), test.want.GetType())
+		}
+		if !reflect.DeepEqual(test.secret.GetImages(), test.want.GetImages()) {
+			t.Errorf("SetImages is %v, want %v", test.secret.GetImages(), test.want.GetImages())
+		}
+		if !reflect.DeepEqual(test.secret.GetEvents(), test.want.GetEvents()) {
+			t.Errorf("SetEvents is %v, want %v", test.secret.GetEvents(), test.want.GetEvents())
+		}
+		if test.secret.GetAllowCommand() != test.want.GetAllowCommand() {
+			t.Errorf("SetAllowCommand is %v, want %v", test.secret.GetAllowCommand(), test.want.GetAllowCommand())
+		}
 	}
 }
 
 func TestLibrary_Secret_String(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	booL := true
-	s := &Secret{
-		ID:           &num64,
-		Org:          &str,
-		Repo:         &str,
-		Team:         &str,
-		Name:         &str,
-		Value:        &str,
-		Type:         &str,
-		Images:       &arr,
-		Events:       &arr,
-		AllowCommand: &booL,
-	}
+	s := testSecret()
+
 	want := fmt.Sprintf("%+v", *s)
 
 	// run test
@@ -497,4 +337,23 @@ func TestLibrary_Secret_String(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("String is %v, want %v", got, want)
 	}
+}
+
+// testSecret is a test helper function to create a Secret
+// type with all fields set to a fake value.
+func testSecret() *Secret {
+	s := new(Secret)
+
+	s.SetID(1)
+	s.SetOrg("github")
+	s.SetRepo("octocat")
+	s.SetTeam("octokitties")
+	s.SetName("foo")
+	s.SetValue("bar")
+	s.SetType("repo")
+	s.SetImages([]string{"alpine"})
+	s.SetEvents([]string{"push", "tag", "deployment"})
+	s.SetAllowCommand(true)
+
+	return s
 }

--- a/library/service_test.go
+++ b/library/service_test.go
@@ -35,408 +35,187 @@ func TestLibrary_Service_Environment(t *testing.T) {
 }
 
 func TestService_Getters(t *testing.T) {
-	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := &Service{
-		ID:           &num64,
-		BuildID:      &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Name:         &str,
-		Image:        &str,
-		Status:       &str,
-		Error:        &str,
-		ExitCode:     &num,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-	wantID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantName := str
-	wantImage := str
-	wantStatus := str
-	wantError := str
-	wantExitCode := num
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-
-	// run test
-	gotID := s.GetID()
-	gotBuildID := s.GetBuildID()
-	gotRepoID := s.GetRepoID()
-	gotNumber := s.GetNumber()
-	gotName := s.GetName()
-	gotImage := s.GetImage()
-	gotStatus := s.GetStatus()
-	gotError := s.GetError()
-	gotExitCode := s.GetExitCode()
-	gotCreated := s.GetCreated()
-	gotStarted := s.GetStarted()
-	gotFinished := s.GetFinished()
-	gotHost := s.GetHost()
-	gotRuntime := s.GetRuntime()
-	gotDistribution := s.GetDistribution()
-
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    *Service
+	}{
+		{
+			service: testService(),
+			want:    testService(),
+		},
+		{
+			service: new(Service),
+			want:    new(Service),
+		},
 	}
 
-	if gotBuildID != wantBuildID {
-		t.Errorf("GetBuildID is %v, want %v", gotBuildID, wantBuildID)
-	}
+	// run tests
+	for _, test := range tests {
+		if test.service.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.service.GetID(), test.want.GetID())
+		}
 
-	if gotRepoID != wantRepoID {
-		t.Errorf("GetRepoID is %v, want %v", gotRepoID, wantRepoID)
-	}
+		if test.service.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.service.GetBuildID(), test.want.GetBuildID())
+		}
 
-	if gotNumber != wantNumber {
-		t.Errorf("GetNumber is %v, want %v", gotNumber, wantNumber)
-	}
+		if test.service.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.service.GetRepoID(), test.want.GetRepoID())
+		}
 
-	if gotName != wantName {
-		t.Errorf("GetName is %v, want %v", gotName, wantName)
-	}
+		if test.service.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.service.GetNumber(), test.want.GetNumber())
+		}
 
-	if gotImage != wantImage {
-		t.Errorf("GetImage is %v, want %v", gotImage, wantImage)
-	}
+		if test.service.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.service.GetName(), test.want.GetName())
+		}
 
-	if gotStatus != wantStatus {
-		t.Errorf("GetStatus is %v, want %v", gotStatus, wantStatus)
-	}
+		if test.service.GetImage() != test.want.GetImage() {
+			t.Errorf("GetImage is %v, want %v", test.service.GetImage(), test.want.GetImage())
+		}
 
-	if gotError != wantError {
-		t.Errorf("GetError is %v, want %v", gotError, wantError)
-	}
+		if test.service.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.service.GetStatus(), test.want.GetStatus())
+		}
 
-	if gotExitCode != wantExitCode {
-		t.Errorf("GetExitCode is %v, want %v", gotExitCode, wantExitCode)
-	}
+		if test.service.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.service.GetError(), test.want.GetError())
+		}
 
-	if gotCreated != wantCreated {
-		t.Errorf("GetCreated is %v, want %v", gotCreated, wantCreated)
-	}
+		if test.service.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("GetExitCode is %v, want %v", test.service.GetExitCode(), test.want.GetExitCode())
+		}
 
-	if gotStarted != wantStarted {
-		t.Errorf("GetStarted is %v, want %v", gotStarted, wantStarted)
-	}
+		if test.service.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.service.GetCreated(), test.want.GetCreated())
+		}
 
-	if gotFinished != wantFinished {
-		t.Errorf("GetFinished is %v, want %v", gotFinished, wantFinished)
-	}
+		if test.service.GetStarted() != test.want.GetStarted() {
+			t.Errorf("GetStarted is %v, want %v", test.service.GetStarted(), test.want.GetStarted())
+		}
 
-	if gotHost != wantHost {
-		t.Errorf("GetHost is %v, want %v", gotHost, wantHost)
-	}
+		if test.service.GetFinished() != test.want.GetFinished() {
+			t.Errorf("GetFinished is %v, want %v", test.service.GetFinished(), test.want.GetFinished())
+		}
 
-	if gotRuntime != wantRuntime {
-		t.Errorf("GetRuntime is %v, want %v", gotRuntime, wantRuntime)
-	}
+		if test.service.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.service.GetHost(), test.want.GetHost())
+		}
 
-	if gotDistribution != wantDistribution {
-		t.Errorf("GetDistribution is %v, want %v", gotDistribution, wantDistribution)
-	}
-}
+		if test.service.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.service.GetRuntime(), test.want.GetRuntime())
+		}
 
-func TestService_Getters_Empty(t *testing.T) {
-	// setup types
-	s := new(Service)
-
-	// run test
-	gotID := s.GetID()
-	gotBuildID := s.GetBuildID()
-	gotRepoID := s.GetRepoID()
-	gotNumber := s.GetNumber()
-	gotName := s.GetName()
-	gotImage := s.GetImage()
-	gotStatus := s.GetStatus()
-	gotError := s.GetError()
-	gotExitCode := s.GetExitCode()
-	gotCreated := s.GetCreated()
-	gotStarted := s.GetStarted()
-	gotFinished := s.GetFinished()
-	gotHost := s.GetHost()
-	gotRuntime := s.GetRuntime()
-	gotDistribution := s.GetDistribution()
-
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-
-	if gotBuildID != 0 {
-		t.Errorf("GetBuildID is %v, want 0", gotBuildID)
-	}
-
-	if gotRepoID != 0 {
-		t.Errorf("GetRepoID is %v, want 0", gotRepoID)
-	}
-
-	if gotNumber != 0 {
-		t.Errorf("GetNumber is %v, want 0", gotNumber)
-	}
-
-	if gotName != "" {
-		t.Errorf("GetName is %v, want \"\"", gotName)
-	}
-
-	if gotImage != "" {
-		t.Errorf("GetImage is %v, want \"\"", gotImage)
-	}
-
-	if gotStatus != "" {
-		t.Errorf("GetStatus is %v, want \"\"", gotStatus)
-	}
-
-	if gotError != "" {
-		t.Errorf("GetError is %v, want \"\"", gotError)
-	}
-
-	if gotExitCode != 0 {
-		t.Errorf("GetExitCode is %v, want 0", gotExitCode)
-	}
-
-	if gotCreated != 0 {
-		t.Errorf("GetCreated is %v, want 0", gotCreated)
-	}
-
-	if gotStarted != 0 {
-		t.Errorf("GetStarted is %v, want 0", gotStarted)
-	}
-
-	if gotFinished != 0 {
-		t.Errorf("GetFinished is %v, want 0", gotFinished)
-	}
-
-	if gotHost != "" {
-		t.Errorf("GetHost is %v, want \"\"", gotHost)
-	}
-
-	if gotRuntime != "" {
-		t.Errorf("GetRuntime is %v, want \"\"", gotRuntime)
-	}
-
-	if gotDistribution != "" {
-		t.Errorf("GetDistribution is %v, want \"\"", gotDistribution)
+		if test.service.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.service.GetDistribution(), test.want.GetDistribution())
+		}
 	}
 }
 
 func TestLibrary_Service_Setters(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := new(Service)
-
-	wantID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantName := str
-	wantImage := str
-	wantStatus := str
-	wantError := str
-	wantExitCode := num
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-
-	// run test
-	s.SetID(wantID)
-	s.SetBuildID(wantBuildID)
-	s.SetRepoID(wantRepoID)
-	s.SetNumber(wantNumber)
-	s.SetName(wantName)
-	s.SetImage(wantImage)
-	s.SetStatus(wantStatus)
-	s.SetError(wantError)
-	s.SetExitCode(wantExitCode)
-	s.SetCreated(wantCreated)
-	s.SetStarted(wantStarted)
-	s.SetFinished(wantFinished)
-	s.SetHost(wantHost)
-	s.SetRuntime(wantRuntime)
-	s.SetDistribution(wantDistribution)
-
-	if s.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", s.GetID(), wantID)
-	}
-
-	if s.GetBuildID() != wantBuildID {
-		t.Errorf("SetBuildID is %v, want %v", s.GetBuildID(), wantBuildID)
-	}
-
-	if s.GetRepoID() != wantRepoID {
-		t.Errorf("SetRepoID is %v, want %v", s.GetRepoID(), wantRepoID)
-	}
-
-	if s.GetNumber() != wantNumber {
-		t.Errorf("SetNumber is %v, want %v", s.GetNumber(), wantNumber)
-	}
-
-	if s.GetName() != wantName {
-		t.Errorf("SetName is %v, want %v", s.GetName(), wantName)
-	}
-
-	if s.GetImage() != wantImage {
-		t.Errorf("SetImage is %v, want %v", s.GetImage(), wantImage)
-	}
-
-	if s.GetStatus() != wantStatus {
-		t.Errorf("SetStatus is %v, want %v", s.GetStatus(), wantStatus)
-	}
-
-	if s.GetError() != wantError {
-		t.Errorf("SetError is %v, want %v", s.GetError(), wantError)
-	}
-
-	if s.GetExitCode() != wantExitCode {
-		t.Errorf("SetExitCode is %v, want %v", s.GetExitCode(), wantExitCode)
-	}
-
-	if s.GetCreated() != wantCreated {
-		t.Errorf("SetCreated is %v, want %v", s.GetCreated(), wantCreated)
-	}
-
-	if s.GetStarted() != wantStarted {
-		t.Errorf("SetStarted is %v, want %v", s.GetStarted(), wantStarted)
-	}
-
-	if s.GetFinished() != wantFinished {
-		t.Errorf("SetFinished is %v, want %v", s.GetFinished(), wantFinished)
-	}
-
-	if s.GetHost() != wantHost {
-		t.Errorf("SetHost is %v, want %v", s.GetHost(), wantHost)
-	}
-
-	if s.GetRuntime() != wantRuntime {
-		t.Errorf("SetRuntime is %v, want %v", s.GetRuntime(), wantRuntime)
-	}
-
-	if s.GetDistribution() != wantDistribution {
-		t.Errorf("SetDistribution is %v, want %v", s.GetDistribution(), wantDistribution)
-	}
-}
-
-func TestLibrary_Service_Setters_Empty(t *testing.T) {
-	// setup types
 	var s *Service
 
-	// run test
-	s.SetID(0)
-	s.SetBuildID(0)
-	s.SetRepoID(0)
-	s.SetNumber(0)
-	s.SetName("")
-	s.SetImage("")
-	s.SetStatus("")
-	s.SetError("")
-	s.SetExitCode(0)
-	s.SetCreated(0)
-	s.SetStarted(0)
-	s.SetFinished(0)
-	s.SetHost("")
-	s.SetRuntime("")
-	s.SetDistribution("")
-
-	if s.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", s.GetID())
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    *Service
+	}{
+		{
+			service: testService(),
+			want:    testService(),
+		},
+		{
+			service: s,
+			want:    new(Service),
+		},
 	}
 
-	if s.GetBuildID() != 0 {
-		t.Errorf("SetBuildID is %v, want 0", s.GetBuildID())
-	}
+	// run tests
+	for _, test := range tests {
+		test.service.SetID(test.service.GetID())
+		test.service.SetBuildID(test.service.GetBuildID())
+		test.service.SetRepoID(test.service.GetRepoID())
+		test.service.SetNumber(test.service.GetNumber())
+		test.service.SetName(test.service.GetName())
+		test.service.SetImage(test.service.GetImage())
+		test.service.SetStatus(test.service.GetStatus())
+		test.service.SetError(test.service.GetError())
+		test.service.SetExitCode(test.service.GetExitCode())
+		test.service.SetCreated(test.service.GetCreated())
+		test.service.SetStarted(test.service.GetStarted())
+		test.service.SetFinished(test.service.GetFinished())
+		test.service.SetHost(test.service.GetHost())
+		test.service.SetRuntime(test.service.GetRuntime())
+		test.service.SetDistribution(test.service.GetDistribution())
 
-	if s.GetRepoID() != 0 {
-		t.Errorf("SetRepoID is %v, want 0", s.GetRepoID())
-	}
+		if test.service.GetID() != test.service.GetID() {
+			t.Errorf("SetID is %v, want %v", test.service.GetID(), test.service.GetID())
+		}
 
-	if s.GetNumber() != 0 {
-		t.Errorf("SetNumber is %v, want 0", s.GetNumber())
-	}
+		if test.service.GetBuildID() != test.service.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.service.GetBuildID(), test.service.GetBuildID())
+		}
 
-	if s.GetName() != "" {
-		t.Errorf("SetName is %v, want \"\"", s.GetName())
-	}
+		if test.service.GetRepoID() != test.service.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.service.GetRepoID(), test.service.GetRepoID())
+		}
 
-	if s.GetImage() != "" {
-		t.Errorf("SetImage is %v, want \"\"", s.GetImage())
-	}
+		if test.service.GetNumber() != test.service.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.service.GetNumber(), test.service.GetNumber())
+		}
 
-	if s.GetStatus() != "" {
-		t.Errorf("SetStatus is %v, want \"\"", s.GetStatus())
-	}
+		if test.service.GetName() != test.service.GetName() {
+			t.Errorf("SetName is %v, want %v", test.service.GetName(), test.service.GetName())
+		}
 
-	if s.GetError() != "" {
-		t.Errorf("SetError is %v, want \"\"", s.GetError())
-	}
+		if test.service.GetImage() != test.service.GetImage() {
+			t.Errorf("SetImage is %v, want %v", test.service.GetImage(), test.service.GetImage())
+		}
 
-	if s.GetExitCode() != 0 {
-		t.Errorf("SetExitCode is %v, want 0", s.GetExitCode())
-	}
+		if test.service.GetStatus() != test.service.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.service.GetStatus(), test.service.GetStatus())
+		}
 
-	if s.GetCreated() != 0 {
-		t.Errorf("SetCreated is %v, want 0", s.GetCreated())
-	}
+		if test.service.GetError() != test.service.GetError() {
+			t.Errorf("SetError is %v, want %v", test.service.GetError(), test.service.GetError())
+		}
 
-	if s.GetStarted() != 0 {
-		t.Errorf("SetStarted is %v, want 0", s.GetStarted())
-	}
+		if test.service.GetExitCode() != test.service.GetExitCode() {
+			t.Errorf("SetExitCode is %v, want %v", test.service.GetExitCode(), test.service.GetExitCode())
+		}
 
-	if s.GetFinished() != 0 {
-		t.Errorf("SetFinished is %v, want 0", s.GetFinished())
-	}
+		if test.service.GetCreated() != test.service.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.service.GetCreated(), test.service.GetCreated())
+		}
 
-	if s.GetHost() != "" {
-		t.Errorf("SetHost is %v, want \"\"", s.GetHost())
-	}
+		if test.service.GetStarted() != test.service.GetStarted() {
+			t.Errorf("SetStarted is %v, want %v", test.service.GetStarted(), test.service.GetStarted())
+		}
 
-	if s.GetRuntime() != "" {
-		t.Errorf("SetRuntime is %v, want \"\"", s.GetRuntime())
-	}
+		if test.service.GetFinished() != test.service.GetFinished() {
+			t.Errorf("SetFinished is %v, want %v", test.service.GetFinished(), test.service.GetFinished())
+		}
 
-	if s.GetDistribution() != "" {
-		t.Errorf("SetDistribution is %v, want \"\"", s.GetDistribution())
+		if test.service.GetHost() != test.service.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.service.GetHost(), test.service.GetHost())
+		}
+
+		if test.service.GetRuntime() != test.service.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.service.GetRuntime(), test.service.GetRuntime())
+		}
+
+		if test.service.GetDistribution() != test.service.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.service.GetDistribution(), test.service.GetDistribution())
+		}
 	}
 }
 
 func TestService_String(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := &Service{
-		ID:           &num64,
-		BuildID:      &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Name:         &str,
-		Image:        &str,
-		Status:       &str,
-		Error:        &str,
-		ExitCode:     &num,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
+	s := testService()
 
 	want := fmt.Sprintf("%+v", *s)
 

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -36,372 +36,197 @@ func TestLibrary_Step_Environment(t *testing.T) {
 }
 
 func TestStep_Getters(t *testing.T) {
-	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := &Step{
-		ID:           &num64,
-		BuildID:      &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Name:         &str,
-		Image:        &str,
-		Stage:        &str,
-		Status:       &str,
-		Error:        &str,
-		ExitCode:     &num,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
+	// setup tests
+	tests := []struct {
+		step *Step
+		want *Step
+	}{
+		{
+			step: testStep(),
+			want: testStep(),
+		},
+		{
+			step: new(Step),
+			want: new(Step),
+		},
 	}
-	wantID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantName := str
-	wantImage := str
-	wantStage := str
-	wantStatus := str
-	wantError := str
-	wantExitCode := num
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
 
-	// run test
-	gotID := s.GetID()
-	gotBuildID := s.GetBuildID()
-	gotRepoID := s.GetRepoID()
-	gotNumber := s.GetNumber()
-	gotName := s.GetName()
-	gotImage := s.GetImage()
-	gotStage := s.GetStage()
-	gotStatus := s.GetStatus()
-	gotError := s.GetError()
-	gotExitCode := s.GetExitCode()
-	gotCreated := s.GetCreated()
-	gotStarted := s.GetStarted()
-	gotFinished := s.GetFinished()
-	gotHost := s.GetHost()
-	gotRuntime := s.GetRuntime()
-	gotDistribution := s.GetDistribution()
+	// run tests
+	for _, test := range tests {
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
 
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
-	}
-	if gotBuildID != wantBuildID {
-		t.Errorf("GetBuildID is %v, want %v", gotBuildID, wantBuildID)
-	}
-	if gotRepoID != wantRepoID {
-		t.Errorf("GetRepoID is %v, want %v", gotRepoID, wantRepoID)
-	}
-	if gotNumber != wantNumber {
-		t.Errorf("GetNumber is %v, want %v", gotNumber, wantNumber)
-	}
-	if gotName != wantName {
-		t.Errorf("GetName is %v, want %v", gotName, wantName)
-	}
-	if gotImage != wantImage {
-		t.Errorf("GetImage is %v, want %v", gotImage, wantImage)
-	}
-	if gotStage != wantStage {
-		t.Errorf("GetStage is %v, want %v", gotStage, wantStage)
-	}
-	if gotStatus != wantStatus {
-		t.Errorf("GetStatus is %v, want %v", gotStatus, wantStatus)
-	}
-	if gotError != wantError {
-		t.Errorf("GetError is %v, want %v", gotError, wantError)
-	}
-	if gotExitCode != wantExitCode {
-		t.Errorf("GetExitCode is %v, want %v", gotExitCode, wantExitCode)
-	}
-	if gotCreated != wantCreated {
-		t.Errorf("GetCreated is %v, want %v", gotCreated, wantCreated)
-	}
-	if gotStarted != wantStarted {
-		t.Errorf("GetStarted is %v, want %v", gotStarted, wantStarted)
-	}
-	if gotFinished != wantFinished {
-		t.Errorf("GetFinished is %v, want %v", gotFinished, wantFinished)
-	}
-	if gotHost != wantHost {
-		t.Errorf("GetHost is %v, want %v", gotHost, wantHost)
-	}
-	if gotRuntime != wantRuntime {
-		t.Errorf("GetRuntime is %v, want %v", gotRuntime, wantRuntime)
-	}
-	if gotDistribution != wantDistribution {
-		t.Errorf("GetDistribution is %v, want %v", gotDistribution, wantDistribution)
-	}
-}
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
 
-func TestStep_Getters_Empty(t *testing.T) {
-	// setup types
-	s := new(Step)
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
 
-	// run test
-	gotID := s.GetID()
-	gotBuildID := s.GetBuildID()
-	gotRepoID := s.GetRepoID()
-	gotNumber := s.GetNumber()
-	gotName := s.GetName()
-	gotImage := s.GetImage()
-	gotStage := s.GetStage()
-	gotStatus := s.GetStatus()
-	gotError := s.GetError()
-	gotExitCode := s.GetExitCode()
-	gotCreated := s.GetCreated()
-	gotStarted := s.GetStarted()
-	gotFinished := s.GetFinished()
-	gotHost := s.GetHost()
-	gotRuntime := s.GetRuntime()
-	gotDistribution := s.GetDistribution()
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
 
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-	if gotBuildID != 0 {
-		t.Errorf("GetBuildID is %v, want 0", gotBuildID)
-	}
-	if gotRepoID != 0 {
-		t.Errorf("GetRepoID is %v, want 0", gotRepoID)
-	}
-	if gotNumber != 0 {
-		t.Errorf("GetNumber is %v, want 0", gotNumber)
-	}
-	if gotName != "" {
-		t.Errorf("GetName is %v, want \"\"", gotName)
-	}
-	if gotImage != "" {
-		t.Errorf("GetImage is %v, want \"\"", gotImage)
-	}
-	if gotStage != "" {
-		t.Errorf("GetStage is %v, want \"\"", gotStage)
-	}
-	if gotStatus != "" {
-		t.Errorf("GetStatus is %v, want \"\"", gotStatus)
-	}
-	if gotError != "" {
-		t.Errorf("GetError is %v, want \"\"", gotError)
-	}
-	if gotExitCode != 0 {
-		t.Errorf("GetExitCode is %v, want 0", gotExitCode)
-	}
-	if gotCreated != 0 {
-		t.Errorf("GetCreated is %v, want 0", gotCreated)
-	}
-	if gotStarted != 0 {
-		t.Errorf("GetStarted is %v, want 0", gotStarted)
-	}
-	if gotFinished != 0 {
-		t.Errorf("GetFinished is %v, want 0", gotFinished)
-	}
-	if gotHost != "" {
-		t.Errorf("GetHost is %v, want \"\"", gotHost)
-	}
-	if gotRuntime != "" {
-		t.Errorf("GetRuntime is %v, want \"\"", gotRuntime)
-	}
-	if gotDistribution != "" {
-		t.Errorf("GetDistribution is %v, want \"\"", gotDistribution)
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetImage() != test.want.GetImage() {
+			t.Errorf("GetImage is %v, want %v", test.step.GetImage(), test.want.GetImage())
+		}
+
+		if test.step.GetStage() != test.want.GetStage() {
+			t.Errorf("GetStage is %v, want %v", test.step.GetStage(), test.want.GetStage())
+		}
+
+		if test.step.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.step.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.step.GetError() != test.want.GetError() {
+			t.Errorf("GetError is %v, want %v", test.step.GetError(), test.want.GetError())
+		}
+
+		if test.step.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("GetExitCode is %v, want %v", test.step.GetExitCode(), test.want.GetExitCode())
+		}
+
+		if test.step.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.step.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.step.GetStarted() != test.want.GetStarted() {
+			t.Errorf("GetStarted is %v, want %v", test.step.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.step.GetFinished() != test.want.GetFinished() {
+			t.Errorf("GetFinished is %v, want %v", test.step.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.step.GetHost() != test.want.GetHost() {
+			t.Errorf("GetHost is %v, want %v", test.step.GetHost(), test.want.GetHost())
+		}
+
+		if test.step.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("GetRuntime is %v, want %v", test.step.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.step.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("GetDistribution is %v, want %v", test.step.GetDistribution(), test.want.GetDistribution())
+		}
 	}
 }
 
 func TestLibrary_Step_Setters(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := new(Step)
-
-	wantID := num64
-	wantBuildID := num64
-	wantRepoID := num64
-	wantNumber := num
-	wantName := str
-	wantImage := str
-	wantStage := str
-	wantStatus := str
-	wantError := str
-	wantExitCode := num
-	wantCreated := num64
-	wantStarted := num64
-	wantFinished := num64
-	wantHost := str
-	wantRuntime := str
-	wantDistribution := str
-
-	// run test
-	s.SetID(wantID)
-	s.SetBuildID(wantBuildID)
-	s.SetRepoID(wantRepoID)
-	s.SetNumber(wantNumber)
-	s.SetName(wantName)
-	s.SetImage(wantImage)
-	s.SetStage(wantStage)
-	s.SetStatus(wantStatus)
-	s.SetError(wantError)
-	s.SetExitCode(wantExitCode)
-	s.SetCreated(wantCreated)
-	s.SetStarted(wantStarted)
-	s.SetFinished(wantFinished)
-	s.SetHost(wantHost)
-	s.SetRuntime(wantRuntime)
-	s.SetDistribution(wantDistribution)
-
-	if s.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", s.GetID(), wantID)
-	}
-	if s.GetBuildID() != wantBuildID {
-		t.Errorf("SetBuildID is %v, want %v", s.GetBuildID(), wantBuildID)
-	}
-	if s.GetRepoID() != wantRepoID {
-		t.Errorf("SetRepoID is %v, want %v", s.GetRepoID(), wantRepoID)
-	}
-	if s.GetNumber() != wantNumber {
-		t.Errorf("SetNumber is %v, want %v", s.GetNumber(), wantNumber)
-	}
-	if s.GetName() != wantName {
-		t.Errorf("SetName is %v, want %v", s.GetName(), wantName)
-	}
-	if s.GetImage() != wantImage {
-		t.Errorf("SetImage is %v, want %v", s.GetImage(), wantImage)
-	}
-	if s.GetStage() != wantStage {
-		t.Errorf("SetStage is %v, want %v", s.GetStage(), wantStage)
-	}
-	if s.GetStatus() != wantStatus {
-		t.Errorf("SetStatus is %v, want %v", s.GetStatus(), wantStatus)
-	}
-	if s.GetError() != wantError {
-		t.Errorf("SetError is %v, want %v", s.GetError(), wantError)
-	}
-	if s.GetExitCode() != wantExitCode {
-		t.Errorf("SetExitCode is %v, want %v", s.GetExitCode(), wantExitCode)
-	}
-	if s.GetCreated() != wantCreated {
-		t.Errorf("SetCreated is %v, want %v", s.GetCreated(), wantCreated)
-	}
-	if s.GetStarted() != wantStarted {
-		t.Errorf("SetStarted is %v, want %v", s.GetStarted(), wantStarted)
-	}
-	if s.GetFinished() != wantFinished {
-		t.Errorf("SetFinished is %v, want %v", s.GetFinished(), wantFinished)
-	}
-	if s.GetHost() != wantHost {
-		t.Errorf("SetHost is %v, want %v", s.GetHost(), wantHost)
-	}
-	if s.GetRuntime() != wantRuntime {
-		t.Errorf("SetRuntime is %v, want %v", s.GetRuntime(), wantRuntime)
-	}
-	if s.GetDistribution() != wantDistribution {
-		t.Errorf("SetDistribution is %v, want %v", s.GetDistribution(), wantDistribution)
-	}
-}
-
-func TestLibrary_Step_Setters_Empty(t *testing.T) {
-	// setup types
 	var s *Step
 
-	// run test
-	s.SetID(0)
-	s.SetBuildID(0)
-	s.SetRepoID(0)
-	s.SetNumber(0)
-	s.SetName("")
-	s.SetImage("")
-	s.SetStage("")
-	s.SetStatus("")
-	s.SetError("")
-	s.SetExitCode(0)
-	s.SetCreated(0)
-	s.SetStarted(0)
-	s.SetFinished(0)
-	s.SetHost("")
-	s.SetRuntime("")
-	s.SetDistribution("")
+	// setup tests
+	tests := []struct {
+		step *Step
+		want *Step
+	}{
+		{
+			step: testStep(),
+			want: testStep(),
+		},
+		{
+			step: s,
+			want: new(Step),
+		},
+	}
 
-	if s.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", s.GetID())
-	}
-	if s.GetBuildID() != 0 {
-		t.Errorf("SetBuildID is %v, want 0", s.GetBuildID())
-	}
-	if s.GetRepoID() != 0 {
-		t.Errorf("SetRepoID is %v, want 0", s.GetRepoID())
-	}
-	if s.GetNumber() != 0 {
-		t.Errorf("SetNumber is %v, want 0", s.GetNumber())
-	}
-	if s.GetName() != "" {
-		t.Errorf("SetName is %v, want \"\"", s.GetName())
-	}
-	if s.GetImage() != "" {
-		t.Errorf("SetImage is %v, want \"\"", s.GetImage())
-	}
-	if s.GetStage() != "" {
-		t.Errorf("SetStage is %v, want \"\"", s.GetStage())
-	}
-	if s.GetStatus() != "" {
-		t.Errorf("SetStatus is %v, want \"\"", s.GetStatus())
-	}
-	if s.GetError() != "" {
-		t.Errorf("SetError is %v, want \"\"", s.GetError())
-	}
-	if s.GetExitCode() != 0 {
-		t.Errorf("SetExitCode is %v, want 0", s.GetExitCode())
-	}
-	if s.GetCreated() != 0 {
-		t.Errorf("SetCreated is %v, want 0", s.GetCreated())
-	}
-	if s.GetStarted() != 0 {
-		t.Errorf("SetStarted is %v, want 0", s.GetStarted())
-	}
-	if s.GetFinished() != 0 {
-		t.Errorf("SetFinished is %v, want 0", s.GetFinished())
-	}
-	if s.GetHost() != "" {
-		t.Errorf("SetHost is %v, want \"\"", s.GetHost())
-	}
-	if s.GetRuntime() != "" {
-		t.Errorf("SetRuntime is %v, want \"\"", s.GetRuntime())
-	}
-	if s.GetDistribution() != "" {
-		t.Errorf("SetDistribution is %v, want \"\"", s.GetDistribution())
+	// run tests
+	for _, test := range tests {
+		test.step.SetID(test.want.GetID())
+		test.step.SetBuildID(test.want.GetBuildID())
+		test.step.SetRepoID(test.want.GetRepoID())
+		test.step.SetNumber(test.want.GetNumber())
+		test.step.SetName(test.want.GetName())
+		test.step.SetImage(test.want.GetImage())
+		test.step.SetStage(test.want.GetStage())
+		test.step.SetStatus(test.want.GetStatus())
+		test.step.SetError(test.want.GetError())
+		test.step.SetExitCode(test.want.GetExitCode())
+		test.step.SetCreated(test.want.GetCreated())
+		test.step.SetStarted(test.want.GetStarted())
+		test.step.SetFinished(test.want.GetFinished())
+		test.step.SetHost(test.want.GetHost())
+		test.step.SetRuntime(test.want.GetRuntime())
+		test.step.SetDistribution(test.want.GetDistribution())
+
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
+
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetImage() != test.want.GetImage() {
+			t.Errorf("SetImage is %v, want %v", test.step.GetImage(), test.want.GetImage())
+		}
+
+		if test.step.GetStage() != test.want.GetStage() {
+			t.Errorf("SetStage is %v, want %v", test.step.GetStage(), test.want.GetStage())
+		}
+
+		if test.step.GetStatus() != test.want.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.step.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.step.GetError() != test.want.GetError() {
+			t.Errorf("SetError is %v, want %v", test.step.GetError(), test.want.GetError())
+		}
+
+		if test.step.GetExitCode() != test.want.GetExitCode() {
+			t.Errorf("SetExitCode is %v, want %v", test.step.GetExitCode(), test.want.GetExitCode())
+		}
+
+		if test.step.GetCreated() != test.want.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.step.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.step.GetStarted() != test.want.GetStarted() {
+			t.Errorf("SetStarted is %v, want %v", test.step.GetStarted(), test.want.GetStarted())
+		}
+
+		if test.step.GetFinished() != test.want.GetFinished() {
+			t.Errorf("SetFinished is %v, want %v", test.step.GetFinished(), test.want.GetFinished())
+		}
+
+		if test.step.GetHost() != test.want.GetHost() {
+			t.Errorf("SetHost is %v, want %v", test.step.GetHost(), test.want.GetHost())
+		}
+
+		if test.step.GetRuntime() != test.want.GetRuntime() {
+			t.Errorf("SetRuntime is %v, want %v", test.step.GetRuntime(), test.want.GetRuntime())
+		}
+
+		if test.step.GetDistribution() != test.want.GetDistribution() {
+			t.Errorf("SetDistribution is %v, want %v", test.step.GetDistribution(), test.want.GetDistribution())
+		}
 	}
 }
 
 func TestStep_String(t *testing.T) {
 	// setup types
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	s := &Step{
-		ID:           &num64,
-		BuildID:      &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Name:         &str,
-		Image:        &str,
-		Stage:        &str,
-		Status:       &str,
-		Error:        &str,
-		ExitCode:     &num,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
+	s := testStep()
+
 	want := fmt.Sprintf("%+v", *s)
 
 	// run test

--- a/library/string_test.go
+++ b/library/string_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestLibrary_ToString(t *testing.T) {
-	// setup types
+	// setup tests
 	tests := []struct {
 		parameter interface{}
 		want      interface{}
@@ -48,7 +48,7 @@ func TestLibrary_ToString(t *testing.T) {
 		},
 	}
 
-	// run test
+	// run tests
 	for _, test := range tests {
 		got := ToString(test.parameter)
 

--- a/library/user_test.go
+++ b/library/user_test.go
@@ -28,219 +28,116 @@ func TestLibrary_User_Environment(t *testing.T) {
 }
 
 func TestLibrary_User_Getters(t *testing.T) {
-	// setup types
-	booL := false
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	u := &User{
-		ID:        &num64,
-		Name:      &str,
-		Token:     &str,
-		Hash:      &str,
-		Favorites: &arr,
-		Active:    &booL,
-		Admin:     &booL,
-	}
-	wantID := num64
-	wantName := str
-	wantToken := str
-	wantHash := str
-	wantFavorites := arr
-	wantActive := booL
-	wantAdmin := booL
-
-	// run test
-	gotID := u.GetID()
-	gotName := u.GetName()
-	gotToken := u.GetToken()
-	gotHash := u.GetHash()
-	gotFavorites := u.GetFavorites()
-	gotActive := u.GetActive()
-	gotAdmin := u.GetAdmin()
-
-	if gotID != wantID {
-		t.Errorf("GetID is %v, want %v", gotID, wantID)
+	// setup tests
+	tests := []struct {
+		user *User
+		want *User
+	}{
+		{
+			user: testUser(),
+			want: testUser(),
+		},
+		{
+			user: new(User),
+			want: new(User),
+		},
 	}
 
-	if gotName != wantName {
-		t.Errorf("GetName is %v, want %v", gotName, wantName)
-	}
+	// run tests
+	for _, test := range tests {
+		if test.user.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.user.GetID(), test.want.GetID())
+		}
 
-	if gotToken != wantToken {
-		t.Errorf("GetToken is %v, want %v", gotToken, wantToken)
-	}
+		if test.user.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.user.GetName(), test.want.GetName())
+		}
 
-	if gotHash != wantHash {
-		t.Errorf("GetHash is %v, want %v", gotHash, wantHash)
-	}
+		if test.user.GetToken() != test.want.GetToken() {
+			t.Errorf("GetToken is %v, want %v", test.user.GetToken(), test.want.GetToken())
+		}
 
-	if !reflect.DeepEqual(gotFavorites, wantFavorites) {
-		t.Errorf("GetFavorites is %v, want %v", gotFavorites, wantFavorites)
-	}
+		if test.user.GetHash() != test.want.GetHash() {
+			t.Errorf("GetHash is %v, want %v", test.user.GetHash(), test.want.GetHash())
+		}
 
-	if gotActive != wantActive {
-		t.Errorf("GetActive is %v, want %v", gotActive, wantActive)
-	}
+		if !reflect.DeepEqual(test.user.GetFavorites(), test.want.GetFavorites()) {
+			t.Errorf("GetFavorites is %v, want %v", test.user.GetFavorites(), test.want.GetFavorites())
+		}
 
-	if gotAdmin != wantAdmin {
-		t.Errorf("GetAdmin is %v, want %v", gotAdmin, wantAdmin)
-	}
-}
+		if test.user.GetActive() != test.want.GetActive() {
+			t.Errorf("GetActive is %v, want %v", test.user.GetActive(), test.want.GetActive())
+		}
 
-func TestLibrary_User_Getters_Empty(t *testing.T) {
-	// setup types
-	u := new(User)
-
-	// run test
-	gotID := u.GetID()
-	gotName := u.GetName()
-	gotToken := u.GetToken()
-	gotHash := u.GetHash()
-	gotFavorites := u.GetFavorites()
-	gotActive := u.GetActive()
-	gotAdmin := u.GetAdmin()
-
-	if gotID != 0 {
-		t.Errorf("GetID is %v, want 0", gotID)
-	}
-
-	if gotName != "" {
-		t.Errorf("GetName is %v, want \"\"", gotName)
-	}
-
-	if gotToken != "" {
-		t.Errorf("GetToken is %v, want \"\"", gotToken)
-	}
-
-	if gotHash != "" {
-		t.Errorf("GetHash is %v, want \"\"", gotHash)
-	}
-
-	if !reflect.DeepEqual(gotFavorites, []string{}) {
-		t.Errorf("GetFavorites is %v, want []string{}", gotFavorites)
-	}
-
-	if gotActive != false {
-		t.Errorf("GetActive is %v, want false", gotActive)
-	}
-
-	if gotAdmin != false {
-		t.Errorf("GetAdmin is %v, want false", gotAdmin)
+		if test.user.GetAdmin() != test.want.GetAdmin() {
+			t.Errorf("GetAdmin is %v, want %v", test.user.GetAdmin(), test.want.GetAdmin())
+		}
 	}
 }
 
 func TestLibrary_User_Setters(t *testing.T) {
 	// setup types
-	booL := false
-	num64 := int64(1)
-	str := "foo"
-	u := new(User)
-	arr := []string{"foo", "bar"}
-
-	wantID := num64
-	wantName := str
-	wantToken := str
-	wantHash := str
-	wantFavorites := arr
-	wantActive := booL
-	wantAdmin := booL
-
-	// run test
-	u.SetID(wantID)
-	u.SetName(wantName)
-	u.SetToken(wantToken)
-	u.SetHash(wantHash)
-	u.SetFavorites(wantFavorites)
-	u.SetActive(wantActive)
-	u.SetAdmin(wantAdmin)
-
-	if u.GetID() != wantID {
-		t.Errorf("SetID is %v, want %v", u.GetID(), wantID)
-	}
-
-	if u.GetName() != wantName {
-		t.Errorf("SetName is %v, want %v", u.GetName(), wantName)
-	}
-
-	if u.GetToken() != wantToken {
-		t.Errorf("SetToken is %v, want %v", u.GetToken(), wantToken)
-	}
-
-	if u.GetHash() != wantHash {
-		t.Errorf("SetHash is %v, want %v", u.GetHash(), wantHash)
-	}
-
-	if !reflect.DeepEqual(u.GetFavorites(), wantFavorites) {
-		t.Errorf("SetFavorites is %v, want %v", u.GetFavorites(), wantFavorites)
-	}
-
-	if u.GetActive() != wantActive {
-		t.Errorf("SetActive is %v, want %v", u.GetActive(), wantActive)
-	}
-
-	if u.GetAdmin() != wantAdmin {
-		t.Errorf("SetAdmin is %v, want %v", u.GetAdmin(), wantAdmin)
-	}
-}
-
-func TestLibrary_User_Setters_Empty(t *testing.T) {
-	// setup types
 	var u *User
 
-	// run test
-	u.SetID(0)
-	u.SetName("")
-	u.SetToken("")
-	u.SetHash("")
-	u.SetFavorites([]string{})
-	u.SetActive(false)
-	u.SetAdmin(false)
-
-	if u.GetID() != 0 {
-		t.Errorf("SetID is %v, want 0", u.GetID())
+	// setup tests
+	tests := []struct {
+		user *User
+		want *User
+	}{
+		{
+			user: testUser(),
+			want: testUser(),
+		},
+		{
+			user: u,
+			want: new(User),
+		},
 	}
 
-	if u.GetName() != "" {
-		t.Errorf("SetName is %v, want \"\"", u.GetName())
-	}
+	// run tests
+	for _, test := range tests {
+		test.user.SetID(test.want.GetID())
+		test.user.SetName(test.want.GetName())
+		test.user.SetToken(test.want.GetToken())
+		test.user.SetHash(test.want.GetHash())
+		test.user.SetFavorites(test.want.GetFavorites())
+		test.user.SetActive(test.want.GetActive())
+		test.user.SetAdmin(test.want.GetAdmin())
 
-	if u.GetToken() != "" {
-		t.Errorf("SetToken is %v, want \"\"", u.GetToken())
-	}
+		if test.user.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.user.GetID(), test.want.GetID())
+		}
 
-	if u.GetHash() != "" {
-		t.Errorf("SetHash is %v, want \"\"", u.GetHash())
-	}
+		if test.user.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.user.GetName(), test.want.GetName())
+		}
 
-	if !reflect.DeepEqual(u.GetFavorites(), []string{}) {
-		t.Errorf("GetFavorites is %v, want []string{}", u.GetFavorites())
-	}
+		if test.user.GetToken() != test.want.GetToken() {
+			t.Errorf("SetToken is %v, want %v", test.user.GetToken(), test.want.GetToken())
+		}
 
-	if u.GetActive() != false {
-		t.Errorf("SetActive is %v, want false", u.GetActive())
-	}
+		if test.user.GetHash() != test.want.GetHash() {
+			t.Errorf("SetHash is %v, want %v", test.user.GetHash(), test.want.GetHash())
+		}
 
-	if u.GetAdmin() != false {
-		t.Errorf("SetAdmin is %v, want false", u.GetAdmin())
+		if !reflect.DeepEqual(test.user.GetFavorites(), test.want.GetFavorites()) {
+			t.Errorf("SetFavorites is %v, want %v", test.user.GetFavorites(), test.want.GetFavorites())
+		}
+
+		if test.user.GetActive() != test.want.GetActive() {
+			t.Errorf("SetActive is %v, want %v", test.user.GetActive(), test.want.GetActive())
+		}
+
+		if test.user.GetAdmin() != test.want.GetAdmin() {
+			t.Errorf("SetAdmin is %v, want %v", test.user.GetAdmin(), test.want.GetAdmin())
+		}
 	}
 }
 
 func TestLibrary_User_String(t *testing.T) {
 	// setup types
-	booL := false
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	u := &User{
-		ID:        &num64,
-		Name:      &str,
-		Token:     &str,
-		Hash:      &str,
-		Favorites: &arr,
-		Active:    &booL,
-		Admin:     &booL,
-	}
+	u := testUser()
+
 	want := fmt.Sprintf("%+v", *u)
 
 	// run test


### PR DESCRIPTION
This will refactor all tests in the `go-vela/types/library` package to use table tests.

More information: https://github.com/golang/go/wiki/TableDrivenTests

I was able to cut the total number lines of code for our tests in half 🎉 