### PR TITLE
feat(skip): add ability to skip hook

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -4,7 +4,17 @@
 
 package types
 
-import "github.com/go-vela/types/library"
+import (
+	"strings"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+)
+
+var (
+	skipDeleteEventMsg = "tag/branch delete event"
+	skipDirectiveMsg   = "skip ci directive found in commit title/message"
+)
 
 // Webhook defines a struct that is used to return
 // the required data when processing webhook event
@@ -15,4 +25,46 @@ type Webhook struct {
 	Hook     *library.Hook
 	Repo     *library.Repo
 	Build    *library.Build
+}
+
+// ShouldSkip uses the build information
+// associated with the given hook to determine
+// whether the hook should be skipped
+func (w *Webhook) ShouldSkip() (bool, string) {
+	// push event
+	if strings.EqualFold(constants.EventPush, w.Build.GetEvent()) {
+		// the head commit will return null in the hook
+		// payload from the scm when the event is
+		// associated with a branch/tag delete
+		if len(w.Build.GetCommit()) == 0 {
+			return true, skipDeleteEventMsg
+		}
+
+		// check for skip ci directive in message or title
+		if hasSkipDirective(w.Build.GetMessage()) ||
+			hasSkipDirective(w.Build.GetTitle()) {
+			return true, skipDirectiveMsg
+		}
+	}
+
+	return false, ""
+}
+
+// hasSkipDirective is a small helper function
+// to check a string for a number of patterns
+// that signal to vela that the hook should
+// be skipped from processing
+func hasSkipDirective(s string) bool {
+	sl := strings.ToLower(s)
+
+	switch {
+	case strings.Contains(sl, "[skip ci]"),
+		strings.Contains(sl, "[ci skip]"),
+		strings.Contains(sl, "[skip vela]"),
+		strings.Contains(sl, "[vela skip]"),
+		strings.Contains(sl, "***no_ci***"):
+		return true
+	default:
+		return false
+	}
 }

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -1,0 +1,90 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/library"
+)
+
+func TestWebhook_ShouldSkip(t *testing.T) {
+	// set up tests
+	tests := []struct {
+		hook       *Webhook
+		wantBool   bool
+		wantString string
+	}{
+		{
+			&Webhook{Build: testPushBuild("testing [SKIP CI]", "", true)},
+			true,
+			skipDirectiveMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing", "wip [ci skip]", true)},
+			true,
+			skipDirectiveMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing [skip VELA]", "", true)},
+			true,
+			skipDirectiveMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing", "wip [vela skip]", true)},
+			true,
+			skipDirectiveMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing ***NO_CI*** ok", "nothing", true)},
+			true,
+			skipDirectiveMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing ok", "nothing", false)},
+			true,
+			skipDeleteEventMsg,
+		},
+		{
+			&Webhook{Build: testPushBuild("testing ok", "nothing", true)},
+			false,
+			"",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		gotBool, gotString := test.hook.ShouldSkip()
+
+		if gotString != test.wantString {
+			t.Errorf("returned an error, wanted %s, but got %s", test.wantString, gotString)
+		}
+
+		if gotBool != test.wantBool {
+			t.Errorf("returned an error, wanted %v, but got %v", test.wantBool, gotBool)
+		}
+	}
+}
+
+func testPushBuild(message, title string, hasCommit bool) *library.Build {
+	b := new(library.Build)
+
+	b.SetEvent(constants.EventPush)
+
+	if len(message) > 0 {
+		b.SetMessage(message)
+	}
+
+	if len(title) > 0 {
+		b.SetTitle(title)
+	}
+
+	if hasCommit {
+		b.SetCommit("deadbeef")
+	}
+
+	return b
+}


### PR DESCRIPTION
pre-work for https://github.com/go-vela/community/issues/66 and https://github.com/go-vela/community/issues/70

will be functional once associated, incoming PR to server is merged (https://github.com/go-vela/server/pull/169)

- adds method on Webhook struct called `ShouldSkip`
- adds helper function to check string for skip directive
- adds tests to check `ShouldSkip` functionality