### PR TITLE
fix(secrets): convert valid to parse functions

### DIFF
--- a/pipeline/secret.go
+++ b/pipeline/secret.go
@@ -97,20 +97,20 @@ func (s *SecretSlice) Purge(r *RuleData) *SecretSlice {
 	return secrets
 }
 
-// ValidOrg returns an error when the secret is valid for a given
-// organization.
-func (s *Secret) ValidOrg(org string) error {
+// ParseOrg returns the parts (org, key) of the secret path
+// when the secret is valid for a given organization.
+func (s *Secret) ParseOrg(org string) (string, string, error) {
 	path := s.Key
 
 	// check if the secret is not a native or vault type
 	if !strings.EqualFold(s.Engine, constants.DriverNative) &&
 		!strings.EqualFold(s.Engine, constants.DriverVault) {
-		return fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
+		return "", "", fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
 	}
 
 	// check if a path was provided
 	if !strings.Contains(path, "/") {
-		return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+		return "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
 
 	// split the full path into parts
@@ -118,26 +118,26 @@ func (s *Secret) ValidOrg(org string) error {
 
 	// secret is invalid
 	if len(parts) != 2 {
-		return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+		return "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
 
 	// check if the org provided matches what we expect
 	if !strings.EqualFold(parts[0], org) {
-		return fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
+		return "", "", fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
 	}
 
-	return nil
+	return parts[0], parts[1], nil
 }
 
-// ValidRepo returns an error when the secret is valid for a given
-// organization and repository.
-func (s *Secret) ValidRepo(org, repo string) error {
+// ParseRepo returns the parts (org, repo, key) of the secret path
+// when the secret is valid for a given organization and repository.
+func (s *Secret) ParseRepo(org, repo string) (string, string, string, error) {
 	path := s.Key
 
 	// check if the secret is not a native or vault type
 	if !strings.EqualFold(s.Engine, constants.DriverNative) &&
 		!strings.EqualFold(s.Engine, constants.DriverVault) {
-		return fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
+		return "", "", "", fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
 	}
 
 	// check if a path was provided for explicit definition
@@ -147,44 +147,44 @@ func (s *Secret) ValidRepo(org, repo string) error {
 
 		// secret is invalid
 		if len(parts) != 3 {
-			return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+			return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 		}
 
 		// check if the org provided matches what we expect
 		if !strings.EqualFold(parts[0], org) {
-			return fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
+			return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
 		}
 
 		// check if the repo provided matches what we expect
 		if !strings.EqualFold(parts[1], repo) {
-			return fmt.Errorf("%s: %s ", ErrInvalidRepo, repo)
+			return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidRepo, repo)
 		}
 
-		return nil
+		return parts[0], parts[1], parts[2], nil
 	}
 
 	// check if name equals key for implicit definition
 	if !strings.EqualFold(s.Name, s.Key) {
-		return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+		return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
 
-	return nil
+	return org, repo, s.Name, nil
 }
 
-// ValidShared returns an error when the secret is valid for a given
-// organization and team.
-func (s *Secret) ValidShared(org string) error {
+// ParseShared returns the parts (org, team, key) of the secret path
+// when the secret is valid for a given organization and team.
+func (s *Secret) ParseShared(org string) (string, string, string, error) {
 	path := s.Key
 
 	// check if the secret is not a native or vault type
 	if !strings.EqualFold(s.Engine, constants.DriverNative) &&
 		!strings.EqualFold(s.Engine, constants.DriverVault) {
-		return fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
+		return "", "", "", fmt.Errorf("%s: %s", ErrInvalidEngine, s.Engine)
 	}
 
 	// check if a path was provided
 	if !strings.Contains(path, "/") {
-		return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+		return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
 
 	// split the full path into parts
@@ -192,13 +192,13 @@ func (s *Secret) ValidShared(org string) error {
 
 	// secret is invalid
 	if len(parts) != 3 {
-		return fmt.Errorf("%s: %s ", ErrInvalidPath, path)
+		return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
 
 	// check if the org provided is not empty
 	if !strings.EqualFold(parts[0], org) {
-		return fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
+		return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidOrg, org)
 	}
 
-	return nil
+	return parts[0], parts[1], parts[2], nil
 }

--- a/pipeline/secret_test.go
+++ b/pipeline/secret_test.go
@@ -254,7 +254,7 @@ func TestPipeline_Secret_ParseRepo_failure(t *testing.T) {
 	}
 }
 
-func TestPipeline_Secret_ValidShared_success(t *testing.T) {
+func TestPipeline_Secret_ParseShared_success(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret

--- a/pipeline/secret_test.go
+++ b/pipeline/secret_test.go
@@ -6,6 +6,7 @@ package pipeline
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -47,7 +48,7 @@ func TestPipeline_SecretSlice_Purge(t *testing.T) {
 	}
 }
 
-func TestPipeline_Secret_ValidOrg_success(t *testing.T) {
+func TestPipeline_Secret_ParseOrg_success(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret
@@ -68,14 +69,24 @@ func TestPipeline_Secret_ValidOrg_success(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidOrg(test.org)
+		org, key, err := test.secret.ParseOrg(test.org)
 		if err != nil {
-			t.Errorf("ValidOrg had an error occur: %+v", err)
+			t.Errorf("ParseOrg had an error occur: %+v", err)
+		}
+
+		p := strings.SplitN(test.secret.Key, "/", 2)
+
+		if !strings.EqualFold(org, p[0]) {
+			t.Errorf("org is %s want %s", org, p[0])
+		}
+
+		if !strings.EqualFold(key, p[1]) {
+			t.Errorf("key is %s want %s", key, p[1])
 		}
 	}
 }
 
-func TestPipeline_Secret_ValidOrg_failure(t *testing.T) {
+func TestPipeline_Secret_ParseOrg_failure(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret
@@ -116,21 +127,21 @@ func TestPipeline_Secret_ValidOrg_failure(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidOrg(test.org)
+		_, _, err := test.secret.ParseOrg(test.org)
 		if err == nil {
-			t.Errorf("ValidOrg should have failed")
+			t.Errorf("ParseOrg should have failed")
 		}
 	}
 }
 
-func TestPipeline_Secret_ValidRepo_success(t *testing.T) {
+func TestPipeline_Secret_ParseRepo_success(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret
 		org    string
 		repo   string
 	}{
-		{ // success with implicit
+		{ // success with explicit
 			secret: &Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -141,7 +152,7 @@ func TestPipeline_Secret_ValidRepo_success(t *testing.T) {
 			org:  "octocat",
 			repo: "helloworld",
 		},
-		{ // success with explicit
+		{ // success with implicit
 			secret: &Secret{
 				Name:   "foo",
 				Value:  "bar",
@@ -157,14 +168,31 @@ func TestPipeline_Secret_ValidRepo_success(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidRepo(test.org, test.repo)
+		org, repo, key, err := test.secret.ParseRepo(test.org, test.repo)
 		if err != nil {
-			t.Errorf("ValidRepo had an error occur: %+v", err)
+			t.Errorf("ParseRepo had an error occur: %+v", err)
+		}
+
+		// checks for explicit only
+		if strings.Contains(test.secret.Key, "/") {
+			p := strings.SplitN(test.secret.Key, "/", 3)
+
+			if !strings.EqualFold(org, p[0]) {
+				t.Errorf("org is %s want %s", org, p[0])
+			}
+
+			if !strings.EqualFold(repo, p[1]) {
+				t.Errorf("repo is %s want %s", key, p[1])
+			}
+
+			if !strings.EqualFold(key, p[2]) {
+				t.Errorf("key is %s want %s", key, p[2])
+			}
 		}
 	}
 }
 
-func TestPipeline_Secret_ValidRepo_failure(t *testing.T) {
+func TestPipeline_Secret_ParseRepo_failure(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret
@@ -219,9 +247,9 @@ func TestPipeline_Secret_ValidRepo_failure(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidRepo(test.org, test.repo)
+		_, _, _, err := test.secret.ParseRepo(test.org, test.repo)
 		if err == nil {
-			t.Errorf("ValidOrg should have failed")
+			t.Errorf("ParseRepo should have failed")
 		}
 	}
 }
@@ -247,14 +275,28 @@ func TestPipeline_Secret_ValidShared_success(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidShared(test.org)
+		org, team, key, err := test.secret.ParseShared(test.org)
 		if err != nil {
-			t.Errorf("ValidShared had an error occur: %+v", err)
+			t.Errorf("ParseShared had an error occur: %+v", err)
+		}
+
+		p := strings.SplitN(test.secret.Key, "/", 3)
+
+		if !strings.EqualFold(org, p[0]) {
+			t.Errorf("org is %s want %s", org, p[0])
+		}
+
+		if !strings.EqualFold(team, p[1]) {
+			t.Errorf("repo is %s want %s", key, p[1])
+		}
+
+		if !strings.EqualFold(key, p[2]) {
+			t.Errorf("key is %s want %s", key, p[2])
 		}
 	}
 }
 
-func TestPipeline_Secret_ValidShared_failure(t *testing.T) {
+func TestPipeline_Secret_ParseShared_failure(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		secret *Secret
@@ -295,7 +337,7 @@ func TestPipeline_Secret_ValidShared_failure(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 
-		err := test.secret.ValidShared(test.org)
+		_, _, _, err := test.secret.ParseShared(test.org)
 		if err == nil {
 			t.Errorf("ValidOrg should have failed")
 		}


### PR DESCRIPTION
This PR will help fix a bug in the executor that is stopping us from using the proper key when querying for a secret.

Executor PR:
https://github.com/go-vela/pkg-executor/pull/45