### PR TITLE
enhancement(ruleset): add an execute func

### DIFF
--- a/pipeline/ruleset.go
+++ b/pipeline/ruleset.go
@@ -82,6 +82,27 @@ func (r *Ruleset) Match(from *RuleData) bool {
 	return false
 }
 
+// Execute returns true when the provided ruledata matches
+// the if rules and does not match any of the unless rules.
+// This function does not check When the provided if and Unless
+// rules are empty.
+func (r *Ruleset) Execute(from *RuleData) bool {
+	// return false when the unless rules are not empty and match
+	if !r.Unless.Empty() {
+		if r.Unless.Match(from, r.Operator) {
+			return false
+		}
+	}
+
+	// return true when the if rules match
+	if r.If.Match(from, r.Operator) {
+		return true
+	}
+
+	// return false if not match is found
+	return false
+}
+
 // Empty returns true if the provided ruletypes are empty.
 func (r *Rules) Empty() bool {
 	// return true if every ruletype is empty

--- a/pipeline/ruleset.go
+++ b/pipeline/ruleset.go
@@ -87,6 +87,11 @@ func (r *Ruleset) Match(from *RuleData) bool {
 // This function does not check When the provided if and Unless
 // rules are empty.
 func (r *Ruleset) Execute(from *RuleData) bool {
+	// return true when the if and unless rules are empty
+	if r.If.Empty() && r.Unless.Empty() {
+		return false
+	}
+
 	// return false when the unless rules are not empty and match
 	if !r.Unless.Empty() {
 		if r.Unless.Match(from, r.Operator) {

--- a/pipeline/ruleset_test.go
+++ b/pipeline/ruleset_test.go
@@ -201,7 +201,7 @@ func TestPipeline_Ruleset_Execute(t *testing.T) {
 		want    bool
 	}{
 		// Empty
-		{ruleset: &Ruleset{}, data: &RuleData{Branch: "master"}, want: true},
+		{ruleset: &Ruleset{}, data: &RuleData{Branch: "master"}, want: false},
 		// If with and operator
 		{
 			ruleset: &Ruleset{If: Rules{Branch: []string{"master"}}},


### PR DESCRIPTION
This change is to simplify and further test how `status` gets executed during a pipeline run.

Steps workflow:
https://github.com/go-vela/pkg-executor/blob/master/executor/linux/build.go#L386-L413

Stages workflow:
https://github.com/go-vela/pkg-executor/blob/master/executor/linux/stage.go#L117-L144

This charge also does some further testing to validate when the status is compared with other fields it can be properly processed.  

Some Fields **can't** be supported with ruleset execution because the data is not available to be processed. These fields are `comment` and `path`. Right now, we don't have a great way to propagate that data so if a `status` ruleset is used with those fields the user should expect the `status` may not be processed as expected. 