### PR TITLE
fix: issue with accidental secret exposure via wrong syntax

### DIFF
--- a/yaml/secret.go
+++ b/yaml/secret.go
@@ -207,7 +207,6 @@ func (s *StepSecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// attempt to unmarshal as a step secret slice type
 	err = unmarshal(secrets)
 	if err == nil {
-
 		// check for secret source and target
 		for _, secret := range *secrets {
 			if len(secret.Source) == 0 || len(secret.Target) == 0 {

--- a/yaml/secret.go
+++ b/yaml/secret.go
@@ -6,6 +6,7 @@ package yaml
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/go-vela/types/constants"
@@ -206,6 +207,14 @@ func (s *StepSecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error
 	// attempt to unmarshal as a step secret slice type
 	err = unmarshal(secrets)
 	if err == nil {
+
+		// check for secret source and target
+		for _, secret := range *secrets {
+			if len(secret.Source) == 0 || len(secret.Target) == 0{
+				return fmt.Errorf("no secret source or target found")
+			}
+		}
+
 		// overwrite existing StepSecretSlice
 		*s = StepSecretSlice(*secrets)
 		return nil

--- a/yaml/secret.go
+++ b/yaml/secret.go
@@ -210,7 +210,7 @@ func (s *StepSecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error
 
 		// check for secret source and target
 		for _, secret := range *secrets {
-			if len(secret.Source) == 0 || len(secret.Target) == 0{
+			if len(secret.Source) == 0 || len(secret.Target) == 0 {
 				return fmt.Errorf("no secret source or target found")
 			}
 		}

--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -290,6 +290,16 @@ func TestYaml_StepSecretSlice_UnmarshalYAML(t *testing.T) {
 		},
 		{
 			failure: true,
+			file:    "testdata/step_secret_slice_invalid_no_source.yml",
+			want:    nil,
+		},
+		{
+			failure: true,
+			file:    "testdata/step_secret_slice_invalid_no_target.yml",
+			want:    nil,
+		},
+		{
+			failure: true,
 			file:    "testdata/invalid.yml",
 			want:    nil,
 		},

--- a/yaml/testdata/step_secret_slice_invalid_no_source.yml
+++ b/yaml/testdata/step_secret_slice_invalid_no_source.yml
@@ -1,0 +1,2 @@
+---
+- target: foo

--- a/yaml/testdata/step_secret_slice_invalid_no_target.yml
+++ b/yaml/testdata/step_secret_slice_invalid_no_target.yml
@@ -1,0 +1,2 @@
+---
+- source: foo


### PR DESCRIPTION
When using the method to inject a secret with alternative name, ie.

```
secrets:
  - source: secret
    target: alt_secret
```

it's possible to expose the secret by doing the following:

```
secrets:
  - source: secret
  - target: alt_secret
```