### PR TITLE
fix(user): implement hard limit on user favorites

### DIFF
--- a/constants/limit.go
+++ b/constants/limit.go
@@ -11,4 +11,7 @@ const (
 
 	// BuildTimeoutMax defines the maximum value in minutes for repo build timeout.
 	BuildTimeoutMax = 90
+
+	// FavoritesMaxSize defines the maximum size in characters for user favorites.
+	FavoritesMaxSize = 5000
 )

--- a/database/user.go
+++ b/database/user.go
@@ -9,6 +9,7 @@ import (
 	"errors"
 	"regexp"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/lib/pq"
 )
@@ -33,6 +34,10 @@ var (
 	// ErrInvalidUserName defines the error type when a
 	// User type has an invalid Name field provided.
 	ErrInvalidUserName = errors.New("invalid user name provided")
+
+	// ErrExceededFavoritesLimit defines the error type when a
+	// User type has Favorites field provided that exceeds the database limit.
+	ErrExceededFavoritesLimit = errors.New("exceeded favorites limit")
 )
 
 // User is the database representation of a user.
@@ -117,6 +122,17 @@ func (u *User) Validate() error {
 	// verify the Name field is valid
 	if !userRegex.MatchString(u.Name.String) {
 		return ErrInvalidUserName
+	}
+
+	// calculate total size of favorites
+	total := 0
+	for _, f := range u.Favorites {
+		total += len(f)
+	}
+
+	// verify the Favorites field is within the database constraints
+	if total > constants.FavoritesMaxSize {
+		return ErrExceededFavoritesLimit
 	}
 
 	return nil

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -7,6 +7,7 @@ package database
 import (
 	"database/sql"
 	"reflect"
+	"strconv"
 	"testing"
 
 	"github.com/go-vela/types/library"
@@ -117,6 +118,16 @@ func TestDatabase_User_Validate(t *testing.T) {
 				Hash:  sql.NullString{String: "superSecretHash", Valid: true},
 			},
 		},
+		{ // invalid favorites set for user
+			failure: true,
+			user: &User{
+				ID:        sql.NullInt64{Int64: 1, Valid: true},
+				Name:      sql.NullString{String: "octocat", Valid: true},
+				Token:     sql.NullString{String: "superSecretToken", Valid: true},
+				Hash:      sql.NullString{String: "superSecretHash", Valid: true},
+				Favorites: exceededFavorites(),
+			},
+		},
 	}
 
 	// run tests
@@ -171,4 +182,22 @@ func testUser() *User {
 		Active:    sql.NullBool{Bool: true, Valid: true},
 		Admin:     sql.NullBool{Bool: false, Valid: true},
 	}
+}
+
+// exceededFavorites returns a list of valid favorites that exceed the maximum size
+func exceededFavorites() []string {
+
+	// initialize empty favorites
+	favorites := []string{}
+
+	// add enough favorites to exceed the character limit
+	for i := 0; i < 500; i++ {
+		// construct favorite
+		// use i to adhere to unique favorites
+		favorite := "github/octocat-" + strconv.Itoa(i)
+
+		favorites = append(favorites, favorite)
+	}
+
+	return favorites
 }


### PR DESCRIPTION
adding logic to adhere to the hard limit imposed by the database of `VARCHAR(5000)`

this logic assumes that postgres does not pad values when inserting `[]string` arrays, will do some more research 