### PR TITLE
feat: add workspace constants for services and steps

### DIFF
--- a/constants/workspace.go
+++ b/constants/workspace.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2020 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package constants
+
+// Service and Step workspace paths.
+const (
+	// WorkspaceDefault defines the default workspace path for a service or a step.
+	WorkspaceDefault = "/vela/src"
+
+	// WorkspaceMount defines the mount workspace path for a service or a step.
+	WorkspaceMount = "/vela"
+)


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/54

This adds constants for setting up the default workspace path and default mount path for services and steps:

https://github.com/go-vela/types/blob/795d689a3f11d97eff2a89e1f1f0d9da6e8b02f1/constants/workspace.go#L9-L10

https://github.com/go-vela/types/blob/795d689a3f11d97eff2a89e1f1f0d9da6e8b02f1/constants/workspace.go#L12-L13

These constants will be used throughout several codebases like:

* [go-vela/cli](https://github.com/go-vela/cli/blob/feature/action/pipeline/exec/action/pipeline/exec.go#L57)
* [go-vela/compiler](https://github.com/go-vela/compiler/blob/master/compiler/native/environment.go#L185)
* [go-vela/pkg-executor](https://github.com/go-vela/pkg-executor/blob/feature/internal/step_environment/internal/step/environment.go#L38)
* [go-vela/pkg-runtime](https://github.com/go-vela/pkg-runtime/blob/master/runtime/docker/volume.go#L96)