### PR TITLE
feat(constants): add local executor driver

### DIFF
--- a/constants/driver.go
+++ b/constants/driver.go
@@ -15,14 +15,17 @@ const (
 
 // Agent executor drivers.
 const (
+	// DriverDarwin defines the driver type when integrating with a darwin distribution.
+	DriverDarwin = "darwin"
+
 	// DriverLinux defines the driver type when integrating with a linux distribution.
 	DriverLinux = "linux"
 
+	// DriverLocal defines the driver type when integrating with a local system.
+	DriverLocal = "local"
+
 	// DriverWindows defines the driver type when integrating with a windows distribution.
 	DriverWindows = "windows"
-
-	// DriverDarwin defines the driver type when integrating with a darwin distribution.
-	DriverDarwin = "darwin"
 )
 
 // Server and agent queue drivers.

--- a/constants/driver.go
+++ b/constants/driver.go
@@ -13,7 +13,7 @@ const (
 	DriverSqlite = "sqlite3"
 )
 
-// Agent executor drivers.
+// Worker executor drivers.
 const (
 	// DriverDarwin defines the driver type when integrating with a darwin distribution.
 	DriverDarwin = "darwin"
@@ -28,7 +28,7 @@ const (
 	DriverWindows = "windows"
 )
 
-// Server and agent queue drivers.
+// Server and worker queue drivers.
 const (
 
 	// DriverKafka defines the driver type when integrating with a Kafka queue.
@@ -38,7 +38,7 @@ const (
 	DriverRedis = "redis"
 )
 
-// Agent runtime drivers.
+// Worker runtime drivers.
 const (
 	// DriverDocker defines the driver type when integrating with a Docker runtime.
 	DriverDocker = "docker"
@@ -47,7 +47,7 @@ const (
 	DriverKubernetes = "kubernetes"
 )
 
-// Server and agent secret drivers.
+// Server and worker secret drivers.
 const (
 	// DriverNative defines the driver type when integrating with a Vela secret service.
 	DriverNative = "native"


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds an executor driver for the `local` executor to our list of constants.

I also renamed any references to `agent` to the proper term of `worker`.