### PR TITLE
feat: add version pkg for Vela

### DIFF
--- a/version/doc.go
+++ b/version/doc.go
@@ -1,0 +1,10 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+// Package version provides the defined version types for Vela.
+//
+// Usage:
+//
+// 	import "github.com/go-vela/types/version"
+package version

--- a/version/metadata.go
+++ b/version/metadata.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import "fmt"
+
+const metaFormat = `{
+  Architecture: %s,
+  BuildDate: %s,
+  Compiler: %s,
+  GitCommit: %s,
+  GoVersion: %s,
+  OperatingSystem: %s,
+}`
+
+// Metadata represents extra information surrounding the application version.
+type Metadata struct {
+	// Architecture represents the architecture information for the application.
+	Architecture string `json:"architecture,omitempty"`
+	// BuildDate represents the build date information for the application.
+	BuildDate string `json:"build_date,omitempty"`
+	// Compiler represents the compiler information for the application.
+	Compiler string `json:"compiler,omitempty"`
+	// GitCommit represents the git commit information for the application.
+	GitCommit string `json:"git_commit,omitempty"`
+	// GoVersion represents the golang version information for the application.
+	GoVersion string `json:"go_version,omitempty"`
+	// OperatingSystem represents the operating system information for the application.
+	OperatingSystem string `json:"operating_system,omitempty"`
+}
+
+// String implements the Stringer interface for the Metadata type.
+func (m *Metadata) String() string {
+	return fmt.Sprintf(
+		metaFormat,
+		m.Architecture,
+		m.BuildDate,
+		m.Compiler,
+		m.GitCommit,
+		m.GoVersion,
+		m.OperatingSystem,
+	)
+}

--- a/version/metadata_test.go
+++ b/version/metadata_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestVersion_Metadata_String(t *testing.T) {
+	// setup types
+	m := &Metadata{
+		Architecture:    "amd64",
+		BuildDate:       "1970-1-1T00:00:00Z",
+		Compiler:        "gc",
+		GitCommit:       "abcdef123456789",
+		GoVersion:       "1.15.0",
+		OperatingSystem: "llinux",
+	}
+
+	want := fmt.Sprintf(
+		metaFormat,
+		m.Architecture,
+		m.BuildDate,
+		m.Compiler,
+		m.GitCommit,
+		m.GoVersion,
+		m.OperatingSystem,
+	)
+
+	// run test
+	got := m.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}

--- a/version/version.go
+++ b/version/version.go
@@ -9,7 +9,7 @@ import (
 )
 
 const versionFormat = `{
-  Full: %s,
+  Canonical: %s,
   Major: %d,
   Minor: %d,
   Patch: %d,
@@ -28,18 +28,18 @@ const versionFormat = `{
 // follows semantic version guidelines from
 // https://semver.org/.
 type Version struct {
+	// Canonical represents a canonical semantic version for the application.
+	Canonical string `json:"canonical"`
 	// Major represents incompatible API changes.
-	Major int64 `json:"major,omitempty"`
+	Major int64 `json:"major"`
 	// Minor represents added functionality in a backwards compatible manner.
-	Minor int64 `json:"minor,omitempty"`
+	Minor int64 `json:"minor"`
 	// Patch represents backwards compatible bug fixes.
-	Patch int64 `json:"patch,omitempty"`
+	Patch int64 `json:"patch"`
 	// PreRelease represents unstable changes that might not be compatible.
 	PreRelease string `json:"pre_release,omitempty"`
-	// Full represents a fully functional semantic version for the application.
-	Full string `json:"full,omitempty"`
 	// Metadata represents extra information surrounding the application version.
-	Metadata Metadata
+	Metadata Metadata `json:"metadata,omitempty"`
 }
 
 // Meta implements a formatted string containing only metadata for the Version type.
@@ -49,14 +49,14 @@ func (v *Version) Meta() string {
 
 // Semantic implements a formatted string containing a formal semantic version for the Version type.
 func (v *Version) Semantic() string {
-	return v.Full
+	return v.Canonical
 }
 
 // String implements the Stringer interface for the Version type.
 func (v *Version) String() string {
 	return fmt.Sprintf(
 		versionFormat,
-		v.Full,
+		v.Canonical,
 		v.Major,
 		v.Minor,
 		v.Patch,

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import (
+	"fmt"
+)
+
+const versionFormat = `{
+  Full: %s,
+  Major: %d,
+  Minor: %d,
+  Patch: %d,
+  PreRelease: %s,
+  Metadata: {
+    Architecture: %s,
+    BuildDate: %s,
+    Compiler: %s,
+    GitCommit: %s,
+    GoVersion: %s,
+    OperatingSystem: %s,
+  }
+}`
+
+// Version represents application information that
+// follows semantic version guidelines from
+// https://semver.org/.
+type Version struct {
+	// Major represents incompatible API changes.
+	Major int64 `json:"major,omitempty"`
+	// Minor represents added functionality in a backwards compatible manner.
+	Minor int64 `json:"minor,omitempty"`
+	// Patch represents backwards compatible bug fixes.
+	Patch int64 `json:"patch,omitempty"`
+	// PreRelease represents unstable changes that might not be compatible.
+	PreRelease string `json:"pre_release,omitempty"`
+	// Full represents a fully functional semantic version for the application.
+	Full string `json:"full,omitempty"`
+	// Metadata represents extra information surrounding the application version.
+	Metadata struct {
+		// Architecture represents the architecture information for the application.
+		Architecture string `json:"architecture,omitempty"`
+		// BuildDate represents the build date information for the application.
+		BuildDate string `json:"build_date,omitempty"`
+		// Compiler represents the compiler information for the application.
+		Compiler string `json:"compiler,omitempty"`
+		// GitCommit represents the git commit information for the application.
+		GitCommit string `json:"git_commit,omitempty"`
+		// GoVersion represents the golang version information for the application.
+		GoVersion string `json:"go_version,omitempty"`
+		// OperatingSystem represents the operating system information for the application.
+		OperatingSystem string `json:"operating_system,omitempty"`
+	} `json:"metadata,omitempty"`
+}
+
+// Semantic implements a semantic string of the Stringer interface for the Version type.
+func (v *Version) Semantic() string {
+	return v.Full
+}
+
+// String implements the Stringer interface for the Version type.
+func (v *Version) String() string {
+	return fmt.Sprintf(
+		versionFormat,
+		v.Full,
+		v.Major,
+		v.Minor,
+		v.Patch,
+		v.PreRelease,
+		v.Metadata.Architecture,
+		v.Metadata.BuildDate,
+		v.Metadata.Compiler,
+		v.Metadata.GitCommit,
+		v.Metadata.GoVersion,
+		v.Metadata.OperatingSystem,
+	)
+}

--- a/version/version.go
+++ b/version/version.go
@@ -39,23 +39,15 @@ type Version struct {
 	// Full represents a fully functional semantic version for the application.
 	Full string `json:"full,omitempty"`
 	// Metadata represents extra information surrounding the application version.
-	Metadata struct {
-		// Architecture represents the architecture information for the application.
-		Architecture string `json:"architecture,omitempty"`
-		// BuildDate represents the build date information for the application.
-		BuildDate string `json:"build_date,omitempty"`
-		// Compiler represents the compiler information for the application.
-		Compiler string `json:"compiler,omitempty"`
-		// GitCommit represents the git commit information for the application.
-		GitCommit string `json:"git_commit,omitempty"`
-		// GoVersion represents the golang version information for the application.
-		GoVersion string `json:"go_version,omitempty"`
-		// OperatingSystem represents the operating system information for the application.
-		OperatingSystem string `json:"operating_system,omitempty"`
-	} `json:"metadata,omitempty"`
+	Metadata Metadata
 }
 
-// Semantic implements a semantic string of the Stringer interface for the Version type.
+// Meta implements a formatted string containing only metadata for the Version type.
+func (v *Version) Meta() string {
+	return v.Metadata.String()
+}
+
+// Semantic implements a formatted string containing a formal semantic version for the Version type.
 func (v *Version) Semantic() string {
 	return v.Full
 }

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,108 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package version
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestVersion_Version_Meta(t *testing.T) {
+	// setup types
+	v := &Version{
+		Canonical:  "v1.2.3",
+		Major:      1,
+		Minor:      2,
+		Patch:      3,
+		PreRelease: "",
+		Metadata: Metadata{
+			Architecture:    "amd64",
+			BuildDate:       "1970-1-1T00:00:00Z",
+			Compiler:        "gc",
+			GitCommit:       "abcdef123456789",
+			GoVersion:       "1.15.0",
+			OperatingSystem: "llinux",
+		},
+	}
+
+	want := v.Metadata.String()
+
+	// run test
+	got := v.Meta()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+func TestVersion_Version_Semantic(t *testing.T) {
+	// setup types
+	v := &Version{
+		Canonical:  "v1.2.3",
+		Major:      1,
+		Minor:      2,
+		Patch:      3,
+		PreRelease: "",
+		Metadata: Metadata{
+			Architecture:    "amd64",
+			BuildDate:       "1970-1-1T00:00:00Z",
+			Compiler:        "gc",
+			GitCommit:       "abcdef123456789",
+			GoVersion:       "1.15.0",
+			OperatingSystem: "llinux",
+		},
+	}
+
+	want := v.Canonical
+
+	// run test
+	got := v.Semantic()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+func TestVersion_Version_String(t *testing.T) {
+	// setup types
+	v := &Version{
+		Canonical:  "v1.2.3",
+		Major:      1,
+		Minor:      2,
+		Patch:      3,
+		PreRelease: "",
+		Metadata: Metadata{
+			Architecture:    "amd64",
+			BuildDate:       "1970-1-1T00:00:00Z",
+			Compiler:        "gc",
+			GitCommit:       "abcdef123456789",
+			GoVersion:       "1.15.0",
+			OperatingSystem: "llinux",
+		},
+	}
+
+	want := fmt.Sprintf(
+		versionFormat,
+		v.Canonical,
+		v.Major,
+		v.Minor,
+		v.Patch,
+		v.PreRelease,
+		v.Metadata.Architecture,
+		v.Metadata.BuildDate,
+		v.Metadata.Compiler,
+		v.Metadata.GitCommit,
+		v.Metadata.GoVersion,
+		v.Metadata.OperatingSystem,
+	)
+
+	// run test
+	got := v.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
Implementing a custom `Version` type for Vela that can be referenced throughout the different repos.

When rendered as JSON the output looks like:

```json
{
  "canonical": "v1.2.3",
  "major": 1,
  "minor": 2,
  "patch": 3,
  "metadata": {
    "architecture": "amd64",
    "build_date": "1970-1-1T00:00:00Z",
    "compiler": "gc",
    "git_commit": "abcdef123456789",
    "go_version": "1.15.0",
    "operating_system": "linux"
  }
}
```

Beyond the `String()` functions, this package also supports two different functions:

* `Meta()` - returns only the metadata surrounding the version of the application
* `Semantic()` - returns only the canonical semantic version of the application