### PR TITLE
fix(schema): check for image or template on step

### DIFF
--- a/yaml/build.go
+++ b/yaml/build.go
@@ -7,12 +7,12 @@ package yaml
 // Build is the yaml representation of a build for a pipeline.
 // nolint:lll // jsonschema will cause long lines
 type Build struct {
-	Version   string        `yaml:"version,omitempty"   jsonschema:"minLength=1,description=Provide syntax version used to evaluate the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/version/"`
+	Version   string        `yaml:"version,omitempty"   jsonschema:"required,minLength=1,description=Provide syntax version used to evaluate the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/version/"`
 	Metadata  Metadata      `yaml:"metadata,omitempty"  jsonschema:"description=Pass extra information.\nReference: https://go-vela.github.io/docs/concepts/pipeline/metadata/"`
 	Worker    Worker        `yaml:"worker,omitempty"    jsonschema:"description=Limit the pipeline to certain types of workers.\nReference: coming soon"`
 	Secrets   SecretSlice   `yaml:"secrets,omitempty"   jsonschema:"description=Provide sensitive information.\nReference: https://go-vela.github.io/docs/concepts/pipeline/secrets/"`
 	Services  ServiceSlice  `yaml:"services,omitempty"  jsonschema:"description=Provide detached (headless) execution instructions.\nReference: https://go-vela.github.io/docs/concepts/pipeline/services/"`
-	Stages    StageSlice    `yaml:"stages,omitempty"    jsonschema:"description=Provide parallel execution instructions.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/"`
-	Steps     StepSlice     `yaml:"steps,omitempty"     jsonschema:"description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/"`
+	Stages    StageSlice    `yaml:"stages,omitempty"    jsonschema:"oneof_required=stages,description=Provide parallel execution instructions.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/"`
+	Steps     StepSlice     `yaml:"steps,omitempty"     jsonschema:"oneof_required=steps,description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/"`
 	Templates TemplateSlice `yaml:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/"`
 }

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -25,14 +25,14 @@ type (
 	// Rules is the yaml representation of the ruletypes
 	// from a ruleset block for a step in a pipeline.
 	Rules struct {
-		Branch  []string `yaml:"branch,omitempty"  jsonschema:"description=Limits the execution of a step to matching build branches.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Comment []string `yaml:"comment,omitempty" jsonschema:"description=Limits the execution of a step to matching a pull request comment.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Event   []string `yaml:"event,omitempty"   jsonschema:"description=Limits the execution of a step to matching build events.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Path    []string `yaml:"path,omitempty"    jsonschema:"description=Limits the execution of a step to matching files changed in a repository.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
+		Branch  []string `yaml:"branch,omitempty"  jsonschema:"description=Limits the execution of a step to matching build branches.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#branch"`
+		Comment []string `yaml:"comment,omitempty" jsonschema:"description=Limits the execution of a step to matching a pull request comment.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#comment"`
+		Event   []string `yaml:"event,omitempty"   jsonschema:"description=Limits the execution of a step to matching build events.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#event"`
+		Path    []string `yaml:"path,omitempty"    jsonschema:"description=Limits the execution of a step to matching files changed in a repository.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#path"`
 		Repo    []string `yaml:"repo,omitempty"    jsonschema:"description=Limits the execution of a step to matching repos.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Status  []string `yaml:"status,omitempty"  jsonschema:"enum=[failure],enum=[success],description=Limits the execution of a step to matching build statuses.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Tag     []string `yaml:"tag,omitempty"     jsonschema:"description=Limits the execution of a step to matching build tag references.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
-		Target  []string `yaml:"target,omitempty"  jsonschema:"description=Limits the execution of a step to matching build deployment targets.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#fields"`
+		Status  []string `yaml:"status,omitempty"  jsonschema:"enum=[failure],enum=[success],description=Limits the execution of a step to matching build statuses.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#status"`
+		Tag     []string `yaml:"tag,omitempty"     jsonschema:"description=Limits the execution of a step to matching build tag references.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#tag"`
+		Target  []string `yaml:"target,omitempty"  jsonschema:"description=Limits the execution of a step to matching build deployment targets.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/#target"`
 	}
 )
 

--- a/yaml/stage.go
+++ b/yaml/stage.go
@@ -22,7 +22,7 @@ type (
 	// of a stage in a pipeline.
 	// nolint:lll // jsonschema will cause long lines
 	Stage struct {
-		Name  string          `yaml:"name,omitempty"  jsonschema:"minLength=1,description=Unique identifier for the stage in the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/"`
+		Name  string          `yaml:"name,omitempty"  jsonschema:"required,minLength=1,description=Unique identifier for the stage in the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/"`
 		Needs raw.StringSlice `yaml:"needs,omitempty" jsonschema:"description=Stages that must complete before starting the current one.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/needs/"`
 		Steps StepSlice       `yaml:"steps,omitempty" jsonschema:"required,description=Sequential execution instructions for the stage.\nReference: https://go-vela.github.io/docs/concepts/pipeline/stages/steps/"`
 	}

--- a/yaml/step.go
+++ b/yaml/step.go
@@ -22,14 +22,14 @@ type (
 		Detach      bool                   `yaml:"detach,omitempty"      jsonschema:"description=Run the container in a detached (headless) state.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/detach/"`
 		Entrypoint  raw.StringSlice        `yaml:"entrypoint,omitempty"  jsonschema:"description=Command to execute inside the container.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/entrypoint/"`
 		Environment raw.StringSliceMap     `yaml:"environment,omitempty" jsonschema:"description=Provide environment variables injected into the container environment.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/environment/"`
-		Image       string                 `yaml:"image,omitempty"       jsonschema:"required,minLength=1,description=Docker image to use to create the ephemeral container.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/image/"`
+		Image       string                 `yaml:"image,omitempty"       jsonschema:"oneof_required=image,minLength=1,description=Docker image to use to create the ephemeral container.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/image/"`
 		Name        string                 `yaml:"name,omitempty"        jsonschema:"required,minLength=1,description=Unique name for the step."`
 		Parameters  map[string]interface{} `yaml:"parameters,omitempty"  jsonschema:"description=Extra configuration variables for a plugin.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/parameters/"`
 		Privileged  bool                   `yaml:"privileged,omitempty"  jsonschema:"description=Run the container with extra privileges.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/privileged/"`
 		Pull        bool                   `yaml:"pull,omitempty"        jsonschema:"description=Automatically upgrade to the latest version of the image.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/pull/"`
 		Ruleset     Ruleset                `yaml:"ruleset,omitempty"     jsonschema:"description=Conditions to limit the execution of the container.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/ruleset/"`
 		Secrets     StepSecretSlice        `yaml:"secrets,omitempty"     jsonschema:"description=Sensitive variables injected into the container environment.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/secrets/"`
-		Template    StepTemplate           `yaml:"template,omitempty"    jsonschema:"description=Name of template to expand in the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/"`
+		Template    StepTemplate           `yaml:"template,omitempty"    jsonschema:"oneof_required=template,description=Name of template to expand in the pipeline.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/"`
 		Ulimits     UlimitSlice            `yaml:"ulimits,omitempty"     jsonschema:"description=Set the user limits for the container.\nReference: coming soon"`
 		Volumes     VolumeSlice            `yaml:"volumes,omitempty"     jsonschema:"description=Mount volumes for the container.\nReference: coming soon"`
 	}

--- a/yaml/template.go
+++ b/yaml/template.go
@@ -14,15 +14,15 @@ type (
 	// from the templates block for a pipeline.
 	Template struct {
 		Name   string `yaml:"name,omitempty"   jsonschema:"required,minLength=1,description=Unique identifier for the template.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/"`
-		Source string `yaml:"source,omitempty" jsonschema:"required,minLength=1,description=Path to template in remote system.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/"`
-		Type   string `yaml:"type,omitempty"   jsonschema:"minLength=1,description=Type of template provided from the remote system.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/,example=github"`
+		Source string `yaml:"source,omitempty" jsonschema:"required,minLength=1,description=Path to template in remote system.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/source/"`
+		Type   string `yaml:"type,omitempty"   jsonschema:"minLength=1,description=Type of template provided from the remote system.\nReference: https://go-vela.github.io/docs/concepts/pipeline/templates/type/,example=github"`
 	}
 
 	// StepTemplate is the yaml representation of the
 	// template block for a step in a pipeline.
 	StepTemplate struct {
-		Name      string                 `yaml:"name,omitempty" jsonschema:"required,minLength=1,description=Unique identifier for the template.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/"`
-		Variables map[string]interface{} `yaml:"vars,omitempty" jsonschema:"description=Variables injected into the template.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/"`
+		Name      string                 `yaml:"name,omitempty" jsonschema:"required,minLength=1,description=Unique identifier for the template.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/#fields"`
+		Variables map[string]interface{} `yaml:"vars,omitempty" jsonschema:"description=Variables injected into the template.\nReference: https://go-vela.github.io/docs/concepts/pipeline/steps/template/#fields"`
 	}
 )
 

--- a/yaml/worker.go
+++ b/yaml/worker.go
@@ -10,8 +10,8 @@ import "github.com/go-vela/types/pipeline"
 // from a worker block in a pipeline.
 // nolint:lll // jsonschema will cause long lines
 type Worker struct {
-	Flavor   string `yaml:"flavor,omitempty"   jsonschema:"minLength=1,description=Flavor identifier for worker.,example=large"`
-	Platform string `yaml:"platform,omitempty" jsonschema:"minLength=1,description=Platform identifier for the worker.,example=kubernetes"`
+	Flavor   string `yaml:"flavor,omitempty"   jsonschema:"minLength=1,description=Flavor identifier for worker.\nReference: coming soon,example=large"`
+	Platform string `yaml:"platform,omitempty" jsonschema:"minLength=1,description=Platform identifier for the worker.\nReference: coming soon,example=kubernetes"`
 }
 
 // ToPipeline converts the Worker type


### PR DESCRIPTION
main reason for the change is that the schema mistakenly showed steps that used `name` + `template` fields as invalid. we're now using `oneof_required` schema tags to help with that and retrofitted `steps` and `stages` at the root level with the same.

other changes:
- minor refactor for consistency
- wrap volume override in check to make sure it exists
- mark missed required fields as `required`
- improve some doc links in jsonschema tags