### PR TITLE
fix(pipeline): handle nil container for Empty()

### DIFF
--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -137,6 +137,11 @@ func (c *Container) Sanitize(driver string) *Container {
 
 // Empty returns true if the provided container is empty.
 func (c *Container) Empty() bool {
+	// return true of the container is nil
+	if c == nil {
+		return true
+	}
+
 	// return true if every container field is empty
 	if len(c.ID) == 0 &&
 		len(c.Commands) == 0 &&

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -105,14 +105,32 @@ func TestPipeline_ContainerSlice_Sanitize(t *testing.T) {
 }
 
 func TestPipeline_Container_Empty(t *testing.T) {
-	// setup types
-	c := Container{}
+	// setup tests
+	tests := []struct {
+		container *Container
+		want      bool
+	}{
+		{
+			container: &Container{},
+			want:      true,
+		},
+		{
+			container: nil,
+			want:      true,
+		},
+		{
+			container: &Container{ID: "foo"},
+			want:      false,
+		},
+	}
 
-	// run test
-	got := c.Empty()
+	// run tests
+	for _, test := range tests {
+		got := test.container.Empty()
 
-	if !got {
-		t.Errorf("Container Empty is %v, want true", got)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("Empty is %v, want %v", got, test.want)
+		}
 	}
 }
 


### PR DESCRIPTION
**EDIT:**

I figured out why I saw this behavior 👍 

I had a corrupted version of the `go-vela/compiler` repo cached in my local stack that I was running for the `go-vela/server`.

This corrupted cache caused the `go-vela/types/pipeline/secret.Origin.Container` field to be `nil` rather than the expected `Container{}` it should be.

**END EDIT**

This PR will make the `go-vela/types/pipeline/container.Empty()` function return true if the underlying container being provided is `nil`.

I ran into this issue when running some pipelines locally today 😢 

I'm not entirely sure how or why I'm seeing this stack trace so I'll have to do more digging to understand the underlying issue.

The error I'm presented with is:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x5263da]

goroutine 9 [running]:
github.com/go-vela/types/pipeline.(*Container).Empty(0x0, 0xc00000a0d4)
	$HOME/go/pkg/mod/github.com/go-vela/types@v0.5.0-rc1.0.20200803141719-70581652958d/pipeline/container.go:141 +0x3a
github.com/go-vela/types/pipeline.(*Build).Sanitize(0xc000158160, 0xc00000a0d4, 0x6, 0x0)
	$HOME/go/pkg/mod/github.com/go-vela/types@v0.5.0-rc1.0.20200803141719-70581652958d/pipeline/build.go:96 +0xbc
main.(*Worker).exec(0xc00011a640, 0x0, 0x0, 0x0)
	$HOME/repos/github.com/go-vela/worker/cmd/vela-worker/exec.go:48 +0x116
main.(*Worker).operate.func1(0x43cee6, 0x18d25f0)
	$HOME/repos/github.com/go-vela/worker/cmd/vela-worker/operate.go:59 +0x56
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc000392180, 0xc000540100)
	$HOME/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:57 +0x59
created by golang.org/x/sync/errgroup.(*Group).Go
	$HOME/go/pkg/mod/golang.org/x/sync@v0.0.0-20200625203802-6e8e738ad208/errgroup/errgroup.go:54 +0x66
```