### PR TITLE
feat: enable pattern matcher for ruleset

### DIFF
--- a/constants/matcher.go
+++ b/constants/matcher.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package constants
+
+// ruleset matchers
+const (
+	// MatcherFilepath defines the ruleset type for the filepath matcher.
+	MatcherFilepath = "filepath"
+
+	// MatcherRegex defines the ruleset type for the regex matcher.
+	MatcherRegex = "regexp"
+)

--- a/constants/operator.go
+++ b/constants/operator.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package constants
+
+// ruleset operators
+const (
+	// OperatorAnd defines the ruleset type for the and operator.
+	OperatorAnd = "and"
+
+	// OperatorOr defines the ruleset type for the or operator.
+	OperatorOr = "or"
+)

--- a/pipeline/ruleset.go
+++ b/pipeline/ruleset.go
@@ -5,8 +5,11 @@
 package pipeline
 
 import (
+	"path/filepath"
 	"regexp"
 	"strings"
+
+	"github.com/go-vela/types/constants"
 )
 
 type (
@@ -17,6 +20,7 @@ type (
 	Ruleset struct {
 		If       Rules  `json:"if,omitempty"       yaml:"if,omitempty"`
 		Unless   Rules  `json:"unless,omitempty"   yaml:"unless,omitempty"`
+		Matcher  string `json:"matcher,omitempty"  yaml:"matcher,omitempty"`
 		Operator string `json:"operator,omitempty" yaml:"operator,omitempty"`
 		Continue bool   `json:"continue,omitempty" yaml:"continue,omitempty"`
 	}
@@ -69,7 +73,7 @@ func (r *Ruleset) Match(from *RuleData) bool {
 
 	// return false when the unless rules are not empty and match
 	if !r.Unless.Empty() {
-		if r.Unless.Match(from, r.Operator) {
+		if r.Unless.Match(from, r.Matcher, r.Operator) {
 			return false
 		}
 	}
@@ -80,7 +84,7 @@ func (r *Ruleset) Match(from *RuleData) bool {
 	}
 
 	// return true when the if rules match
-	if r.If.Match(from, r.Operator) {
+	if r.If.Match(from, r.Matcher, r.Operator) {
 		return true
 	}
 
@@ -123,32 +127,30 @@ func (r *Rules) Empty() bool {
 // ruletypes from the rules match the provided ruledata. For
 // both operators, when none of the ruletypes from the rules
 // match the provided ruledata, the function returns false.
-func (r *Rules) Match(from *RuleData, op string) bool {
+func (r *Rules) Match(from *RuleData, matcher, op string) bool {
 	// set defaults
 	status := true
 
 	// if the path ruletype is provided
 	if len(from.Path) > 0 {
 		// if the "or" operator is provided in the ruleset
-		if strings.EqualFold(op, "or") {
-
+		if strings.EqualFold(op, constants.OperatorOr) {
 			// override the default to the "or"
 			if len(from.Status) != 0 {
-				status = r.Status.MatchOr(from.Status)
+				status = r.Status.MatchOr(from.Status, matcher)
 			}
 
 			// iterate through each path in the ruletype
 			for _, p := range from.Path {
-
 				// return true if any ruletype matches the ruledata
-				if r.Branch.MatchOr(from.Branch) ||
-					r.Comment.MatchOr(from.Comment) ||
-					r.Event.MatchOr(from.Event) ||
-					r.Path.MatchOr(p) ||
-					r.Repo.MatchOr(from.Repo) ||
+				if r.Branch.MatchOr(from.Branch, matcher) ||
+					r.Comment.MatchOr(from.Comment, matcher) ||
+					r.Event.MatchOr(from.Event, matcher) ||
+					r.Path.MatchOr(p, matcher) ||
+					r.Repo.MatchOr(from.Repo, matcher) ||
 					status ||
-					r.Tag.MatchOr(from.Tag) ||
-					r.Target.MatchOr(from.Target) {
+					r.Tag.MatchOr(from.Tag, matcher) ||
+					r.Target.MatchOr(from.Target, matcher) {
 					return true
 				}
 			}
@@ -159,21 +161,20 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 
 		// override the default to the "and"
 		if len(from.Status) != 0 {
-			status = r.Status.MatchAnd(from.Status)
+			status = r.Status.MatchAnd(from.Status, matcher)
 		}
 
 		// iterate through each path in the ruletype
 		for _, p := range from.Path {
-
 			// return true if every ruletype matches the ruledata
-			if r.Branch.MatchAnd(from.Branch) &&
-				r.Comment.MatchAnd(from.Comment) &&
-				r.Event.MatchAnd(from.Event) &&
-				r.Path.MatchAnd(p) &&
-				r.Repo.MatchAnd(from.Repo) &&
+			if r.Branch.MatchAnd(from.Branch, matcher) &&
+				r.Comment.MatchAnd(from.Comment, matcher) &&
+				r.Event.MatchAnd(from.Event, matcher) &&
+				r.Path.MatchAnd(p, matcher) &&
+				r.Repo.MatchAnd(from.Repo, matcher) &&
 				status &&
-				r.Tag.MatchAnd(from.Tag) &&
-				r.Target.MatchAnd(from.Target) {
+				r.Tag.MatchAnd(from.Tag, matcher) &&
+				r.Target.MatchAnd(from.Target, matcher) {
 				return true
 			}
 		}
@@ -183,22 +184,21 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 	}
 
 	// if the "or" operator is provided in the ruleset
-	if strings.EqualFold(op, "or") {
-
+	if strings.EqualFold(op, constants.OperatorOr) {
 		// override the default to the "or"
 		if len(from.Status) != 0 {
-			status = r.Status.MatchOr(from.Status)
+			status = r.Status.MatchOr(from.Status, matcher)
 		}
 
 		// return true if any ruletype matches the ruledata
-		if r.Branch.MatchOr(from.Branch) ||
-			r.Comment.MatchOr(from.Comment) ||
-			r.Event.MatchOr(from.Event) ||
-			r.Path.MatchOr("") ||
-			r.Repo.MatchOr(from.Repo) ||
+		if r.Branch.MatchOr(from.Branch, matcher) ||
+			r.Comment.MatchOr(from.Comment, matcher) ||
+			r.Event.MatchOr(from.Event, matcher) ||
+			r.Path.MatchOr("", matcher) ||
+			r.Repo.MatchOr(from.Repo, matcher) ||
 			status ||
-			r.Tag.MatchOr(from.Tag) ||
-			r.Target.MatchOr(from.Target) {
+			r.Tag.MatchOr(from.Tag, matcher) ||
+			r.Target.MatchOr(from.Target, matcher) {
 			return true
 		}
 
@@ -208,18 +208,18 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 
 	// override the default to the "and"
 	if len(from.Status) != 0 {
-		status = r.Status.MatchAnd(from.Status)
+		status = r.Status.MatchAnd(from.Status, matcher)
 	}
 
 	// return true if every ruletype matches the ruledata
-	if r.Branch.MatchAnd(from.Branch) &&
-		r.Comment.MatchAnd(from.Comment) &&
-		r.Event.MatchAnd(from.Event) &&
-		r.Path.MatchAnd("") &&
-		r.Repo.MatchAnd(from.Repo) &&
+	if r.Branch.MatchAnd(from.Branch, matcher) &&
+		r.Comment.MatchAnd(from.Comment, matcher) &&
+		r.Event.MatchAnd(from.Event, matcher) &&
+		r.Path.MatchAnd("", matcher) &&
+		r.Repo.MatchAnd(from.Repo, matcher) &&
 		status &&
-		r.Tag.MatchAnd(from.Tag) &&
-		r.Target.MatchAnd(from.Target) {
+		r.Tag.MatchAnd(from.Tag, matcher) &&
+		r.Target.MatchAnd(from.Target, matcher) {
 		return true
 	}
 
@@ -230,7 +230,7 @@ func (r *Rules) Match(from *RuleData, op string) bool {
 // MatchAnd returns true when the provided ruletype
 // matches the provided ruledata. When the provided
 // ruletype is empty, the function returns true.
-func (r *Ruletype) MatchAnd(data string) bool {
+func (r *Ruletype) MatchAnd(data, matcher string) bool {
 	// return true if an empty ruletype is provided
 	if len(*r) == 0 {
 		return true
@@ -238,10 +238,21 @@ func (r *Ruletype) MatchAnd(data string) bool {
 
 	// iterate through each pattern in the ruletype
 	for _, pattern := range *r {
-
-		// return true if the pattern matches the ruledata
-		if regexp.MustCompile(pattern).MatchString(data) {
-			return true
+		// handle the pattern based off the matcher provided
+		switch matcher {
+		case constants.MatcherRegex, "regex":
+			// return true if the regexp pattern matches the ruledata
+			if regexp.MustCompile(pattern).MatchString(data) {
+				return true
+			}
+		case constants.MatcherFilepath:
+			fallthrough
+		default:
+			// return true if the pattern matches the ruledata
+			ok, _ := filepath.Match(pattern, data)
+			if ok {
+				return true
+			}
 		}
 	}
 
@@ -252,7 +263,7 @@ func (r *Ruletype) MatchAnd(data string) bool {
 // MatchOr returns true when the provided ruletype
 // matches the provided ruledata. When the provided
 // ruletype is empty, the function returns false.
-func (r *Ruletype) MatchOr(data string) bool {
+func (r *Ruletype) MatchOr(data, matcher string) bool {
 	// return false if an empty ruletype is provided
 	if len(*r) == 0 {
 		return false
@@ -260,10 +271,21 @@ func (r *Ruletype) MatchOr(data string) bool {
 
 	// iterate through each pattern in the ruletype
 	for _, pattern := range *r {
-
-		// return true if the pattern matches the ruledata
-		if regexp.MustCompile(pattern).MatchString(data) {
-			return true
+		// handle the pattern based off the matcher provided
+		switch matcher {
+		case constants.MatcherRegex, "regex":
+			// return true if the regexp pattern matches the ruledata
+			if regexp.MustCompile(pattern).MatchString(data) {
+				return true
+			}
+		case constants.MatcherFilepath:
+			fallthrough
+		default:
+			// return true if the pattern matches the ruledata
+			ok, _ := filepath.Match(pattern, data)
+			if ok {
+				return true
+			}
 		}
 	}
 

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -53,6 +53,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Ulimits: UlimitSlice{
@@ -81,6 +82,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Volumes: VolumeSlice{
@@ -109,6 +111,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Volumes: VolumeSlice{
@@ -138,6 +141,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 					},
@@ -152,6 +156,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Branch: []string{"master"}, Event: []string{"push"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Secrets: StepSecretSlice{
@@ -236,6 +241,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Pull:  true,
 								Ruleset: Ruleset{
 									If:       Rules{Event: []string{"push", "pull_request"}},
+									Matcher:  "filepath",
 									Operator: "and",
 								},
 								Volumes: VolumeSlice{
@@ -270,6 +276,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Pull:  true,
 								Ruleset: Ruleset{
 									If:       Rules{Event: []string{"push", "pull_request"}},
+									Matcher:  "filepath",
 									Operator: "and",
 								},
 								Volumes: VolumeSlice{
@@ -304,6 +311,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Pull:  true,
 								Ruleset: Ruleset{
 									If:       Rules{Event: []string{"push", "pull_request"}},
+									Matcher:  "filepath",
 									Operator: "and",
 								},
 								Volumes: VolumeSlice{
@@ -345,6 +353,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Volumes: VolumeSlice{
@@ -373,6 +382,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Volumes: VolumeSlice{
@@ -401,6 +411,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Pull:  true,
 						Ruleset: Ruleset{
 							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
 							Operator: "and",
 						},
 						Volumes: VolumeSlice{

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -5,6 +5,7 @@
 package yaml
 
 import (
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"
 )
@@ -15,6 +16,7 @@ type (
 	Ruleset struct {
 		If       Rules  `yaml:"if,omitempty"`
 		Unless   Rules  `yaml:"unless,omitempty"`
+		Matcher  string `yaml:"matcher,omitempty"`
 		Operator string `yaml:"operator,omitempty"`
 		Continue bool   `yaml:"continue,omitempty"`
 	}
@@ -39,6 +41,7 @@ func (r *Ruleset) ToPipeline() *pipeline.Ruleset {
 	return &pipeline.Ruleset{
 		If:       *r.If.ToPipeline(),
 		Unless:   *r.Unless.ToPipeline(),
+		Matcher:  r.Matcher,
 		Operator: r.Operator,
 		Continue: r.Continue,
 	}
@@ -53,6 +56,7 @@ func (r *Ruleset) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	advanced := new(struct {
 		If       Rules
 		Unless   Rules
+		Matcher  string
 		Operator string
 		Continue bool
 	})
@@ -64,6 +68,8 @@ func (r *Ruleset) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	// set ruleset `unless` to advanced `unless` rules
 	r.Unless = advanced.Unless
+	// set ruleset `matcher` to advanced `matcher`
+	r.Matcher = advanced.Matcher
 	// set ruleset `operator` to advanced `operator`
 	r.Operator = advanced.Operator
 	// set ruleset `continue` to advanced `continue`
@@ -82,9 +88,14 @@ func (r *Ruleset) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// set ruleset `if` to advanced `if` rules
 	r.If = advanced.If
 
+	// implicitly set `matcher` field if empty for ruleset
+	if len(r.Matcher) == 0 {
+		r.Matcher = constants.MatcherFilepath
+	}
+
 	// implicitly set `operator` field if empty for ruleset
 	if len(r.Operator) == 0 {
-		r.Operator = "and"
+		r.Operator = constants.OperatorAnd
 	}
 
 	return nil

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -41,6 +41,7 @@ func TestYaml_Ruleset_ToPipeline(t *testing.T) {
 					Tag:     []string{"v0.2.0"},
 					Target:  []string{"production"},
 				},
+				Matcher:  "filepath",
 				Operator: "and",
 				Continue: false,
 			},
@@ -65,6 +66,7 @@ func TestYaml_Ruleset_ToPipeline(t *testing.T) {
 					Tag:     []string{"v0.2.0"},
 					Target:  []string{"production"},
 				},
+				Matcher:  "filepath",
 				Operator: "and",
 				Continue: false,
 			},
@@ -100,6 +102,7 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 					Tag:     []string{"v0.1.0"},
 					Target:  []string{"production"},
 				},
+				Matcher:  "filepath",
 				Operator: "and",
 				Continue: true,
 			},
@@ -110,24 +113,15 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 				If: Rules{
 					Branch: []string{"master"},
 					Event:  []string{"push"},
+					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
 				},
 				Unless: Rules{
 					Event: []string{"deployment", "pull_request"},
 					Path:  []string{"foo.txt", "/foo/bar.txt"},
 				},
+				Matcher:  "regexp",
 				Operator: "or",
 				Continue: true,
-			},
-		},
-		{
-			file: "testdata/ruleset_regex.yml",
-			want: &Ruleset{
-				If: Rules{
-					Branch: []string{"master"},
-					Event:  []string{"tag"},
-					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
-				},
-				Operator: "and",
 			},
 		},
 	}

--- a/yaml/testdata/ruleset_advanced.yml
+++ b/yaml/testdata/ruleset_advanced.yml
@@ -1,9 +1,13 @@
 ---
 if:
-  branch: master
+  branch: [ master ]
   event: push
+  tag: "^refs/tags/(\\d+\\.)+\\d+$"
 unless:
-  event: [ deployment, pull_request]
+  event:
+    - deployment
+    - pull_request
   path: [ foo.txt, /foo/bar.txt ]
+matcher: regexp
 operator: or
 continue: true


### PR DESCRIPTION
This PR is part of the effort for https://github.com/go-vela/community/issues/12

It adds a `matcher` field to the `ruleset` struct. The default for this field will be `filepath`.

**NOTE: The `matcher` field is not required to be provided to maintain backwards compatibility.**

As an example:

```yaml
steps:
  - name: foo
    image: alpine:latest
    pull: true
    ruleset:
      tag: "^refs/tags/(\\d+\\.)+\\d+$"
      matcher: regexp
```

Tests have been added to account for this new change.