### PR TITLE
test(database): refactor for table tests

### DIFF
--- a/database/build_test.go
+++ b/database/build_test.go
@@ -17,16 +17,14 @@ func TestDatabase_Build_Crop(t *testing.T) {
 	// setup types
 	title := randomString(1001)
 	message := randomString(2001)
-	want := &Build{
-		ID:      sql.NullInt64{Int64: 1, Valid: true},
-		Title:   sql.NullString{String: title[:1000], Valid: true},
-		Message: sql.NullString{String: message[:2000], Valid: true},
-	}
-	b := &Build{
-		ID:      sql.NullInt64{Int64: 1, Valid: true},
-		Title:   sql.NullString{String: title, Valid: true},
-		Message: sql.NullString{String: message, Valid: true},
-	}
+
+	b := testBuild()
+	b.Title = sql.NullString{String: title, Valid: true}
+	b.Message = sql.NullString{String: message, Valid: true}
+
+	want := testBuild()
+	want.Title = sql.NullString{String: title[:1000], Valid: true}
+	want.Message = sql.NullString{String: message[:2000], Valid: true}
 
 	// run test
 	got := b.Crop()
@@ -38,35 +36,8 @@ func TestDatabase_Build_Crop(t *testing.T) {
 
 func TestDatabase_Build_Nullify(t *testing.T) {
 	// setup types
-	b := &Build{
-		ID:           sql.NullInt64{Int64: 0, Valid: true},
-		RepoID:       sql.NullInt64{Int64: 0, Valid: true},
-		Number:       sql.NullInt32{Int32: 0, Valid: true},
-		Parent:       sql.NullInt32{Int32: 0, Valid: true},
-		Event:        sql.NullString{String: "", Valid: true},
-		Status:       sql.NullString{String: "", Valid: true},
-		Error:        sql.NullString{String: "", Valid: true},
-		Enqueued:     sql.NullInt64{Int64: 0, Valid: true},
-		Created:      sql.NullInt64{Int64: 0, Valid: true},
-		Started:      sql.NullInt64{Int64: 0, Valid: true},
-		Finished:     sql.NullInt64{Int64: 0, Valid: true},
-		Deploy:       sql.NullString{String: "", Valid: true},
-		Clone:        sql.NullString{String: "", Valid: true},
-		Source:       sql.NullString{String: "", Valid: true},
-		Title:        sql.NullString{String: "", Valid: true},
-		Message:      sql.NullString{String: "", Valid: true},
-		Commit:       sql.NullString{String: "", Valid: true},
-		Sender:       sql.NullString{String: "", Valid: true},
-		Author:       sql.NullString{String: "", Valid: true},
-		Email:        sql.NullString{String: "", Valid: true},
-		Link:         sql.NullString{String: "", Valid: true},
-		Branch:       sql.NullString{String: "", Valid: true},
-		Ref:          sql.NullString{String: "", Valid: true},
-		BaseRef:      sql.NullString{String: "", Valid: true},
-		Host:         sql.NullString{String: "", Valid: true},
-		Runtime:      sql.NullString{String: "", Valid: true},
-		Distribution: sql.NullString{String: "", Valid: true},
-	}
+	var b *Build
+
 	want := &Build{
 		ID:           sql.NullInt64{Int64: 0, Valid: false},
 		RepoID:       sql.NullInt64{Int64: 0, Valid: false},
@@ -97,93 +68,69 @@ func TestDatabase_Build_Nullify(t *testing.T) {
 		Distribution: sql.NullString{String: "", Valid: false},
 	}
 
-	// run test
-	got := b.Nullify()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Nullify is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		build *Build
+		want  *Build
+	}{
+		{
+			build: testBuild(),
+			want:  testBuild(),
+		},
+		{
+			build: b,
+			want:  nil,
+		},
+		{
+			build: new(Build),
+			want:  want,
+		},
 	}
-}
 
-func TestDatabase_Build_Nullify_Empty(t *testing.T) {
-	// setup types
-	var b *Build
+	// run tests
+	for _, test := range tests {
+		got := test.build.Nullify()
 
-	// run test
-	got := b.Nullify()
-
-	if got != nil {
-		t.Errorf("Nullify is %v, want nil", got)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_Build_ToLibrary(t *testing.T) {
 	// setup types
-	sqlNum := sql.NullInt32{Int32: 1, Valid: true}
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	want := &library.Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
-	b := &Build{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		RepoID:       sql.NullInt64{Int64: num64, Valid: true},
-		Number:       sqlNum,
-		Parent:       sqlNum,
-		Event:        sql.NullString{String: str, Valid: true},
-		Status:       sql.NullString{String: str, Valid: true},
-		Error:        sql.NullString{String: str, Valid: true},
-		Enqueued:     sql.NullInt64{Int64: num64, Valid: true},
-		Created:      sql.NullInt64{Int64: num64, Valid: true},
-		Started:      sql.NullInt64{Int64: num64, Valid: true},
-		Finished:     sql.NullInt64{Int64: num64, Valid: true},
-		Deploy:       sql.NullString{String: str, Valid: true},
-		Clone:        sql.NullString{String: str, Valid: true},
-		Source:       sql.NullString{String: str, Valid: true},
-		Title:        sql.NullString{String: str, Valid: true},
-		Message:      sql.NullString{String: str, Valid: true},
-		Commit:       sql.NullString{String: str, Valid: true},
-		Sender:       sql.NullString{String: str, Valid: true},
-		Author:       sql.NullString{String: str, Valid: true},
-		Email:        sql.NullString{String: str, Valid: true},
-		Link:         sql.NullString{String: str, Valid: true},
-		Branch:       sql.NullString{String: str, Valid: true},
-		Ref:          sql.NullString{String: str, Valid: true},
-		BaseRef:      sql.NullString{String: str, Valid: true},
-		Host:         sql.NullString{String: str, Valid: true},
-		Runtime:      sql.NullString{String: str, Valid: true},
-		Distribution: sql.NullString{String: str, Valid: true},
-	}
+	want := new(library.Build)
+
+	want.SetID(1)
+	want.SetRepoID(1)
+	want.SetNumber(1)
+	want.SetParent(1)
+	want.SetEvent("push")
+	want.SetStatus("running")
+	want.SetError("")
+	want.SetEnqueued(1563474077)
+	want.SetCreated(1563474076)
+	want.SetStarted(1563474078)
+	want.SetFinished(1563474079)
+	want.SetDeploy("")
+	want.SetClone("https://github.com/github/octocat.git")
+	want.SetSource("https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163")
+	want.SetTitle("push received from https://github.com/github/octocat")
+	want.SetMessage("First commit...")
+	want.SetCommit("48afb5bdc41ad69bf22588491333f7cf71135163")
+	want.SetSender("OctoKitty")
+	want.SetAuthor("OctoKitty")
+	want.SetEmail("OctoKitty@github.com")
+	want.SetLink("https://example.company.com/github/octocat/1")
+	want.SetBranch("master")
+	want.SetRef("refs/heads/master")
+	want.SetBaseRef("")
+	want.SetHost("example.company.com")
+	want.SetRuntime("docker")
+	want.SetDistribution("linux")
 
 	// run test
-	got := b.ToLibrary()
+	got := testBuild().ToLibrary()
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ToLibrary is %v, want %v", got, want)
@@ -191,116 +138,82 @@ func TestDatabase_Build_ToLibrary(t *testing.T) {
 }
 
 func TestDatabase_Build_Validate(t *testing.T) {
-	// setup types
-	b := &Build{
-		ID:     sql.NullInt64{Int64: 1, Valid: true},
-		RepoID: sql.NullInt64{Int64: 1, Valid: true},
-		Number: sql.NullInt32{Int32: 1, Valid: true},
+	// setup tests
+	tests := []struct {
+		failure bool
+		build   *Build
+	}{
+		{
+			failure: false,
+			build:   testBuild(),
+		},
+		{ // no repo_id set for build
+			failure: true,
+			build: &Build{
+				ID:     sql.NullInt64{Int64: 1, Valid: true},
+				Number: sql.NullInt32{Int32: 1, Valid: true},
+			},
+		},
+		{ // no number set for build
+			failure: true,
+			build: &Build{
+				ID:     sql.NullInt64{Int64: 1, Valid: true},
+				RepoID: sql.NullInt64{Int64: 1, Valid: true},
+			},
+		},
 	}
 
-	// run test
-	err := b.Validate()
+	// run tests
+	for _, test := range tests {
+		err := test.build.Validate()
 
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
-	}
-}
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
 
-func TestDatabase_Build_Validate_NoRepoID(t *testing.T) {
-	// setup types
-	b := &Build{
-		ID:     sql.NullInt64{Int64: 1, Valid: true},
-		Number: sql.NullInt32{Int32: 1, Valid: true},
-	}
+			continue
+		}
 
-	// run test
-	err := b.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Build_Validate_NoNumber(t *testing.T) {
-	// setup types
-	b := &Build{
-		ID:     sql.NullInt64{Int64: 1, Valid: true},
-		RepoID: sql.NullInt64{Int64: 1, Valid: true},
-	}
-
-	// run test
-	err := b.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }
 
 func TestDatabase_BuildFromLibrary(t *testing.T) {
 	// setup types
-	sqlNum := sql.NullInt32{Int32: 1, Valid: true}
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	want := &Build{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		RepoID:       sql.NullInt64{Int64: num64, Valid: true},
-		Number:       sqlNum,
-		Parent:       sqlNum,
-		Event:        sql.NullString{String: str, Valid: true},
-		Status:       sql.NullString{String: str, Valid: true},
-		Error:        sql.NullString{String: str, Valid: true},
-		Enqueued:     sql.NullInt64{Int64: num64, Valid: true},
-		Created:      sql.NullInt64{Int64: num64, Valid: true},
-		Started:      sql.NullInt64{Int64: num64, Valid: true},
-		Finished:     sql.NullInt64{Int64: num64, Valid: true},
-		Deploy:       sql.NullString{String: str, Valid: true},
-		Clone:        sql.NullString{String: str, Valid: true},
-		Source:       sql.NullString{String: str, Valid: true},
-		Title:        sql.NullString{String: str, Valid: true},
-		Message:      sql.NullString{String: str, Valid: true},
-		Commit:       sql.NullString{String: str, Valid: true},
-		Sender:       sql.NullString{String: str, Valid: true},
-		Author:       sql.NullString{String: str, Valid: true},
-		Email:        sql.NullString{String: str, Valid: true},
-		Link:         sql.NullString{String: str, Valid: true},
-		Branch:       sql.NullString{String: str, Valid: true},
-		Ref:          sql.NullString{String: str, Valid: true},
-		BaseRef:      sql.NullString{String: str, Valid: true},
-		Host:         sql.NullString{String: str, Valid: true},
-		Runtime:      sql.NullString{String: str, Valid: true},
-		Distribution: sql.NullString{String: str, Valid: true},
-	}
+	b := new(library.Build)
 
-	b := &library.Build{
-		ID:           &num64,
-		RepoID:       &num64,
-		Number:       &num,
-		Parent:       &num,
-		Event:        &str,
-		Status:       &str,
-		Error:        &str,
-		Enqueued:     &num64,
-		Created:      &num64,
-		Started:      &num64,
-		Finished:     &num64,
-		Deploy:       &str,
-		Clone:        &str,
-		Source:       &str,
-		Title:        &str,
-		Message:      &str,
-		Commit:       &str,
-		Sender:       &str,
-		Author:       &str,
-		Email:        &str,
-		Link:         &str,
-		Branch:       &str,
-		Ref:          &str,
-		BaseRef:      &str,
-		Host:         &str,
-		Runtime:      &str,
-		Distribution: &str,
-	}
+	b.SetID(1)
+	b.SetRepoID(1)
+	b.SetNumber(1)
+	b.SetParent(1)
+	b.SetEvent("push")
+	b.SetStatus("running")
+	b.SetError("")
+	b.SetEnqueued(1563474077)
+	b.SetCreated(1563474076)
+	b.SetStarted(1563474078)
+	b.SetFinished(1563474079)
+	b.SetDeploy("")
+	b.SetClone("https://github.com/github/octocat.git")
+	b.SetSource("https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163")
+	b.SetTitle("push received from https://github.com/github/octocat")
+	b.SetMessage("First commit...")
+	b.SetCommit("48afb5bdc41ad69bf22588491333f7cf71135163")
+	b.SetSender("OctoKitty")
+	b.SetAuthor("OctoKitty")
+	b.SetEmail("OctoKitty@github.com")
+	b.SetLink("https://example.company.com/github/octocat/1")
+	b.SetBranch("master")
+	b.SetRef("refs/heads/master")
+	b.SetBaseRef("")
+	b.SetHost("example.company.com")
+	b.SetRuntime("docker")
+	b.SetDistribution("linux")
+
+	want := testBuild()
 
 	// run test
 	got := BuildFromLibrary(b)
@@ -319,4 +232,38 @@ func randomString(n int) string {
 	}
 
 	return string(b)
+}
+
+// testBuild is a test helper function to create a Build
+// type with all fields set to a fake value.
+func testBuild() *Build {
+	return &Build{
+		ID:           sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:       sql.NullInt64{Int64: 1, Valid: true},
+		Number:       sql.NullInt32{Int32: 1, Valid: true},
+		Parent:       sql.NullInt32{Int32: 1, Valid: true},
+		Event:        sql.NullString{String: "push", Valid: true},
+		Status:       sql.NullString{String: "running", Valid: true},
+		Error:        sql.NullString{String: "", Valid: false},
+		Enqueued:     sql.NullInt64{Int64: 1563474077, Valid: true},
+		Created:      sql.NullInt64{Int64: 1563474076, Valid: true},
+		Started:      sql.NullInt64{Int64: 1563474078, Valid: true},
+		Finished:     sql.NullInt64{Int64: 1563474079, Valid: true},
+		Deploy:       sql.NullString{String: "", Valid: false},
+		Clone:        sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
+		Source:       sql.NullString{String: "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163", Valid: true},
+		Title:        sql.NullString{String: "push received from https://github.com/github/octocat", Valid: true},
+		Message:      sql.NullString{String: "First commit...", Valid: true},
+		Commit:       sql.NullString{String: "48afb5bdc41ad69bf22588491333f7cf71135163", Valid: true},
+		Sender:       sql.NullString{String: "OctoKitty", Valid: true},
+		Author:       sql.NullString{String: "OctoKitty", Valid: true},
+		Email:        sql.NullString{String: "OctoKitty@github.com", Valid: true},
+		Link:         sql.NullString{String: "https://example.company.com/github/octocat/1", Valid: true},
+		Branch:       sql.NullString{String: "master", Valid: true},
+		Ref:          sql.NullString{String: "refs/heads/master", Valid: true},
+		BaseRef:      sql.NullString{String: "", Valid: false},
+		Host:         sql.NullString{String: "example.company.com", Valid: true},
+		Runtime:      sql.NullString{String: "docker", Valid: true},
+		Distribution: sql.NullString{String: "linux", Valid: true},
+	}
 }

--- a/database/context_test.go
+++ b/database/context_test.go
@@ -6,61 +6,48 @@ package database
 
 import (
 	"context"
-	"database/sql"
 	"testing"
 )
 
 func TestDatabase_BuildFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Build{ID: sql.NullInt64{Int64: 1, Valid: true}}
+	b := testBuild()
 
-	// setup context
-	ctx = context.WithValue(ctx, buildKey, want)
-
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != want {
-		t.Errorf("BuildFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Build
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), buildKey, b),
+			want: b,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), buildKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestDatabase_BuildFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := BuildFromContext(test.ctx)
 
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("BuildFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_BuildFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, buildKey, id)
-
-	// run test
-	got := BuildFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("BuildFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("BuildFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_BuildWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Build{ID: sql.NullInt64{Int64: 1, Valid: true}}
+	want := testBuild()
 
 	// setup context
-	ctx = BuildWithContext(ctx, want)
+	ctx := BuildWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(buildKey)
@@ -72,59 +59,43 @@ func TestDatabase_BuildWithContext(t *testing.T) {
 
 func TestDatabase_LogFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Log{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
+	l := testLog()
+
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Log
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), logKey, l),
+			want: l,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), logKey, "foo"),
+			want: nil,
+		},
 	}
 
-	// setup context
-	ctx = context.WithValue(ctx, logKey, want)
+	// run tests
+	for _, test := range tests {
+		got := LogFromContext(test.ctx)
 
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != want {
-		t.Errorf("LogFromContext is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_LogFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("LogFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_LogFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, logKey, id)
-
-	// run test
-	got := LogFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("LogFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("LogFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_LogWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Log{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
-	}
+	want := testLog()
 
 	// setup context
-	ctx = LogWithContext(ctx, want)
+	ctx := LogWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(logKey)
@@ -136,59 +107,43 @@ func TestDatabase_LogWithContext(t *testing.T) {
 
 func TestDatabase_RepoFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Repo{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
+	r := testRepo()
+
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Repo
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), repoKey, r),
+			want: r,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), repoKey, "foo"),
+			want: nil,
+		},
 	}
 
-	// setup context
-	ctx = context.WithValue(ctx, repoKey, want)
+	// run tests
+	for _, test := range tests {
+		got := RepoFromContext(test.ctx)
 
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != want {
-		t.Errorf("RepoFromContext is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_RepoFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("RepoFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_RepoFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, repoKey, id)
-
-	// run test
-	got := RepoFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("RepoFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("RepoFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_RepoWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Repo{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
-	}
+	want := testRepo()
 
 	// setup context
-	ctx = RepoWithContext(ctx, want)
+	ctx := RepoWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(repoKey)
@@ -200,55 +155,43 @@ func TestDatabase_RepoWithContext(t *testing.T) {
 
 func TestDatabase_SecretFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Secret{ID: sql.NullInt64{Int64: 1, Valid: true}}
+	s := testSecret()
 
-	// setup context
-	ctx = context.WithValue(ctx, secretKey, want)
-
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != want {
-		t.Errorf("SecretFromContext is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Secret
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), secretKey, s),
+			want: s,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), secretKey, "foo"),
+			want: nil,
+		},
 	}
-}
 
-func TestDatabase_SecretFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
+	// run tests
+	for _, test := range tests {
+		got := SecretFromContext(test.ctx)
 
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("SecretFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_SecretFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, secretKey, id)
-
-	// run test
-	got := SecretFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("SecretFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("SecretFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_SecretWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Secret{ID: sql.NullInt64{Int64: 1, Valid: true}}
+	want := testSecret()
 
 	// setup context
-	ctx = SecretWithContext(ctx, want)
+	ctx := SecretWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(secretKey)
@@ -260,59 +203,43 @@ func TestDatabase_SecretWithContext(t *testing.T) {
 
 func TestDatabase_StepFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Step{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
+	s := testStep()
+
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *Step
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), stepKey, s),
+			want: s,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), stepKey, "foo"),
+			want: nil,
+		},
 	}
 
-	// setup context
-	ctx = context.WithValue(ctx, stepKey, want)
+	// run tests
+	for _, test := range tests {
+		got := StepFromContext(test.ctx)
 
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != want {
-		t.Errorf("StepFromContext is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_StepFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("StepFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_StepFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, stepKey, id)
-
-	// run test
-	got := StepFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("StepFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("StepFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_StepWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &Step{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
-	}
+	want := testStep()
 
 	// setup context
-	ctx = StepWithContext(ctx, want)
+	ctx := StepWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(stepKey)
@@ -324,59 +251,43 @@ func TestDatabase_StepWithContext(t *testing.T) {
 
 func TestDatabase_UserFromContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &User{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
+	u := testUser()
+
+	// setup tests
+	tests := []struct {
+		ctx  context.Context
+		want *User
+	}{
+		{
+			ctx:  context.WithValue(context.Background(), userKey, u),
+			want: u,
+		},
+		{
+			ctx:  context.Background(),
+			want: nil,
+		},
+		{
+			ctx:  context.WithValue(context.Background(), userKey, "foo"),
+			want: nil,
+		},
 	}
 
-	// setup context
-	ctx = context.WithValue(ctx, userKey, want)
+	// run tests
+	for _, test := range tests {
+		got := UserFromContext(test.ctx)
 
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != want {
-		t.Errorf("UserFromContext is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_UserFromContext_Empty(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("UserFromContext is %v, want nil", got)
-	}
-}
-
-func TestDatabase_UserFromContext_WrongType(t *testing.T) {
-	// setup types
-	ctx := context.Background()
-	id := int64(1)
-
-	// setup context
-	ctx = context.WithValue(ctx, userKey, id)
-
-	// run test
-	got := UserFromContext(ctx)
-
-	if got != nil {
-		t.Errorf("UserFromContext is %v, want nil", got)
+		if got != test.want {
+			t.Errorf("UserFromContext is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_UserWithContext(t *testing.T) {
 	// setup types
-	ctx := context.Background()
-	want := &User{
-		ID: sql.NullInt64{Int64: 1, Valid: true},
-	}
+	want := testUser()
 
 	// setup context
-	ctx = UserWithContext(ctx, want)
+	ctx := UserWithContext(context.Background(), want)
 
 	// run test
 	got := ctx.Value(userKey)

--- a/database/hook_test.go
+++ b/database/hook_test.go
@@ -15,20 +15,8 @@ import (
 
 func TestDatabase_Hook_Nullify(t *testing.T) {
 	// setup types
-	h := &Hook{
-		ID:       sql.NullInt64{Int64: 0, Valid: true},
-		RepoID:   sql.NullInt64{Int64: 0, Valid: true},
-		BuildID:  sql.NullInt64{Int64: 0, Valid: true},
-		Number:   sql.NullInt32{Int32: 0, Valid: true},
-		SourceID: sql.NullString{String: "", Valid: true},
-		Created:  sql.NullInt64{Int64: 0, Valid: true},
-		Host:     sql.NullString{String: "", Valid: true},
-		Event:    sql.NullString{String: "", Valid: true},
-		Branch:   sql.NullString{String: "", Valid: true},
-		Error:    sql.NullString{String: "", Valid: true},
-		Status:   sql.NullString{String: "", Valid: true},
-		Link:     sql.NullString{String: "", Valid: true},
-	}
+	var h *Hook
+
 	want := &Hook{
 		ID:       sql.NullInt64{Int64: 0, Valid: false},
 		RepoID:   sql.NullInt64{Int64: 0, Valid: false},
@@ -44,23 +32,32 @@ func TestDatabase_Hook_Nullify(t *testing.T) {
 		Link:     sql.NullString{String: "", Valid: false},
 	}
 
-	// run test
-	got := h.Nullify()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Nullify is %v, want %v", got, want)
+	// setup tests
+	tests := []struct {
+		hook *Hook
+		want *Hook
+	}{
+		{
+			hook: testHook(),
+			want: testHook(),
+		},
+		{
+			hook: h,
+			want: nil,
+		},
+		{
+			hook: new(Hook),
+			want: want,
+		},
 	}
-}
 
-func TestDatabase_Hook_Nullify_Empty(t *testing.T) {
-	// setup types
-	var h *Hook
+	// run tests
+	for _, test := range tests {
+		got := test.hook.Nullify()
 
-	// run test
-	got := h.Nullify()
-
-	if got != nil {
-		t.Errorf("Nullify is %v, want nil", got)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
 	}
 }
 
@@ -204,5 +201,24 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("HookFromLibrary is %v, want %v", got, want)
+	}
+}
+
+// testHook is a test helper function to create a Hook
+// type with all fields set to a fake value.
+func testHook() *Hook {
+	return &Hook{
+		ID:       sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:   sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:  sql.NullInt64{Int64: 1, Valid: true},
+		Number:   sql.NullInt32{Int32: 1, Valid: true},
+		SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:  sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:     sql.NullString{String: "github.com", Valid: true},
+		Event:    sql.NullString{String: "push", Valid: true},
+		Branch:   sql.NullString{String: "master", Valid: true},
+		Error:    sql.NullString{String: "", Valid: false},
+		Status:   sql.NullString{String: "success", Valid: true},
+		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
 	}
 }

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -14,120 +14,77 @@ import (
 
 func TestDatabase_Repo_Nullify(t *testing.T) {
 	// setup types
-	r := &Repo{
-		ID:           sql.NullInt64{Int64: 0, Valid: true},
-		UserID:       sql.NullInt64{Int64: 0, Valid: true},
-		Hash:         sql.NullString{String: "", Valid: true},
-		Org:          sql.NullString{String: "", Valid: true},
-		Name:         sql.NullString{String: "", Valid: true},
-		FullName:     sql.NullString{String: "", Valid: true},
-		Link:         sql.NullString{String: "", Valid: true},
-		Clone:        sql.NullString{String: "", Valid: true},
-		Branch:       sql.NullString{String: "", Valid: true},
-		Timeout:      sql.NullInt64{Int64: 0, Valid: true},
-		Visibility:   sql.NullString{String: "", Valid: true},
-		Private:      sql.NullBool{Bool: false, Valid: true},
-		Trusted:      sql.NullBool{Bool: false, Valid: true},
-		Active:       sql.NullBool{Bool: false, Valid: true},
-		AllowPull:    sql.NullBool{Bool: false, Valid: true},
-		AllowPush:    sql.NullBool{Bool: false, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
-		AllowTag:     sql.NullBool{Bool: false, Valid: true},
-		AllowComment: sql.NullBool{Bool: false, Valid: true},
-	}
-	want := &Repo{
-		ID:           sql.NullInt64{Int64: 0, Valid: false},
-		UserID:       sql.NullInt64{Int64: 0, Valid: false},
-		Hash:         sql.NullString{String: "", Valid: false},
-		Org:          sql.NullString{String: "", Valid: false},
-		Name:         sql.NullString{String: "", Valid: false},
-		FullName:     sql.NullString{String: "", Valid: false},
-		Link:         sql.NullString{String: "", Valid: false},
-		Clone:        sql.NullString{String: "", Valid: false},
-		Branch:       sql.NullString{String: "", Valid: false},
-		Timeout:      sql.NullInt64{Int64: 0, Valid: false},
-		Visibility:   sql.NullString{String: "", Valid: false},
-		Private:      sql.NullBool{Bool: false, Valid: true},
-		Trusted:      sql.NullBool{Bool: false, Valid: true},
-		Active:       sql.NullBool{Bool: false, Valid: true},
-		AllowPull:    sql.NullBool{Bool: false, Valid: true},
-		AllowPush:    sql.NullBool{Bool: false, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
-		AllowTag:     sql.NullBool{Bool: false, Valid: true},
-		AllowComment: sql.NullBool{Bool: false, Valid: true},
-	}
-
-	// run test
-	got := r.Nullify()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Nullify is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_Repo_Nullify_Empty(t *testing.T) {
-	// setup types
 	var r *Repo
 
-	// run test
-	got := r.Nullify()
+	want := &Repo{
+		ID:         sql.NullInt64{Int64: 0, Valid: false},
+		UserID:     sql.NullInt64{Int64: 0, Valid: false},
+		Hash:       sql.NullString{String: "", Valid: false},
+		Org:        sql.NullString{String: "", Valid: false},
+		Name:       sql.NullString{String: "", Valid: false},
+		FullName:   sql.NullString{String: "", Valid: false},
+		Link:       sql.NullString{String: "", Valid: false},
+		Clone:      sql.NullString{String: "", Valid: false},
+		Branch:     sql.NullString{String: "", Valid: false},
+		Timeout:    sql.NullInt64{Int64: 0, Valid: false},
+		Visibility: sql.NullString{String: "", Valid: false},
+	}
 
-	if got != nil {
-		t.Errorf("Nullify is %v, want nil", got)
+	// setup tests
+	tests := []struct {
+		repo *Repo
+		want *Repo
+	}{
+		{
+			repo: testRepo(),
+			want: testRepo(),
+		},
+		{
+			repo: r,
+			want: nil,
+		},
+		{
+			repo: new(Repo),
+			want: want,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.repo.Nullify()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_Repo_ToLibrary(t *testing.T) {
 	// setup types
-	booL := false
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	want := &library.Repo{
-		ID:           &num64,
-		UserID:       &num64,
-		Hash:         &str,
-		Org:          &str,
-		Name:         &str,
-		FullName:     &str,
-		Link:         &str,
-		Clone:        &str,
-		Branch:       &str,
-		Timeout:      &num64,
-		Visibility:   &str,
-		Private:      &booL,
-		Trusted:      &booL,
-		Active:       &booL,
-		AllowPull:    &booL,
-		AllowPush:    &booL,
-		AllowDeploy:  &booL,
-		AllowTag:     &booL,
-		AllowComment: &booL,
-	}
-	r := &Repo{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		UserID:       sql.NullInt64{Int64: num64, Valid: true},
-		Hash:         sql.NullString{String: str, Valid: true},
-		Org:          sql.NullString{String: str, Valid: true},
-		Name:         sql.NullString{String: str, Valid: true},
-		FullName:     sql.NullString{String: str, Valid: true},
-		Link:         sql.NullString{String: str, Valid: true},
-		Clone:        sql.NullString{String: str, Valid: true},
-		Branch:       sql.NullString{String: str, Valid: true},
-		Timeout:      sql.NullInt64{Int64: num64, Valid: true},
-		Visibility:   sql.NullString{String: str, Valid: true},
-		Private:      sql.NullBool{Bool: booL, Valid: true},
-		Trusted:      sql.NullBool{Bool: booL, Valid: true},
-		Active:       sql.NullBool{Bool: booL, Valid: true},
-		AllowPull:    sql.NullBool{Bool: booL, Valid: true},
-		AllowPush:    sql.NullBool{Bool: booL, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: booL, Valid: true},
-		AllowTag:     sql.NullBool{Bool: booL, Valid: true},
-		AllowComment: sql.NullBool{Bool: booL, Valid: true},
-	}
+	want := new(library.Repo)
+
+	want.SetID(1)
+	want.SetUserID(1)
+	want.SetHash("superSecretHash")
+	want.SetOrg("github")
+	want.SetName("octocat")
+	want.SetFullName("github/octocat")
+	want.SetLink("https://github.com/github/octocat")
+	want.SetClone("https://github.com/github/octocat.git")
+	want.SetBranch("master")
+	want.SetTimeout(30)
+	want.SetVisibility("public")
+	want.SetPrivate(false)
+	want.SetTrusted(false)
+	want.SetActive(true)
+	want.SetAllowPull(false)
+	want.SetAllowPush(true)
+	want.SetAllowDeploy(false)
+	want.SetAllowTag(false)
+	want.SetAllowComment(false)
 
 	// run test
-	got := r.ToLibrary()
+	got := testRepo().ToLibrary()
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ToLibrary is %v, want %v", got, want)
@@ -135,189 +92,157 @@ func TestDatabase_Repo_ToLibrary(t *testing.T) {
 }
 
 func TestDatabase_Repo_Validate(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		UserID:     sql.NullInt64{Int64: 1, Valid: true},
-		Hash:       sql.NullString{String: "baz", Valid: true},
-		Org:        sql.NullString{String: "foo", Valid: true},
-		Name:       sql.NullString{String: "bar", Valid: true},
-		FullName:   sql.NullString{String: "foo/bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
+	// setup tests
+	tests := []struct {
+		failure bool
+		repo    *Repo
+	}{
+		{
+			failure: false,
+			repo:    testRepo(),
+		},
+		{ // no user_id set for repo
+			failure: true,
+			repo: &Repo{
+				ID:         sql.NullInt64{Int64: 1, Valid: true},
+				Hash:       sql.NullString{String: "superSecretHash", Valid: true},
+				Org:        sql.NullString{String: "github", Valid: true},
+				Name:       sql.NullString{String: "octocat", Valid: true},
+				FullName:   sql.NullString{String: "github/octocat", Valid: true},
+				Visibility: sql.NullString{String: "public", Valid: true},
+			},
+		},
+		{ // no hash set for repo
+			failure: true,
+			repo: &Repo{
+				ID:         sql.NullInt64{Int64: 1, Valid: true},
+				UserID:     sql.NullInt64{Int64: 1, Valid: true},
+				Org:        sql.NullString{String: "github", Valid: true},
+				Name:       sql.NullString{String: "octocat", Valid: true},
+				FullName:   sql.NullString{String: "github/octocat", Valid: true},
+				Visibility: sql.NullString{String: "public", Valid: true},
+			},
+		},
+		{ // no org set for repo
+			failure: true,
+			repo: &Repo{
+				ID:         sql.NullInt64{Int64: 1, Valid: true},
+				UserID:     sql.NullInt64{Int64: 1, Valid: true},
+				Hash:       sql.NullString{String: "superSecretHash", Valid: true},
+				Name:       sql.NullString{String: "octocat", Valid: true},
+				FullName:   sql.NullString{String: "github/octocat", Valid: true},
+				Visibility: sql.NullString{String: "public", Valid: true},
+			},
+		},
+		{ // no name set for repo
+			failure: true,
+			repo: &Repo{
+				ID:         sql.NullInt64{Int64: 1, Valid: true},
+				UserID:     sql.NullInt64{Int64: 1, Valid: true},
+				Hash:       sql.NullString{String: "superSecretHash", Valid: true},
+				Org:        sql.NullString{String: "github", Valid: true},
+				FullName:   sql.NullString{String: "github/octocat", Valid: true},
+				Visibility: sql.NullString{String: "public", Valid: true},
+			},
+		},
+		{ // no full_name set for repo
+			failure: true,
+			repo: &Repo{
+				ID:         sql.NullInt64{Int64: 1, Valid: true},
+				UserID:     sql.NullInt64{Int64: 1, Valid: true},
+				Hash:       sql.NullString{String: "superSecretHash", Valid: true},
+				Org:        sql.NullString{String: "github", Valid: true},
+				Name:       sql.NullString{String: "octocat", Valid: true},
+				Visibility: sql.NullString{String: "public", Valid: true},
+			},
+		},
+		{ // no visibility set for repo
+			failure: true,
+			repo: &Repo{
+				ID:       sql.NullInt64{Int64: 1, Valid: true},
+				UserID:   sql.NullInt64{Int64: 1, Valid: true},
+				Hash:     sql.NullString{String: "superSecretHash", Valid: true},
+				Org:      sql.NullString{String: "github", Valid: true},
+				Name:     sql.NullString{String: "octocat", Valid: true},
+				FullName: sql.NullString{String: "github/octocat", Valid: true},
+			},
+		},
 	}
 
-	// run test
-	err := r.Validate()
+	// run tests
+	for _, test := range tests {
+		err := test.repo.Validate()
 
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
-	}
-}
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
 
-func TestDatabase_Repo_Validate_NoUserID(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		Org:        sql.NullString{String: "foo", Valid: true},
-		Hash:       sql.NullString{String: "baz", Valid: true},
-		Name:       sql.NullString{String: "bar", Valid: true},
-		FullName:   sql.NullString{String: "foo/bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
-	}
+			continue
+		}
 
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Repo_Validate_NoHash(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		UserID:     sql.NullInt64{Int64: 1, Valid: true},
-		Org:        sql.NullString{String: "foo", Valid: true},
-		Name:       sql.NullString{String: "bar", Valid: true},
-		FullName:   sql.NullString{String: "foo/bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
-	}
-
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Repo_Validate_NoOrg(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		UserID:     sql.NullInt64{Int64: 1, Valid: true},
-		Hash:       sql.NullString{String: "baz", Valid: true},
-		Name:       sql.NullString{String: "bar", Valid: true},
-		FullName:   sql.NullString{String: "foo/bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
-	}
-
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Repo_Validate_NoName(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		UserID:     sql.NullInt64{Int64: 1, Valid: true},
-		Hash:       sql.NullString{String: "baz", Valid: true},
-		Org:        sql.NullString{String: "foo", Valid: true},
-		FullName:   sql.NullString{String: "foo/bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
-	}
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Repo_Validate_NoFullName(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:         sql.NullInt64{Int64: 1, Valid: true},
-		UserID:     sql.NullInt64{Int64: 1, Valid: true},
-		Hash:       sql.NullString{String: "baz", Valid: true},
-		Org:        sql.NullString{String: "foo", Valid: true},
-		Name:       sql.NullString{String: "bar", Valid: true},
-		Visibility: sql.NullString{String: "public", Valid: true},
-	}
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Repo_Validate_NoVisibility(t *testing.T) {
-	// setup types
-	r := &Repo{
-		ID:       sql.NullInt64{Int64: 1, Valid: true},
-		UserID:   sql.NullInt64{Int64: 1, Valid: true},
-		Hash:     sql.NullString{String: "baz", Valid: true},
-		Org:      sql.NullString{String: "foo", Valid: true},
-		Name:     sql.NullString{String: "bar", Valid: true},
-		FullName: sql.NullString{String: "foo/bar", Valid: true},
-	}
-	// run test
-	err := r.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }
 
 func TestDatabase_RepoFromLibrary(t *testing.T) {
 	// setup types
-	booL := false
-	num := 1
-	num64 := int64(num)
-	str := "foo"
-	want := &Repo{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		UserID:       sql.NullInt64{Int64: num64, Valid: true},
-		Hash:         sql.NullString{String: str, Valid: true},
-		Org:          sql.NullString{String: str, Valid: true},
-		Name:         sql.NullString{String: str, Valid: true},
-		FullName:     sql.NullString{String: str, Valid: true},
-		Link:         sql.NullString{String: str, Valid: true},
-		Clone:        sql.NullString{String: str, Valid: true},
-		Branch:       sql.NullString{String: str, Valid: true},
-		Timeout:      sql.NullInt64{Int64: num64, Valid: true},
-		Visibility:   sql.NullString{String: str, Valid: true},
-		Private:      sql.NullBool{Bool: booL, Valid: true},
-		Trusted:      sql.NullBool{Bool: booL, Valid: true},
-		Active:       sql.NullBool{Bool: booL, Valid: true},
-		AllowPull:    sql.NullBool{Bool: booL, Valid: true},
-		AllowPush:    sql.NullBool{Bool: booL, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: booL, Valid: true},
-		AllowTag:     sql.NullBool{Bool: booL, Valid: true},
-		AllowComment: sql.NullBool{Bool: booL, Valid: true},
-	}
-	r := &library.Repo{
-		ID:           &num64,
-		UserID:       &num64,
-		Hash:         &str,
-		Org:          &str,
-		Name:         &str,
-		FullName:     &str,
-		Link:         &str,
-		Clone:        &str,
-		Branch:       &str,
-		Timeout:      &num64,
-		Visibility:   &str,
-		Private:      &booL,
-		Trusted:      &booL,
-		Active:       &booL,
-		AllowPull:    &booL,
-		AllowPush:    &booL,
-		AllowDeploy:  &booL,
-		AllowTag:     &booL,
-		AllowComment: &booL,
-	}
+	r := new(library.Repo)
+
+	r.SetID(1)
+	r.SetUserID(1)
+	r.SetHash("superSecretHash")
+	r.SetOrg("github")
+	r.SetName("octocat")
+	r.SetFullName("github/octocat")
+	r.SetLink("https://github.com/github/octocat")
+	r.SetClone("https://github.com/github/octocat.git")
+	r.SetBranch("master")
+	r.SetTimeout(30)
+	r.SetVisibility("public")
+	r.SetPrivate(false)
+	r.SetTrusted(false)
+	r.SetActive(true)
+	r.SetAllowPull(false)
+	r.SetAllowPush(true)
+	r.SetAllowDeploy(false)
+	r.SetAllowTag(false)
+	r.SetAllowComment(false)
+
+	want := testRepo()
 
 	// run test
 	got := RepoFromLibrary(r)
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("RepoFromLibrary is %v, want %v", got, want)
+	}
+}
+
+// testRepo is a test helper function to create a Repo
+// type with all fields set to a fake value.
+func testRepo() *Repo {
+	return &Repo{
+		ID:           sql.NullInt64{Int64: 1, Valid: true},
+		UserID:       sql.NullInt64{Int64: 1, Valid: true},
+		Hash:         sql.NullString{String: "superSecretHash", Valid: true},
+		Org:          sql.NullString{String: "github", Valid: true},
+		Name:         sql.NullString{String: "octocat", Valid: true},
+		FullName:     sql.NullString{String: "github/octocat", Valid: true},
+		Link:         sql.NullString{String: "https://github.com/github/octocat", Valid: true},
+		Clone:        sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
+		Branch:       sql.NullString{String: "master", Valid: true},
+		Timeout:      sql.NullInt64{Int64: 30, Valid: true},
+		Visibility:   sql.NullString{String: "public", Valid: true},
+		Private:      sql.NullBool{Bool: false, Valid: true},
+		Trusted:      sql.NullBool{Bool: false, Valid: true},
+		Active:       sql.NullBool{Bool: true, Valid: true},
+		AllowPull:    sql.NullBool{Bool: false, Valid: true},
+		AllowPush:    sql.NullBool{Bool: true, Valid: true},
+		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
+		AllowTag:     sql.NullBool{Bool: false, Valid: true},
+		AllowComment: sql.NullBool{Bool: false, Valid: true},
 	}
 }

--- a/database/secret_test.go
+++ b/database/secret_test.go
@@ -14,82 +14,64 @@ import (
 
 func TestDatabase_Secret_Nullify(t *testing.T) {
 	// setup types
-	s := &Secret{
-		ID:     sql.NullInt64{Int64: 0, Valid: true},
-		Org:    sql.NullString{String: "", Valid: true},
-		Repo:   sql.NullString{String: "", Valid: true},
-		Team:   sql.NullString{String: "", Valid: true},
-		Name:   sql.NullString{String: "", Valid: true},
-		Value:  sql.NullString{String: "", Valid: true},
-		Type:   sql.NullString{String: "", Valid: true},
-		Images: []string{},
-		Events: []string{},
-	}
-	want := &Secret{
-		ID:     sql.NullInt64{Int64: 0, Valid: false},
-		Org:    sql.NullString{String: "", Valid: false},
-		Repo:   sql.NullString{String: "", Valid: false},
-		Team:   sql.NullString{String: "", Valid: false},
-		Name:   sql.NullString{String: "", Valid: false},
-		Value:  sql.NullString{String: "", Valid: false},
-		Type:   sql.NullString{String: "", Valid: false},
-		Images: []string{},
-		Events: []string{},
-	}
-
-	// run test
-	got := s.Nullify()
-
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("Nullify is %v, want %v", got, want)
-	}
-}
-
-func TestDatabase_Secret_Nullify_Empty(t *testing.T) {
-	// setup types
 	var s *Secret
 
-	// run test
-	got := s.Nullify()
+	want := &Secret{
+		ID:    sql.NullInt64{Int64: 0, Valid: false},
+		Org:   sql.NullString{String: "", Valid: false},
+		Repo:  sql.NullString{String: "", Valid: false},
+		Team:  sql.NullString{String: "", Valid: false},
+		Name:  sql.NullString{String: "", Valid: false},
+		Value: sql.NullString{String: "", Valid: false},
+		Type:  sql.NullString{String: "", Valid: false},
+	}
 
-	if got != nil {
-		t.Errorf("Nullify is %v, want nil", got)
+	// setup tests
+	tests := []struct {
+		secret *Secret
+		want   *Secret
+	}{
+		{
+			secret: testSecret(),
+			want:   testSecret(),
+		},
+		{
+			secret: s,
+			want:   nil,
+		},
+		{
+			secret: new(Secret),
+			want:   want,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.secret.Nullify()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Nullify is %v, want %v", got, test.want)
+		}
 	}
 }
 
 func TestDatabase_Secret_ToLibrary(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	booL := false
-	want := &library.Secret{
-		ID:           &num64,
-		Org:          &str,
-		Repo:         &str,
-		Team:         &str,
-		Name:         &str,
-		Value:        &str,
-		Type:         &str,
-		Images:       &arr,
-		Events:       &arr,
-		AllowCommand: &booL,
-	}
-	s := &Secret{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		Org:          sql.NullString{String: str, Valid: true},
-		Repo:         sql.NullString{String: str, Valid: true},
-		Team:         sql.NullString{String: str, Valid: true},
-		Name:         sql.NullString{String: str, Valid: true},
-		Value:        sql.NullString{String: str, Valid: true},
-		Type:         sql.NullString{String: str, Valid: true},
-		Images:       arr,
-		Events:       arr,
-		AllowCommand: sql.NullBool{Bool: booL, Valid: true},
-	}
+	want := new(library.Secret)
+
+	want.SetID(1)
+	want.SetOrg("github")
+	want.SetRepo("octocat")
+	want.SetTeam("octokitties")
+	want.SetName("foo")
+	want.SetValue("bar")
+	want.SetType("repo")
+	want.SetImages([]string{"alpine"})
+	want.SetEvents([]string{"push", "tag", "deployment"})
+	want.SetAllowCommand(true)
 
 	// run test
-	got := s.ToLibrary()
+	got := testSecret().ToLibrary()
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("ToLibrary is %v, want %v", got, want)
@@ -98,174 +80,138 @@ func TestDatabase_Secret_ToLibrary(t *testing.T) {
 
 func TestDatabase_Secret_Validate(t *testing.T) {
 	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Org:   sql.NullString{String: "foo", Valid: true},
-		Repo:  sql.NullString{String: "bar", Valid: true},
-		Team:  sql.NullString{String: "foobar", Valid: true},
-		Name:  sql.NullString{String: "foo", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-		Type:  sql.NullString{String: "repo", Valid: true},
+	tests := []struct {
+		failure bool
+		secret  *Secret
+	}{
+		{
+			failure: false,
+			secret:  testSecret(),
+		},
+		{ // no name set for secret
+			failure: true,
+			secret: &Secret{
+				ID:    sql.NullInt64{Int64: 1, Valid: true},
+				Org:   sql.NullString{String: "github", Valid: true},
+				Repo:  sql.NullString{String: "octocat", Valid: true},
+				Team:  sql.NullString{String: "octokitties", Valid: true},
+				Value: sql.NullString{String: "bar", Valid: true},
+				Type:  sql.NullString{String: "repo", Valid: true},
+			},
+		},
+		{ // no org set for secret
+			failure: true,
+			secret: &Secret{
+				ID:    sql.NullInt64{Int64: 1, Valid: true},
+				Repo:  sql.NullString{String: "octocat", Valid: true},
+				Team:  sql.NullString{String: "octokitties", Valid: true},
+				Name:  sql.NullString{String: "foo", Valid: true},
+				Value: sql.NullString{String: "bar", Valid: true},
+				Type:  sql.NullString{String: "repo", Valid: true},
+			},
+		},
+		{ // no repo set for secret
+			failure: true,
+			secret: &Secret{
+				ID:    sql.NullInt64{Int64: 1, Valid: true},
+				Org:   sql.NullString{String: "github", Valid: true},
+				Team:  sql.NullString{String: "octokitties", Valid: true},
+				Name:  sql.NullString{String: "foo", Valid: true},
+				Value: sql.NullString{String: "bar", Valid: true},
+				Type:  sql.NullString{String: "repo", Valid: true},
+			},
+		},
+		{ // no team set for secret
+			failure: true,
+			secret: &Secret{
+				ID:    sql.NullInt64{Int64: 1, Valid: true},
+				Org:   sql.NullString{String: "github", Valid: true},
+				Repo:  sql.NullString{String: "octocat", Valid: true},
+				Name:  sql.NullString{String: "foo", Valid: true},
+				Value: sql.NullString{String: "bar", Valid: true},
+				Type:  sql.NullString{String: "shared", Valid: true},
+			},
+		},
+		{ // no type set for secret
+			failure: true,
+			secret: &Secret{
+				ID:    sql.NullInt64{Int64: 1, Valid: true},
+				Org:   sql.NullString{String: "github", Valid: true},
+				Repo:  sql.NullString{String: "octocat", Valid: true},
+				Team:  sql.NullString{String: "octokitties", Valid: true},
+				Name:  sql.NullString{String: "foo", Valid: true},
+				Value: sql.NullString{String: "bar", Valid: true},
+			},
+		},
+		{ // no value set for secret
+			failure: true,
+			secret: &Secret{
+				ID:   sql.NullInt64{Int64: 1, Valid: true},
+				Org:  sql.NullString{String: "github", Valid: true},
+				Repo: sql.NullString{String: "octocat", Valid: true},
+				Team: sql.NullString{String: "octokitties", Valid: true},
+				Name: sql.NullString{String: "foo", Valid: true},
+				Type: sql.NullString{String: "repo", Valid: true},
+			},
+		},
 	}
 
-	// run test
-	err := s.Validate()
+	// run tests
+	for _, test := range tests {
+		err := test.secret.Validate()
 
-	if err != nil {
-		t.Errorf("Validate returned err: %v", err)
-	}
-}
+		if test.failure {
+			if err == nil {
+				t.Errorf("Validate should have returned err")
+			}
 
-func TestDatabase_Secret_Validate_NoOrg(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Repo:  sql.NullString{String: "bar", Valid: true},
-		Team:  sql.NullString{String: "foobar", Valid: true},
-		Name:  sql.NullString{String: "foo", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-		Type:  sql.NullString{String: "repo", Valid: true},
-	}
+			continue
+		}
 
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Secret_Validate_NoType(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Org:   sql.NullString{String: "foo", Valid: true},
-		Repo:  sql.NullString{String: "bar", Valid: true},
-		Team:  sql.NullString{String: "foobar", Valid: true},
-		Name:  sql.NullString{String: "foo", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-	}
-
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Secret_Validate_NoRepo(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Org:   sql.NullString{String: "foo", Valid: true},
-		Team:  sql.NullString{String: "foobar", Valid: true},
-		Name:  sql.NullString{String: "foo", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-		Type:  sql.NullString{String: "repo", Valid: true},
-	}
-
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Secret_Validate_NoTeam(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Org:   sql.NullString{String: "foo", Valid: true},
-		Repo:  sql.NullString{String: "bar", Valid: true},
-		Name:  sql.NullString{String: "foo", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-		Type:  sql.NullString{String: "shared", Valid: true},
-	}
-
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Secret_Validate_NoName(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:    sql.NullInt64{Int64: 1, Valid: true},
-		Org:   sql.NullString{String: "foo", Valid: true},
-		Repo:  sql.NullString{String: "bar", Valid: true},
-		Team:  sql.NullString{String: "foobar", Valid: true},
-		Value: sql.NullString{String: "bar", Valid: true},
-		Type:  sql.NullString{String: "repo", Valid: true},
-	}
-
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
-	}
-}
-
-func TestDatabase_Secret_Validate_NoValue(t *testing.T) {
-	// setup types
-	s := &Secret{
-		ID:   sql.NullInt64{Int64: 1, Valid: true},
-		Org:  sql.NullString{String: "foo", Valid: true},
-		Repo: sql.NullString{String: "bar", Valid: true},
-		Team: sql.NullString{String: "foobar", Valid: true},
-		Name: sql.NullString{String: "foo", Valid: true},
-		Type: sql.NullString{String: "repo", Valid: true},
-	}
-
-	// run test
-	err := s.Validate()
-
-	if err == nil {
-		t.Errorf("Validate should have returned err")
+		if err != nil {
+			t.Errorf("Validate returned err: %v", err)
+		}
 	}
 }
 
 func TestDatabase_SecretFromLibrary(t *testing.T) {
 	// setup types
-	num64 := int64(1)
-	str := "foo"
-	arr := []string{"foo", "bar"}
-	booL := false
-	want := &Secret{
-		ID:           sql.NullInt64{Int64: num64, Valid: true},
-		Org:          sql.NullString{String: str, Valid: true},
-		Repo:         sql.NullString{String: str, Valid: true},
-		Team:         sql.NullString{String: str, Valid: true},
-		Name:         sql.NullString{String: str, Valid: true},
-		Value:        sql.NullString{String: str, Valid: true},
-		Type:         sql.NullString{String: str, Valid: true},
-		Images:       arr,
-		Events:       arr,
-		AllowCommand: sql.NullBool{Bool: booL, Valid: true},
-	}
+	s := new(library.Secret)
 
-	s := &library.Secret{
-		ID:           &num64,
-		Org:          &str,
-		Repo:         &str,
-		Team:         &str,
-		Name:         &str,
-		Value:        &str,
-		Type:         &str,
-		Images:       &arr,
-		Events:       &arr,
-		AllowCommand: &booL,
-	}
+	s.SetID(1)
+	s.SetOrg("github")
+	s.SetRepo("octocat")
+	s.SetTeam("octokitties")
+	s.SetName("foo")
+	s.SetValue("bar")
+	s.SetType("repo")
+	s.SetImages([]string{"alpine"})
+	s.SetEvents([]string{"push", "tag", "deployment"})
+	s.SetAllowCommand(true)
+
+	want := testSecret()
 
 	// run test
 	got := SecretFromLibrary(s)
 
 	if !reflect.DeepEqual(got, want) {
 		t.Errorf("SecretFromLibrary is %v, want %v", got, want)
+	}
+}
+
+// testSecret is a test helper function to create a Secret
+// type with all fields set to a fake value.
+func testSecret() *Secret {
+	return &Secret{
+		ID:           sql.NullInt64{Int64: 1, Valid: true},
+		Org:          sql.NullString{String: "github", Valid: true},
+		Repo:         sql.NullString{String: "octocat", Valid: true},
+		Team:         sql.NullString{String: "octokitties", Valid: true},
+		Name:         sql.NullString{String: "foo", Valid: true},
+		Value:        sql.NullString{String: "bar", Valid: true},
+		Type:         sql.NullString{String: "repo", Valid: true},
+		Images:       []string{"alpine"},
+		Events:       []string{"push", "tag", "deployment"},
+		AllowCommand: sql.NullBool{Bool: true, Valid: true},
 	}
 }


### PR DESCRIPTION
This will refactor all tests in the `go-vela/types/database` package to use table tests.

More information: https://github.com/golang/go/wiki/TableDrivenTests

I was able to significantly reduce the total number lines of code for our tests 🎉