### PR TITLE
feat(open-api): add open api (swagger) definitions to models

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -12,6 +12,8 @@ import (
 )
 
 // Build is the library representation of a build for a pipeline.
+//
+// swagger:model Build
 type Build struct {
 	ID           *int64  `json:"id,omitempty"`
 	RepoID       *int64  `json:"repo_id,omitempty"`

--- a/library/hook.go
+++ b/library/hook.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // Hook is the library representation of a webhook for a repo.
+//
+// swagger:model Hook
 type Hook struct {
 	ID       *int64  `json:"id,omitempty"`
 	RepoID   *int64  `json:"repo_id,omitempty"`

--- a/library/hook.go
+++ b/library/hook.go
@@ -8,7 +8,7 @@ import "fmt"
 
 // Hook is the library representation of a webhook for a repo.
 //
-// swagger:model Hook
+// swagger:model Webhook
 type Hook struct {
 	ID       *int64  `json:"id,omitempty"`
 	RepoID   *int64  `json:"repo_id,omitempty"`

--- a/library/log.go
+++ b/library/log.go
@@ -8,7 +8,7 @@ import "fmt"
 
 // Log is the library representation of a log for a step in a build.
 //
-// swagger:model Service
+// swagger:model Log
 type Log struct {
 	ID        *int64  `json:"id,omitempty"`
 	BuildID   *int64  `json:"build_id,omitempty"`

--- a/library/log.go
+++ b/library/log.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // Log is the library representation of a log for a step in a build.
+//
+// swagger:model Service
 type Log struct {
 	ID        *int64  `json:"id,omitempty"`
 	BuildID   *int64  `json:"build_id,omitempty"`

--- a/library/login.go
+++ b/library/login.go
@@ -17,6 +17,8 @@ package library
 import "fmt"
 
 // Login is the library representation of a user login.
+//
+// swagger:model Login
 type Login struct {
 	Username *string `json:"username,omitempty"`
 	Password *string `json:"password,omitempty"`

--- a/library/repo.go
+++ b/library/repo.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // Repo is the library representation of a repo.
+//
+// swagger:model Repo
 type Repo struct {
 	ID           *int64  `json:"id,omitempty"`
 	UserID       *int64  `json:"user_id,omitempty"`

--- a/library/secret.go
+++ b/library/secret.go
@@ -13,6 +13,8 @@ import (
 )
 
 // Secret is the library representation of a secret.
+//
+// swagger:model Secret
 type Secret struct {
 	ID           *int64    `json:"id,omitempty"`
 	Org          *string   `json:"org,omitempty"`

--- a/library/service.go
+++ b/library/service.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // Service is the library representation of a service in a build.
+//
+// swagger:model Service
 type Service struct {
 	ID           *int64  `json:"id,omitempty"`
 	BuildID      *int64  `json:"build_id,omitempty"`

--- a/library/step.go
+++ b/library/step.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // Step is the library representation of a step in a build.
+//
+// swagger:model Step
 type Step struct {
 	ID           *int64  `json:"id,omitempty"`
 	BuildID      *int64  `json:"build_id,omitempty"`

--- a/library/user.go
+++ b/library/user.go
@@ -7,6 +7,8 @@ package library
 import "fmt"
 
 // User is the library representation of a user.
+//
+// swagger:model User
 type User struct {
 	ID        *int64    `json:"id,omitempty"`
 	Name      *string   `json:"name,omitempty"`


### PR DESCRIPTION
Adding swagger model definitions to types used in endpoints defined in [go-vela/server](https://github.com/go-vela/server)