### PR TITLE
feat: add template to library, add map helper from compiler

### DIFF
--- a/library/template.go
+++ b/library/template.go
@@ -12,23 +12,23 @@ import (
 //
 // swagger:model Template
 type Template struct {
-	URL    *string `json:"url,omitempty"`
+	Link   *string `json:"link,omitempty"`
 	Name   *string `json:"name,omitempty"`
 	Source *string `json:"source,omitempty"`
 	Type   *string `json:"type,omitempty"`
 }
 
-// GetURL returns the URL field.
+// GetLink returns the Link field.
 //
 // When the provided Template type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
-func (t *Template) GetURL() string {
-	// return zero value if Template type or URL field is nil
-	if t == nil || t.URL == nil {
+func (t *Template) GetLink() string {
+	// return zero value if Template type or Link field is nil
+	if t == nil || t.Link == nil {
 		return ""
 	}
 
-	return *t.URL
+	return *t.Link
 }
 
 // GetName returns the Name field.
@@ -70,17 +70,17 @@ func (t *Template) GetType() string {
 	return *t.Type
 }
 
-// SetURL sets the URL field.
+// SetLink sets the Link field.
 //
 // When the provided Template type is nil, it
 // will set nothing and immediately return.
-func (t *Template) SetURL(v string) {
+func (t *Template) SetLink(v string) {
 	// return if Template type is nil
 	if t == nil {
 		return
 	}
 
-	t.URL = &v
+	t.Link = &v
 }
 
 // SetName sets the Name field.
@@ -130,7 +130,7 @@ func (t *Template) String() string {
   Source: %s,
   Type: %s,
 }`,
-		t.GetURL(),
+		t.GetLink(),
 		t.GetName(),
 		t.GetSource(),
 		t.GetType(),

--- a/library/template.go
+++ b/library/template.go
@@ -12,7 +12,7 @@ import (
 //
 // swagger:model Template
 type Template struct {
-	HTMLURL *string `json:"id,omitempty"`
+	HTMLURL *string `json:"html_url,omitempty"`
 	Name    *string `json:"name,omitempty"`
 	Source  *string `json:"source,omitempty"`
 	Type    *string `json:"type,omitempty"`

--- a/library/template.go
+++ b/library/template.go
@@ -1,0 +1,138 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import (
+	"fmt"
+)
+
+// Template is the library representation of a template for a pipeline.
+//
+// swagger:model Template
+type Template struct {
+	HTMLURL *string `json:"id,omitempty"`
+	Name    *string `json:"name,omitempty"`
+	Source  *string `json:"source,omitempty"`
+	Type    *string `json:"type,omitempty"`
+}
+
+// GetHTMLURL returns the HTMLURL field.
+//
+// When the provided Template type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (t *Template) GetHTMLURL() string {
+	// return zero value if Template type or HTMLURL field is nil
+	if t == nil || t.HTMLURL == nil {
+		return ""
+	}
+
+	return *t.HTMLURL
+}
+
+// GetName returns the Name field.
+//
+// When the provided Template type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (t *Template) GetName() string {
+	// return zero value if Template type or Name field is nil
+	if t == nil || t.Name == nil {
+		return ""
+	}
+
+	return *t.Name
+}
+
+// GetSource returns the Source field.
+//
+// When the provided Template type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (t *Template) GetSource() string {
+	// return zero value if Template type or Source field is nil
+	if t == nil || t.Source == nil {
+		return ""
+	}
+
+	return *t.Source
+}
+
+// GetType returns the Type field.
+//
+// When the provided Template type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (t *Template) GetType() string {
+	// return zero value if Template type or Type field is nil
+	if t == nil || t.Type == nil {
+		return ""
+	}
+
+	return *t.Type
+}
+
+// SetHTMLURL sets the HTMLURL field.
+//
+// When the provided Template type is nil, it
+// will set nothing and immediately return.
+func (t *Template) SetHTMLURL(v string) {
+	// return if Template type is nil
+	if t == nil {
+		return
+	}
+
+	t.HTMLURL = &v
+}
+
+// SetName sets the Name field.
+//
+// When the provided Template type is nil, it
+// will set nothing and immediately return.
+func (t *Template) SetName(v string) {
+	// return if Template type is nil
+	if t == nil {
+		return
+	}
+
+	t.Name = &v
+}
+
+// SetSource sets the Source field.
+//
+// When the provided Template type is nil, it
+// will set nothing and immediately return.
+func (t *Template) SetSource(v string) {
+	// return if Template type is nil
+	if t == nil {
+		return
+	}
+
+	t.Source = &v
+}
+
+// SetType sets the Type field.
+//
+// When the provided Template type is nil, it
+// will set nothing and immediately return.
+func (t *Template) SetType(v string) {
+	// return if Template type is nil
+	if t == nil {
+		return
+	}
+
+	t.Type = &v
+}
+
+// String implements the Stringer interface for the Template type.
+func (t *Template) String() string {
+	return fmt.Sprintf(`{
+  Link: %s,
+  Name: %s,
+  Source: %s,
+  Type: %s,
+}`,
+		t.GetHTMLURL(),
+		t.GetName(),
+		t.GetSource(),
+		t.GetType(),
+	)
+}

--- a/library/template.go
+++ b/library/template.go
@@ -12,23 +12,23 @@ import (
 //
 // swagger:model Template
 type Template struct {
-	HTMLURL *string `json:"html_url,omitempty"`
-	Name    *string `json:"name,omitempty"`
-	Source  *string `json:"source,omitempty"`
-	Type    *string `json:"type,omitempty"`
+	URL    *string `json:"url,omitempty"`
+	Name   *string `json:"name,omitempty"`
+	Source *string `json:"source,omitempty"`
+	Type   *string `json:"type,omitempty"`
 }
 
-// GetHTMLURL returns the HTMLURL field.
+// GetURL returns the URL field.
 //
 // When the provided Template type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
-func (t *Template) GetHTMLURL() string {
-	// return zero value if Template type or HTMLURL field is nil
-	if t == nil || t.HTMLURL == nil {
+func (t *Template) GetURL() string {
+	// return zero value if Template type or URL field is nil
+	if t == nil || t.URL == nil {
 		return ""
 	}
 
-	return *t.HTMLURL
+	return *t.URL
 }
 
 // GetName returns the Name field.
@@ -70,17 +70,17 @@ func (t *Template) GetType() string {
 	return *t.Type
 }
 
-// SetHTMLURL sets the HTMLURL field.
+// SetURL sets the URL field.
 //
 // When the provided Template type is nil, it
 // will set nothing and immediately return.
-func (t *Template) SetHTMLURL(v string) {
+func (t *Template) SetURL(v string) {
 	// return if Template type is nil
 	if t == nil {
 		return
 	}
 
-	t.HTMLURL = &v
+	t.URL = &v
 }
 
 // SetName sets the Name field.
@@ -130,7 +130,7 @@ func (t *Template) String() string {
   Source: %s,
   Type: %s,
 }`,
-		t.GetHTMLURL(),
+		t.GetURL(),
 		t.GetName(),
 		t.GetSource(),
 		t.GetType(),

--- a/library/template_test.go
+++ b/library/template_test.go
@@ -1,0 +1,128 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestLibrary_Template_Getters(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		template *Template
+		want     *Template
+	}{
+		{
+			template: testTemplate(),
+			want:     testTemplate(),
+		},
+		{
+			template: new(Template),
+			want:     new(Template),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		if test.template.GetHTMLURL() != test.want.GetHTMLURL() {
+			t.Errorf("GetHTMLURL is %v, want %v", test.template.GetHTMLURL(), test.want.GetHTMLURL())
+		}
+
+		if test.template.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.template.GetName(), test.want.GetName())
+		}
+
+		if test.template.GetSource() != test.want.GetSource() {
+			t.Errorf("GetSource is %v, want %v", test.template.GetSource(), test.want.GetSource())
+		}
+
+		if test.template.GetType() != test.want.GetType() {
+			t.Errorf("GetType is %v, want %v", test.template.GetType(), test.want.GetType())
+		}
+	}
+}
+
+func TestLibrary_Template_Setters(t *testing.T) {
+	// setup types
+	var tmpl *Template
+
+	// setup tests
+	tests := []struct {
+		template *Template
+		want     *Template
+	}{
+		{
+			template: testTemplate(),
+			want:     testTemplate(),
+		},
+		{
+			template: tmpl,
+			want:     new(Template),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		test.template.SetHTMLURL(test.want.GetHTMLURL())
+		test.template.SetName(test.want.GetName())
+		test.template.SetSource(test.want.GetSource())
+		test.template.SetType(test.want.GetType())
+
+		if test.template.GetHTMLURL() != test.want.GetHTMLURL() {
+			t.Errorf("SetHTMLURL is %v, want %v", test.template.GetHTMLURL(), test.want.GetHTMLURL())
+		}
+
+		if test.template.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.template.GetName(), test.want.GetName())
+		}
+
+		if test.template.GetSource() != test.want.GetSource() {
+			t.Errorf("SetSource is %v, want %v", test.template.GetSource(), test.want.GetSource())
+		}
+
+		if test.template.GetType() != test.want.GetType() {
+			t.Errorf("SetType is %v, want %v", test.template.GetType(), test.want.GetType())
+		}
+	}
+}
+
+func TestLibrary_Template_String(t *testing.T) {
+	// setup types
+	tmpl := testTemplate()
+
+	want := fmt.Sprintf(`{
+  Link: %s,
+  Name: %s,
+  Source: %s,
+  Type: %s,
+}`,
+		tmpl.GetHTMLURL(),
+		tmpl.GetName(),
+		tmpl.GetSource(),
+		tmpl.GetType(),
+	)
+
+	// run test
+	got := tmpl.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+// testTemplate is a test helper function to create a Template
+// type with all fields set to a fake value.
+func testTemplate() *Template {
+	u := new(Template)
+
+	u.SetHTMLURL("https://github.com/github/octocat/blob/branch/template.yml")
+	u.SetName("template")
+	u.SetSource("github.com/github/octocat/template.yml@branch")
+	u.SetType("github")
+
+	return u
+}

--- a/library/template_test.go
+++ b/library/template_test.go
@@ -28,8 +28,8 @@ func TestLibrary_Template_Getters(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		if test.template.GetURL() != test.want.GetURL() {
-			t.Errorf("GetURL is %v, want %v", test.template.GetURL(), test.want.GetURL())
+		if test.template.GetLink() != test.want.GetLink() {
+			t.Errorf("GetLink is %v, want %v", test.template.GetLink(), test.want.GetLink())
 		}
 
 		if test.template.GetName() != test.want.GetName() {
@@ -67,13 +67,13 @@ func TestLibrary_Template_Setters(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		test.template.SetURL(test.want.GetURL())
+		test.template.SetLink(test.want.GetLink())
 		test.template.SetName(test.want.GetName())
 		test.template.SetSource(test.want.GetSource())
 		test.template.SetType(test.want.GetType())
 
-		if test.template.GetURL() != test.want.GetURL() {
-			t.Errorf("SetURL is %v, want %v", test.template.GetURL(), test.want.GetURL())
+		if test.template.GetLink() != test.want.GetLink() {
+			t.Errorf("SetLink is %v, want %v", test.template.GetLink(), test.want.GetLink())
 		}
 
 		if test.template.GetName() != test.want.GetName() {
@@ -100,7 +100,7 @@ func TestLibrary_Template_String(t *testing.T) {
   Source: %s,
   Type: %s,
 }`,
-		tmpl.GetURL(),
+		tmpl.GetLink(),
 		tmpl.GetName(),
 		tmpl.GetSource(),
 		tmpl.GetType(),
@@ -119,7 +119,7 @@ func TestLibrary_Template_String(t *testing.T) {
 func testTemplate() *Template {
 	t := new(Template)
 
-	t.SetURL("https://github.com/github/octocat/blob/branch/template.yml")
+	t.SetLink("https://github.com/github/octocat/blob/branch/template.yml")
 	t.SetName("template")
 	t.SetSource("github.com/github/octocat/template.yml@branch")
 	t.SetType("github")

--- a/library/template_test.go
+++ b/library/template_test.go
@@ -28,8 +28,8 @@ func TestLibrary_Template_Getters(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		if test.template.GetHTMLURL() != test.want.GetHTMLURL() {
-			t.Errorf("GetHTMLURL is %v, want %v", test.template.GetHTMLURL(), test.want.GetHTMLURL())
+		if test.template.GetURL() != test.want.GetURL() {
+			t.Errorf("GetURL is %v, want %v", test.template.GetURL(), test.want.GetURL())
 		}
 
 		if test.template.GetName() != test.want.GetName() {
@@ -67,13 +67,13 @@ func TestLibrary_Template_Setters(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		test.template.SetHTMLURL(test.want.GetHTMLURL())
+		test.template.SetURL(test.want.GetURL())
 		test.template.SetName(test.want.GetName())
 		test.template.SetSource(test.want.GetSource())
 		test.template.SetType(test.want.GetType())
 
-		if test.template.GetHTMLURL() != test.want.GetHTMLURL() {
-			t.Errorf("SetHTMLURL is %v, want %v", test.template.GetHTMLURL(), test.want.GetHTMLURL())
+		if test.template.GetURL() != test.want.GetURL() {
+			t.Errorf("SetURL is %v, want %v", test.template.GetURL(), test.want.GetURL())
 		}
 
 		if test.template.GetName() != test.want.GetName() {
@@ -100,7 +100,7 @@ func TestLibrary_Template_String(t *testing.T) {
   Source: %s,
   Type: %s,
 }`,
-		tmpl.GetHTMLURL(),
+		tmpl.GetURL(),
 		tmpl.GetName(),
 		tmpl.GetSource(),
 		tmpl.GetType(),
@@ -119,7 +119,7 @@ func TestLibrary_Template_String(t *testing.T) {
 func testTemplate() *Template {
 	t := new(Template)
 
-	t.SetHTMLURL("https://github.com/github/octocat/blob/branch/template.yml")
+	t.SetURL("https://github.com/github/octocat/blob/branch/template.yml")
 	t.SetName("template")
 	t.SetSource("github.com/github/octocat/template.yml@branch")
 	t.SetType("github")

--- a/library/template_test.go
+++ b/library/template_test.go
@@ -117,12 +117,12 @@ func TestLibrary_Template_String(t *testing.T) {
 // testTemplate is a test helper function to create a Template
 // type with all fields set to a fake value.
 func testTemplate() *Template {
-	u := new(Template)
+	t := new(Template)
 
-	u.SetHTMLURL("https://github.com/github/octocat/blob/branch/template.yml")
-	u.SetName("template")
-	u.SetSource("github.com/github/octocat/template.yml@branch")
-	u.SetType("github")
+	t.SetHTMLURL("https://github.com/github/octocat/blob/branch/template.yml")
+	t.SetName("template")
+	t.SetSource("github.com/github/octocat/template.yml@branch")
+	t.SetType("github")
 
-	return u
+	return t
 }

--- a/yaml/template.go
+++ b/yaml/template.go
@@ -72,10 +72,14 @@ func TemplateFromLibrary(t *library.Template) *Template {
 }
 
 // Map helper function that creates a map of templates from a slice of templates.
-func (t *TemplateSlice) Map(templates TemplateSlice) map[string]*Template {
+func (t *TemplateSlice) Map() map[string]*Template {
 	m := make(map[string]*Template)
 
-	for _, tmpl := range templates {
+	if t == nil {
+		return m
+	}
+
+	for _, tmpl := range *t {
 		m[tmpl.Name] = tmpl
 	}
 

--- a/yaml/template.go
+++ b/yaml/template.go
@@ -4,6 +4,10 @@
 
 package yaml
 
+import (
+	"github.com/go-vela/types/library"
+)
+
 // nolint:lll // jsonschema will cause long lines
 type (
 	// TemplateSlice is the yaml representation
@@ -41,6 +45,30 @@ func (t *TemplateSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	*t = TemplateSlice(*templateSlice)
 
 	return nil
+}
+
+// ToLibrary converts the Template type
+// to a library Template type.
+func (t *Template) ToLibrary() *library.Template {
+	template := new(library.Template)
+
+	template.SetName(t.Name)
+	template.SetSource(t.Source)
+	template.SetType(t.Type)
+
+	return template
+}
+
+// TemplateFromLibrary converts the library Template type
+// to a yaml Template type.
+func TemplateFromLibrary(t *library.Template) *Template {
+	template := &Template{
+		Name:   t.GetName(),
+		Source: t.GetSource(),
+		Type:   t.GetType(),
+	}
+
+	return template
 }
 
 // Map helper function that creates a map of templates from a slice of templates.

--- a/yaml/template.go
+++ b/yaml/template.go
@@ -42,3 +42,14 @@ func (t *TemplateSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	return nil
 }
+
+// Map helper function that creates a map of templates from a slice of templates.
+func (t *TemplateSlice) Map(templates TemplateSlice) map[string]*Template {
+	m := make(map[string]*Template)
+
+	for _, tmpl := range templates {
+		m[tmpl.Name] = tmpl
+	}
+
+	return m
+}

--- a/yaml/template_test.go
+++ b/yaml/template_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/types/library"
 	yaml "gopkg.in/yaml.v2"
 )
 
@@ -68,5 +69,46 @@ func TestBuild_TemplateSlice_UnmarshalYAML(t *testing.T) {
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("UnmarshalYAML is %v, want %v", got, test.want)
 		}
+	}
+}
+
+func TestYAML_Template_ToLibrary(t *testing.T) {
+	// setup types
+	want := new(library.Template)
+	want.SetName("docker_build")
+	want.SetSource("github.com/go-vela/atlas/stable/docker_build")
+	want.SetType("github")
+
+	tmpl := &Template{
+		Name:   "docker_build",
+		Source: "github.com/go-vela/atlas/stable/docker_build",
+		Type:   "github",
+	}
+
+	// run test
+	got := tmpl.ToLibrary()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToLibrary is %v, want %v", got, want)
+	}
+}
+
+func TestYAML_TemplateFromLibrary(t *testing.T) {
+	// setup types
+	want := &Template{
+		Name:   "docker_build",
+		Source: "github.com/go-vela/atlas/stable/docker_build",
+		Type:   "github",
+	}
+
+	tmpl := new(library.Template)
+	tmpl.SetName("docker_build")
+	tmpl.SetSource("github.com/go-vela/atlas/stable/docker_build")
+	tmpl.SetType("github")
+	// run test
+	got := TemplateFromLibrary(tmpl)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("TemplateFromLibrary is %v, want %v", got, want)
 	}
 }

--- a/yaml/template_test.go
+++ b/yaml/template_test.go
@@ -105,6 +105,7 @@ func TestYAML_TemplateFromLibrary(t *testing.T) {
 	tmpl.SetName("docker_build")
 	tmpl.SetSource("github.com/go-vela/atlas/stable/docker_build")
 	tmpl.SetType("github")
+
 	// run test
 	got := TemplateFromLibrary(tmpl)
 


### PR DESCRIPTION
Changes:
- Adding Template library type for use with `pipelines/*/*/templates` referenced in the pipeline endpoints feature https://github.com/go-vela/server/pull/203
- Moving map helper to yaml Template type (duplicate code used in server AND compiler) 

Why?
- YAML Template type exists here https://github.com/go-vela/types/blob/master/yaml/template.go#L15-L19 but lacks a field for HTMLURL that would greatly improve the functionality provided by`pipelines/*/*/templates`. Namely, providing the HTMLURL will allow for direct-linking to templates in the UI.
- mapFromTemplates exists in the compiler but is now being duplicated in https://github.com/go-vela/server/pull/203
https://github.com/go-vela/compiler/blob/cd7849cddf72ecd91e092ca050d7dd71d6c30f73/compiler/native/expand.go#L92-L101 this PR de-dupes and moves the code to the yaml package 