### PR TITLE
fix: change worker lastCheckedIn to type int64

### DIFF
--- a/database/worker.go
+++ b/database/worker.go
@@ -29,7 +29,7 @@ type Worker struct {
 	Address       sql.NullString `sql:"address"`
 	Routes        pq.StringArray `sql:"routes"`
 	Active        sql.NullBool   `sql:"active"`
-	LastCheckedIn sql.NullTime   `sql:"last_checked_in"`
+	LastCheckedIn sql.NullInt64  `sql:"last_checked_in"`
 }
 
 // Nullify ensures the valid flag for
@@ -58,6 +58,11 @@ func (w *Worker) Nullify() *Worker {
 		w.Hostname.Valid = false
 	}
 
+	// check if the LastCheckedIn field should be false
+	if w.LastCheckedIn.Int64 == 0 {
+		w.LastCheckedIn.Valid = false
+	}
+
 	return w
 }
 
@@ -71,7 +76,7 @@ func (w *Worker) ToLibrary() *library.Worker {
 	worker.SetAddress(w.Address.String)
 	worker.SetRoutes(w.Routes)
 	worker.SetActive(w.Active.Bool)
-	worker.SetLastCheckedIn(w.LastCheckedIn.Time)
+	worker.SetLastCheckedIn(w.LastCheckedIn.Int64)
 	return worker
 }
 
@@ -100,7 +105,7 @@ func WorkerFromLibrary(w *library.Worker) *Worker {
 		Address:       sql.NullString{String: w.GetAddress(), Valid: true},
 		Routes:        w.GetRoutes(),
 		Active:        sql.NullBool{Bool: w.GetActive(), Valid: true},
-		LastCheckedIn: sql.NullTime{Time: w.GetLastCheckedIn(), Valid: true},
+		LastCheckedIn: sql.NullInt64{Int64: w.GetLastCheckedIn(), Valid: true},
 	}
 
 	return worker.Nullify()

--- a/database/worker_test.go
+++ b/database/worker_test.go
@@ -8,7 +8,6 @@ import (
 	"database/sql"
 	"reflect"
 	"testing"
-	"time"
 
 	"github.com/go-vela/types/library"
 )
@@ -22,7 +21,7 @@ func TestDatabase_Worker_Nullify(t *testing.T) {
 		Hostname:      sql.NullString{String: "", Valid: false},
 		Address:       sql.NullString{String: "", Valid: false},
 		Active:        sql.NullBool{Bool: false, Valid: false},
-		LastCheckedIn: sql.NullTime{Time: time.Time{}, Valid: false},
+		LastCheckedIn: sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -63,7 +62,7 @@ func TestDatabase_Worker_ToLibrary(t *testing.T) {
 	want.SetAddress("http://localhost:8080")
 	want.SetRoutes([]string{"vela"})
 	want.SetActive(true)
-	want.SetLastCheckedIn(time.Time{})
+	want.SetLastCheckedIn(1563474077)
 
 	// run test
 	got := testWorker().ToLibrary()
@@ -89,7 +88,7 @@ func TestDatabase_Worker_Validate(t *testing.T) {
 				ID:            sql.NullInt64{Int64: 1, Valid: true},
 				Address:       sql.NullString{String: "http://localhost:8080", Valid: true},
 				Active:        sql.NullBool{Bool: true, Valid: true},
-				LastCheckedIn: sql.NullTime{Time: time.Time{}, Valid: true},
+				LastCheckedIn: sql.NullInt64{Int64: 1563474077, Valid: true},
 			},
 		},
 		{ // no Address set for worker
@@ -98,7 +97,7 @@ func TestDatabase_Worker_Validate(t *testing.T) {
 				ID:            sql.NullInt64{Int64: 1, Valid: true},
 				Hostname:      sql.NullString{String: "worker_0", Valid: true},
 				Active:        sql.NullBool{Bool: true, Valid: true},
-				LastCheckedIn: sql.NullTime{Time: time.Time{}, Valid: true},
+				LastCheckedIn: sql.NullInt64{Int64: 1563474077, Valid: true},
 			},
 		},
 	}
@@ -130,7 +129,7 @@ func TestDatabase_WorkerFromLibrary(t *testing.T) {
 	w.SetAddress("http://localhost:8080")
 	w.SetRoutes([]string{"vela"})
 	w.SetActive(true)
-	w.SetLastCheckedIn(time.Time{})
+	w.SetLastCheckedIn(1563474077)
 
 	want := testWorker()
 
@@ -151,6 +150,6 @@ func testWorker() *Worker {
 		Address:       sql.NullString{String: "http://localhost:8080", Valid: true},
 		Routes:        []string{"vela"},
 		Active:        sql.NullBool{Bool: true, Valid: true},
-		LastCheckedIn: sql.NullTime{Time: time.Time{}, Valid: true},
+		LastCheckedIn: sql.NullInt64{Int64: 1563474077, Valid: true},
 	}
 }

--- a/library/worker.go
+++ b/library/worker.go
@@ -6,19 +6,18 @@ package library
 
 import (
 	"fmt"
-	"time"
 )
 
 // Worker is the library representation of a worker.
 //
 // swagger:model Worker
 type Worker struct {
-	ID            *int64     `json:"id,omitempty"`
-	Hostname      *string    `json:"hostname,omitempty"`
-	Address       *string    `json:"address,omitempty"`
-	Routes        *[]string  `json:"routes,omitempty"`
-	Active        *bool      `json:"active,omitempty"`
-	LastCheckedIn *time.Time `json:"last_checked_in,omitempty"`
+	ID            *int64    `json:"id,omitempty"`
+	Hostname      *string   `json:"hostname,omitempty"`
+	Address       *string   `json:"address,omitempty"`
+	Routes        *[]string `json:"routes,omitempty"`
+	Active        *bool     `json:"active,omitempty"`
+	LastCheckedIn *int64    `json:"last_checked_in,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -90,10 +89,10 @@ func (w *Worker) GetActive() bool {
 //
 // When the provided Worker type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
-func (w *Worker) GetLastCheckedIn() time.Time {
+func (w *Worker) GetLastCheckedIn() int64 {
 	// return zero value if Worker type or LastCheckedIn field is nil
 	if w == nil || w.LastCheckedIn == nil {
-		return time.Time{} // 0001-01-01 00:00:00 +0000 UTC
+		return 0
 	}
 
 	return *w.LastCheckedIn
@@ -168,7 +167,7 @@ func (w *Worker) SetActive(v bool) {
 //
 // When the provided Worker type is nil, it
 // will set nothing and immediately return.
-func (w *Worker) SetLastCheckedIn(v time.Time) {
+func (w *Worker) SetLastCheckedIn(v int64) {
 	// return if Worker type is nil
 	if w == nil {
 		return

--- a/library/worker_test.go
+++ b/library/worker_test.go
@@ -146,7 +146,7 @@ func testWorker() *Worker {
 	w.SetAddress("http://localhost:8080")
 	w.SetRoutes([]string{"vela"})
 	w.SetActive(true)
-	w.SetLastCheckedIn(time.Time{})
+	w.SetLastCheckedIn(time.Time{}.UTC().Unix())
 
 	return w
 }


### PR DESCRIPTION
change to make the LastCheckedIn type more similar to build's [enqueued field](https://github.com/go-vela/types/blob/f1af1d59136e3be6a6126870779b42c212ce3565/database/build.go#L33)