### PR TITLE
enhance(workers): add build_limit field

### DIFF
--- a/database/worker.go
+++ b/database/worker.go
@@ -30,6 +30,7 @@ type Worker struct {
 	Routes        pq.StringArray `sql:"routes"`
 	Active        sql.NullBool   `sql:"active"`
 	LastCheckedIn sql.NullInt64  `sql:"last_checked_in"`
+	BuildLimit    sql.NullInt64  `sql:"build_limit"`
 }
 
 // Nullify ensures the valid flag for
@@ -63,6 +64,10 @@ func (w *Worker) Nullify() *Worker {
 		w.LastCheckedIn.Valid = false
 	}
 
+	if w.BuildLimit.Int64 == 0 {
+		w.BuildLimit.Valid = false
+	}
+
 	return w
 }
 
@@ -77,6 +82,7 @@ func (w *Worker) ToLibrary() *library.Worker {
 	worker.SetRoutes(w.Routes)
 	worker.SetActive(w.Active.Bool)
 	worker.SetLastCheckedIn(w.LastCheckedIn.Int64)
+	worker.SetBuildLimit(w.BuildLimit.Int64)
 	return worker
 }
 
@@ -106,6 +112,7 @@ func WorkerFromLibrary(w *library.Worker) *Worker {
 		Routes:        w.GetRoutes(),
 		Active:        sql.NullBool{Bool: w.GetActive(), Valid: true},
 		LastCheckedIn: sql.NullInt64{Int64: w.GetLastCheckedIn(), Valid: true},
+		BuildLimit:    sql.NullInt64{Int64: w.GetBuildLimit(), Valid: true},
 	}
 
 	return worker.Nullify()

--- a/database/worker_test.go
+++ b/database/worker_test.go
@@ -22,6 +22,7 @@ func TestDatabase_Worker_Nullify(t *testing.T) {
 		Address:       sql.NullString{String: "", Valid: false},
 		Active:        sql.NullBool{Bool: false, Valid: false},
 		LastCheckedIn: sql.NullInt64{Int64: 0, Valid: false},
+		BuildLimit:    sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -63,6 +64,7 @@ func TestDatabase_Worker_ToLibrary(t *testing.T) {
 	want.SetRoutes([]string{"vela"})
 	want.SetActive(true)
 	want.SetLastCheckedIn(1563474077)
+	want.SetBuildLimit(2)
 
 	// run test
 	got := testWorker().ToLibrary()
@@ -130,6 +132,7 @@ func TestDatabase_WorkerFromLibrary(t *testing.T) {
 	w.SetRoutes([]string{"vela"})
 	w.SetActive(true)
 	w.SetLastCheckedIn(1563474077)
+	w.SetBuildLimit(2)
 
 	want := testWorker()
 
@@ -151,5 +154,6 @@ func testWorker() *Worker {
 		Routes:        []string{"vela"},
 		Active:        sql.NullBool{Bool: true, Valid: true},
 		LastCheckedIn: sql.NullInt64{Int64: 1563474077, Valid: true},
+		BuildLimit:    sql.NullInt64{Int64: 2, Valid: true},
 	}
 }

--- a/library/worker.go
+++ b/library/worker.go
@@ -18,7 +18,7 @@ type Worker struct {
 	Routes        *[]string `json:"routes,omitempty"`
 	Active        *bool     `json:"active,omitempty"`
 	LastCheckedIn *int64    `json:"last_checked_in,omitempty"`
-	BuildLimit    *int      `json:"build_limit,omitempty"`
+	BuildLimit    *int64    `json:"build_limit,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -103,7 +103,7 @@ func (w *Worker) GetLastCheckedIn() int64 {
 //
 // When the provided Worker type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
-func (w *Worker) GetBuildLimit() int {
+func (w *Worker) GetBuildLimit() int64 {
 	// return zero value if Worker type or BuildLimit field is nil
 	if w == nil || w.BuildLimit == nil {
 		return 0
@@ -194,7 +194,7 @@ func (w *Worker) SetLastCheckedIn(v int64) {
 //
 // When the provided Worker type is nil, it
 // will set nothing and immediately return.
-func (w *Worker) SetBuildLimit(v int) {
+func (w *Worker) SetBuildLimit(v int64) {
 	// return if Worker type is nil
 	if w == nil {
 		return

--- a/library/worker.go
+++ b/library/worker.go
@@ -18,6 +18,7 @@ type Worker struct {
 	Routes        *[]string `json:"routes,omitempty"`
 	Active        *bool     `json:"active,omitempty"`
 	LastCheckedIn *int64    `json:"last_checked_in,omitempty"`
+	BuildLimit    *int      `json:"build_limit,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -85,7 +86,7 @@ func (w *Worker) GetActive() bool {
 	return *w.Active
 }
 
-// GetLastCheckedIn returns the Active field.
+// GetLastCheckedIn returns the LastCheckedIn field.
 //
 // When the provided Worker type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
@@ -96,6 +97,19 @@ func (w *Worker) GetLastCheckedIn() int64 {
 	}
 
 	return *w.LastCheckedIn
+}
+
+// GetBuildLimit returns the BuildLimit field.
+//
+// When the provided Worker type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (w *Worker) GetBuildLimit() int {
+	// return zero value if Worker type or BuildLimit field is nil
+	if w == nil || w.BuildLimit == nil {
+		return 0
+	}
+
+	return *w.BuildLimit
 }
 
 // SetID sets the ID field.
@@ -176,6 +190,19 @@ func (w *Worker) SetLastCheckedIn(v int64) {
 	w.LastCheckedIn = &v
 }
 
+// SetBuildLimit sets the LastBuildLimit field.
+//
+// When the provided Worker type is nil, it
+// will set nothing and immediately return.
+func (w *Worker) SetBuildLimit(v int) {
+	// return if Worker type is nil
+	if w == nil {
+		return
+	}
+
+	w.BuildLimit = &v
+}
+
 // String implements the Stringer interface for the Worker type.
 func (w *Worker) String() string {
 	return fmt.Sprintf(`{
@@ -185,6 +212,7 @@ func (w *Worker) String() string {
   Routes: %s,
   Active: %t,
   LastCheckedIn: %v,
+  BuildLimit: %v,
 }`,
 		w.GetID(),
 		w.GetHostname(),
@@ -192,5 +220,6 @@ func (w *Worker) String() string {
 		w.GetRoutes(),
 		w.GetActive(),
 		w.GetLastCheckedIn(),
+		w.GetBuildLimit(),
 	)
 }

--- a/library/worker_test.go
+++ b/library/worker_test.go
@@ -52,6 +52,10 @@ func TestLibrary_Worker_Getters(t *testing.T) {
 		if test.worker.GetLastCheckedIn() != test.want.GetLastCheckedIn() {
 			t.Errorf("GetLastCheckedIn is %v, want %v", test.worker.GetLastCheckedIn(), test.want.GetLastCheckedIn())
 		}
+
+		if test.worker.GetBuildLimit() != test.want.GetBuildLimit() {
+			t.Errorf("GetBuildLimit is %v, want %v", test.worker.GetBuildLimit(), test.want.GetBuildLimit())
+		}
 	}
 }
 
@@ -81,6 +85,7 @@ func TestLibrary_Worker_Setters(t *testing.T) {
 		test.worker.SetAddress(test.want.GetAddress())
 		test.worker.SetActive(test.want.GetActive())
 		test.worker.SetLastCheckedIn(test.want.GetLastCheckedIn())
+		test.worker.SetBuildLimit(test.want.GetBuildLimit())
 
 		if test.worker.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.worker.GetID(), test.want.GetID())
@@ -105,6 +110,10 @@ func TestLibrary_Worker_Setters(t *testing.T) {
 		if test.worker.GetLastCheckedIn() != test.want.GetLastCheckedIn() {
 			t.Errorf("SetLastCheckedIn is %v, want %v", test.worker.GetLastCheckedIn(), test.want.GetLastCheckedIn())
 		}
+
+		if test.worker.GetBuildLimit() != test.want.GetBuildLimit() {
+			t.Errorf("SetBuildLimit is %v, want %v", test.worker.GetBuildLimit(), test.want.GetBuildLimit())
+		}
 	}
 }
 
@@ -119,6 +128,7 @@ func TestLibrary_Worker_String(t *testing.T) {
   Routes: %s,
   Active: %t,
   LastCheckedIn: %v,
+  BuildLimit: %v,
 }`,
 		w.GetID(),
 		w.GetHostname(),
@@ -126,6 +136,7 @@ func TestLibrary_Worker_String(t *testing.T) {
 		w.GetRoutes(),
 		w.GetActive(),
 		w.GetLastCheckedIn(),
+		w.GetBuildLimit(),
 	)
 
 	// run test
@@ -147,6 +158,7 @@ func testWorker() *Worker {
 	w.SetRoutes([]string{"vela"})
 	w.SetActive(true)
 	w.SetLastCheckedIn(time.Time{}.UTC().Unix())
+	w.SetBuildLimit(2)
 
 	return w
 }


### PR DESCRIPTION
Add the `build_limit` field to the Worker struct to allow tracking the [BUILD_LIMIT](https://github.com/go-vela/worker/blob/7e41a9d30647af09eab67e97c6ada259e4f0b3f2/cmd/vela-worker/flags.go#L48) for all workers.

xref: https://github.com/go-vela/community/issues/164