### PR TITLE
feat(repo settings): allow minimum build timeout of 1 minute

### DIFF
--- a/constants/limit.go
+++ b/constants/limit.go
@@ -7,7 +7,7 @@ package constants
 // Limits and constraints.
 const (
 	// BuildTimeoutMin defines the minimum value in minutes for repo build timeout.
-	BuildTimeoutMin = 30
+	BuildTimeoutMin = 1
 
 	// BuildTimeoutMax defines the maximum value in minutes for repo build timeout.
 	BuildTimeoutMax = 90


### PR DESCRIPTION
* this allows for a build timeout of as low as 1 minute to be set in cli, ui, etc.

* corresponding ui pr: https://github.com/go-vela/ui/pull/240