### PR TITLE
fix: skip path rule for container.Execute()

### DIFF
--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -182,6 +182,19 @@ func (c *Container) Execute(r *RuleData) bool {
 		// treat the ruleset status as success
 		r.Status = constants.StatusSuccess
 
+		// skip evaluating path in ruleset
+		//
+		// the compiler is the component responsible for
+		// choosing whether a container will run based
+		// off the files changed for a build
+		//
+		// the worker doesn't have any record of
+		// what files changed for a build so we
+		// should "skip" evaluating what the
+		// user provided for the path element
+		c.Ruleset.If.Path = []string{}
+		c.Ruleset.Unless.Path = []string{}
+
 		// return if the container ruleset matches the conditions
 		return c.Ruleset.Match(r)
 	}

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -346,6 +346,69 @@ func TestPipeline_Container_Execute(t *testing.T) {
 			},
 			want: false,
 		},
+		{ // branch/event/path container with build running
+			container: &Container{
+				Name:     "branch/event/path-running",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch: []string{"master"},
+						Event:  []string{constants.EventPush},
+						Path:   []string{"README.md"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "master",
+				Event:  "push",
+				Repo:   "foo/bar",
+				Status: "running",
+			},
+			want: true,
+		},
+		{ // branch/event/path container with build success
+			container: &Container{
+				Name:     "branch/event/path-success",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch: []string{"master"},
+						Event:  []string{constants.EventPush},
+						Path:   []string{"README.md"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "master",
+				Event:  "push",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
+		{ // branch/event/path container with build failure
+			container: &Container{
+				Name:     "branch/event/path-failure",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch: []string{"master"},
+						Event:  []string{constants.EventPush},
+						Path:   []string{"README.md"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "master",
+				Event:  "push",
+				Repo:   "foo/bar",
+				Status: "failure",
+			},
+			want: false,
+		},
 		{ // branch/event/status container with build running
 			container: &Container{
 				Name:     "branch/event/status-running",


### PR DESCRIPTION
Intended to fix:

https://github.com/go-vela/community/issues/108