### PR TITLE
Issue #70: Allow greater fidelity of ruleset matching

### DIFF
--- a/pipeline/ruleset.go
+++ b/pipeline/ruleset.go
@@ -5,7 +5,7 @@
 package pipeline
 
 import (
-	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -223,7 +223,7 @@ func (r *Ruletype) MatchAnd(data string) bool {
 	for _, pattern := range *r {
 
 		// return true if the pattern matches the ruledata
-		if ok, _ := filepath.Match(pattern, data); ok {
+		if regexp.MustCompile(pattern).MatchString(data) {
 			return true
 		}
 	}
@@ -245,7 +245,7 @@ func (r *Ruletype) MatchOr(data string) bool {
 	for _, pattern := range *r {
 
 		// return true if the pattern matches the ruledata
-		if ok, _ := filepath.Match(pattern, data); ok {
+		if regexp.MustCompile(pattern).MatchString(data) {
 			return true
 		}
 	}

--- a/pipeline/ruleset_test.go
+++ b/pipeline/ruleset_test.go
@@ -435,6 +435,13 @@ func TestPipeline_Ruletype_MatchAnd(t *testing.T) {
 		// Tag
 		{rule: []string{"release/*"}, pattern: "release/*", want: true},
 		{rule: []string{"release/*"}, pattern: "stage/*", want: false},
+		{rule: []string{"release/[0-9]+.*-rc$"}, pattern: "release/111.2.3-rc", want: true},
+		{rule: []string{"release/[0-9]+.*-rc$"}, pattern: "release/1.2.3-rc-hold", want: false},
+		{rule: []string{"release/*"}, pattern: "release/stage/1.2.3-rc", want: true},
+		{rule: []string{"release/stage/*"}, pattern: "release/stage/1.2.3-rc", want: true},
+		{rule: []string{"release/prod/*"}, pattern: "release/stage/1.2.3-rc", want: false},
+		{rule: []string{"release/[0-9]+.[0-9]+.[0-9]+$"}, pattern: "release/1.2.3-rc", want: false},
+		{rule: []string{"release/[0-9]+.[0-9]+.[0-9]+$"}, pattern: "release/1.2.3", want: true},
 		// Target
 		{rule: []string{"production"}, pattern: "production", want: true},
 		{rule: []string{"stage"}, pattern: "production", want: false},

--- a/pipeline/ruleset_test.go
+++ b/pipeline/ruleset_test.go
@@ -336,6 +336,12 @@ func TestPipeline_Rules_Match(t *testing.T) {
 			operator: "and",
 			want:     true,
 		},
+		{
+			rules:    &Rules{Event: []string{"tag"}, Tag: []string{"path/to/thing/*/*"}},
+			data:     &RuleData{Branch: "master", Event: "tag", Repo: "octocat/hello-world", Status: "pending", Tag: "path/to/thing/stage/1.0.2-rc", Target: ""},
+			operator: "and",
+			want:     true,
+		},
 		// or operator
 		{
 			rules:    &Rules{Branch: []string{"master"}, Event: []string{"push"}},

--- a/pipeline/ruleset_test.go
+++ b/pipeline/ruleset_test.go
@@ -438,6 +438,7 @@ func TestPipeline_Ruletype_MatchAnd(t *testing.T) {
 		{rule: []string{"release/[0-9]+.*-rc$"}, pattern: "release/111.2.3-rc", want: true},
 		{rule: []string{"release/[0-9]+.*-rc$"}, pattern: "release/1.2.3-rc-hold", want: false},
 		{rule: []string{"release/*"}, pattern: "release/stage/1.2.3-rc", want: true},
+		{rule: []string{"release/*/*"}, pattern: "release/stage/1.2.3-rc", want: true},
 		{rule: []string{"release/stage/*"}, pattern: "release/stage/1.2.3-rc", want: true},
 		{rule: []string{"release/prod/*"}, pattern: "release/stage/1.2.3-rc", want: false},
 		{rule: []string{"release/[0-9]+.[0-9]+.[0-9]+$"}, pattern: "release/1.2.3-rc", want: false},

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -119,6 +119,17 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 				Continue: true,
 			},
 		},
+		{
+			file: "testdata/ruleset_regex.yml",
+			want: &Ruleset{
+				If: Rules{
+					Branch: []string{"master"},
+					Event:  []string{"tag"},
+					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
+				},
+				Operator: "and",
+			},
+		},
 	}
 
 	// run tests

--- a/yaml/testdata/ruleset_regex.yml
+++ b/yaml/testdata/ruleset_regex.yml
@@ -1,0 +1,6 @@
+---
+if:
+  branch: master
+  event: tag
+  tag: [ "^refs/tags/(\\d+\\.)+\\d+$" ]
+  operator: and


### PR DESCRIPTION
Current ruleset matching utilizes a file match pattern utility. This does not allow for more stringent matching, particularly with version tags. Use regex pattern matching since it allows for greater control and it commonly known.