### PR TITLE
feat(build): track head and base ref for pr

### DIFF
--- a/database/build.go
+++ b/database/build.go
@@ -47,6 +47,7 @@ type Build struct {
 	Branch       sql.NullString `sql:"branch"`
 	Ref          sql.NullString `sql:"ref"`
 	BaseRef      sql.NullString `sql:"base_ref"`
+	HeadRef      sql.NullString `sql:"head_ref"`
 	Host         sql.NullString `sql:"host"`
 	Runtime      sql.NullString `sql:"runtime"`
 	Distribution sql.NullString `sql:"distribution"`
@@ -199,6 +200,11 @@ func (b *Build) Nullify() *Build {
 		b.BaseRef.Valid = false
 	}
 
+	// check if the HeadRef field should be false
+	if len(b.HeadRef.String) == 0 {
+		b.HeadRef.Valid = false
+	}
+
 	// check if the Host field should be false
 	if len(b.Host.String) == 0 {
 		b.Host.Valid = false
@@ -246,6 +252,7 @@ func (b *Build) ToLibrary() *library.Build {
 	build.SetBranch(b.Branch.String)
 	build.SetRef(b.Ref.String)
 	build.SetBaseRef(b.BaseRef.String)
+	build.SetHeadRef(b.HeadRef.String)
 	build.SetHost(b.Host.String)
 	build.SetRuntime(b.Runtime.String)
 	build.SetDistribution(b.Distribution.String)
@@ -297,6 +304,7 @@ func BuildFromLibrary(b *library.Build) *Build {
 		Branch:       sql.NullString{String: b.GetBranch(), Valid: true},
 		Ref:          sql.NullString{String: b.GetRef(), Valid: true},
 		BaseRef:      sql.NullString{String: b.GetBaseRef(), Valid: true},
+		HeadRef:      sql.NullString{String: b.GetHeadRef(), Valid: true},
 		Host:         sql.NullString{String: b.GetHost(), Valid: true},
 		Runtime:      sql.NullString{String: b.GetRuntime(), Valid: true},
 		Distribution: sql.NullString{String: b.GetDistribution(), Valid: true},

--- a/database/build_test.go
+++ b/database/build_test.go
@@ -63,6 +63,7 @@ func TestDatabase_Build_Nullify(t *testing.T) {
 		Branch:       sql.NullString{String: "", Valid: false},
 		Ref:          sql.NullString{String: "", Valid: false},
 		BaseRef:      sql.NullString{String: "", Valid: false},
+		HeadRef:      sql.NullString{String: "", Valid: false},
 		Host:         sql.NullString{String: "", Valid: false},
 		Runtime:      sql.NullString{String: "", Valid: false},
 		Distribution: sql.NullString{String: "", Valid: false},
@@ -125,6 +126,7 @@ func TestDatabase_Build_ToLibrary(t *testing.T) {
 	want.SetBranch("master")
 	want.SetRef("refs/heads/master")
 	want.SetBaseRef("")
+	want.SetHeadRef("")
 	want.SetHost("example.company.com")
 	want.SetRuntime("docker")
 	want.SetDistribution("linux")
@@ -209,6 +211,7 @@ func TestDatabase_BuildFromLibrary(t *testing.T) {
 	b.SetBranch("master")
 	b.SetRef("refs/heads/master")
 	b.SetBaseRef("")
+	b.SetHeadRef("")
 	b.SetHost("example.company.com")
 	b.SetRuntime("docker")
 	b.SetDistribution("linux")
@@ -262,6 +265,7 @@ func testBuild() *Build {
 		Branch:       sql.NullString{String: "master", Valid: true},
 		Ref:          sql.NullString{String: "refs/heads/master", Valid: true},
 		BaseRef:      sql.NullString{String: "", Valid: false},
+		HeadRef:      sql.NullString{String: "", Valid: false},
 		Host:         sql.NullString{String: "example.company.com", Valid: true},
 		Runtime:      sql.NullString{String: "docker", Valid: true},
 		Distribution: sql.NullString{String: "linux", Valid: true},

--- a/library/build.go
+++ b/library/build.go
@@ -39,6 +39,7 @@ type Build struct {
 	Branch       *string `json:"branch,omitempty"`
 	Ref          *string `json:"ref,omitempty"`
 	BaseRef      *string `json:"base_ref,omitempty"`
+	HeadRef      *string `json:"head_ref,omitempty"`
 	Host         *string `json:"host,omitempty"`
 	Runtime      *string `json:"runtime,omitempty"`
 	Distribution *string `json:"distribution,omitempty"`
@@ -130,6 +131,8 @@ func (b *Build) Environment() map[string]string {
 		envs["BUILD_PULL_REQUEST_NUMBER"] = number
 		envs["VELA_BUILD_PULL_REQUEST"] = number
 		envs["VELA_PULL_REQUEST"] = number
+		envs["VELA_PULL_REQUEST_SOURCE"] = b.GetHeadRef()
+		envs["VELA_PULL_REQUEST_TARGET"] = b.GetBaseRef()
 	}
 
 	// check if the Build event is tag
@@ -455,6 +458,19 @@ func (b *Build) GetBaseRef() string {
 	}
 
 	return *b.BaseRef
+}
+
+// GetHeadRef returns the HeadRef field.
+//
+// When the provided Build type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *Build) GetHeadRef() string {
+	// return zero value if Build type or HeadRef field is nil
+	if b == nil || b.HeadRef == nil {
+		return ""
+	}
+
+	return *b.HeadRef
 }
 
 // GetHost returns the Host field.
@@ -808,6 +824,19 @@ func (b *Build) SetBaseRef(v string) {
 	b.BaseRef = &v
 }
 
+// SetHeadRef sets the HeadRef field.
+//
+// When the provided Build type is nil, it
+// will set nothing and immediately return.
+func (b *Build) SetHeadRef(v string) {
+	// return if Build type is nil
+	if b == nil {
+		return
+	}
+
+	b.HeadRef = &v
+}
+
 // SetHost sets the Host field.
 //
 // When the provided Build type is nil, it
@@ -863,6 +892,7 @@ func (b *Build) String() string {
   Error: %s,
   Event: %s,
   Finished: %d,
+  HeadRef: %s,
   Host: %s,
   ID: %d,
   Link: %s,
@@ -891,6 +921,7 @@ func (b *Build) String() string {
 		b.GetError(),
 		b.GetEvent(),
 		b.GetFinished(),
+		b.GetHeadRef(),
 		b.GetHost(),
 		b.GetID(),
 		b.GetLink(),

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -227,6 +227,8 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_TITLE":          "push received from https://github.com/github/octocat",
 				"VELA_BUILD_WORKSPACE":      "TODO",
 				"VELA_PULL_REQUEST":         "1",
+				"VELA_PULL_REQUEST_SOURCE":  "changes",
+				"VELA_PULL_REQUEST_TARGET":  "",
 				"BUILD_AUTHOR":              "OctoKitty",
 				"BUILD_AUTHOR_EMAIL":        "OctoKitty@github.com",
 				"BUILD_BASE_REF":            "",
@@ -434,6 +436,10 @@ func TestLibrary_Build_Getters(t *testing.T) {
 			t.Errorf("GetBaseRef is %v, want %v", test.build.GetBaseRef(), test.want.GetBaseRef())
 		}
 
+		if test.build.GetHeadRef() != test.want.GetHeadRef() {
+			t.Errorf("GetHeadRef is %v, want %v", test.build.GetHeadRef(), test.want.GetHeadRef())
+		}
+
 		if test.build.GetHost() != test.want.GetHost() {
 			t.Errorf("GetHost is %v, want %v", test.build.GetHost(), test.want.GetHost())
 		}
@@ -493,6 +499,7 @@ func TestLibrary_Build_Setters(t *testing.T) {
 		test.build.SetBranch(test.want.GetBranch())
 		test.build.SetRef(test.want.GetRef())
 		test.build.SetBaseRef(test.want.GetBaseRef())
+		test.build.SetHeadRef(test.want.GetHeadRef())
 		test.build.SetHost(test.want.GetHost())
 		test.build.SetRuntime(test.want.GetRuntime())
 		test.build.SetDistribution(test.want.GetDistribution())
@@ -593,6 +600,10 @@ func TestLibrary_Build_Setters(t *testing.T) {
 			t.Errorf("SetBaseRef is %v, want %v", test.build.GetBaseRef(), test.want.GetBaseRef())
 		}
 
+		if test.build.GetHeadRef() != test.want.GetHeadRef() {
+			t.Errorf("SetHeadRef is %v, want %v", test.build.GetHeadRef(), test.want.GetHeadRef())
+		}
+
 		if test.build.GetHost() != test.want.GetHost() {
 			t.Errorf("SetHost is %v, want %v", test.build.GetHost(), test.want.GetHost())
 		}
@@ -625,6 +636,7 @@ func TestLibrary_Build_String(t *testing.T) {
   Error: %s,
   Event: %s,
   Finished: %d,
+  HeadRef: %s,
   Host: %s,
   ID: %d,
   Link: %s,
@@ -653,6 +665,7 @@ func TestLibrary_Build_String(t *testing.T) {
 		b.GetError(),
 		b.GetEvent(),
 		b.GetFinished(),
+		b.GetHeadRef(),
 		b.GetHost(),
 		b.GetID(),
 		b.GetLink(),
@@ -706,6 +719,7 @@ func testBuild() *Build {
 	b.SetBranch("master")
 	b.SetRef("refs/heads/master")
 	b.SetBaseRef("")
+	b.SetHeadRef("changes")
 	b.SetHost("example.company.com")
 	b.SetRuntime("docker")
 	b.SetDistribution("linux")


### PR DESCRIPTION
## summary

Adds the `VELA_PULL_REQUEST_SOURCE` and `VELA_PULL_REQUEST_TARGET` variables that match the base and head refs from [go-github](https://github.com/google/go-github/blob/master/github/pulls.go#L72-L73). 

Starts the work to complete https://github.com/go-vela/community/issues/28.

## value

Allows plugins/users to determine both branches involved in a given pull request.

Note: The failing reviewdog action is unrelated to my changes.