### PR TITLE
fix(step): ignore images that contain variables

### DIFF
--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -438,6 +438,11 @@ func TestYaml_SecretSlice_Validate(t *testing.T) {
 			file:    "testdata/secret/validate/plugin_bad_image.yml",
 			wantErr: true,
 		},
+		{
+			name:    "success: secret plugin variable image",
+			file:    "testdata/secret/validate/plugin_variable_image.yml",
+			wantErr: false,
+		},
 	}
 
 	// run tests

--- a/yaml/service.go
+++ b/yaml/service.go
@@ -7,8 +7,9 @@ package yaml
 import (
 	"errors"
 	"fmt"
-	"github.com/docker/distribution/reference"
 	"strings"
+
+	"github.com/docker/distribution/reference"
 
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"

--- a/yaml/service_test.go
+++ b/yaml/service_test.go
@@ -149,6 +149,11 @@ func TestServiceSlice_Validate(t *testing.T) {
 			file:    "testdata/service/validate/bad_image.yml",
 			wantErr: true,
 		},
+		{
+			name:    "success: image with variable image",
+			file:    "testdata/service/validate/variable_image.yml",
+			wantErr: false,
+		},
 	}
 
 	// run tests

--- a/yaml/step.go
+++ b/yaml/step.go
@@ -169,7 +169,7 @@ func (s *StepSlice) Validate(pipeline []byte) error {
 			// nolint:lll // line can not be shortened due to providing detailed error message
 			invalid = fmt.Errorf("%w: %s", invalid, fmt.Errorf("no commands, environment, parameters, secrets or template provided for step %s:\n%s\n ", step.Name, string(source)))
 		}
-
+		// ignore images that contain variable interpolation since expansion is not handled until later
 		if len(step.Image) != 0 && !strings.Contains(step.Image, "${") {
 			// parse the image provided into a
 			// named, fully qualified reference

--- a/yaml/step.go
+++ b/yaml/step.go
@@ -170,7 +170,7 @@ func (s *StepSlice) Validate(pipeline []byte) error {
 			invalid = fmt.Errorf("%w: %s", invalid, fmt.Errorf("no commands, environment, parameters, secrets or template provided for step %s:\n%s\n ", step.Name, string(source)))
 		}
 
-		if len(step.Image) != 0 {
+		if len(step.Image) != 0 && !strings.Contains(step.Image, "${") {
 			// parse the image provided into a
 			// named, fully qualified reference
 			//

--- a/yaml/step_test.go
+++ b/yaml/step_test.go
@@ -280,6 +280,11 @@ func TestStepSlice_Validate(t *testing.T) {
 			file:    "testdata/step/validate/bad_image.yml",
 			wantErr: true,
 		},
+		{
+			name:    "success: step with variable image",
+			file:    "testdata/step/validate/variable_image.yml",
+			wantErr: false,
+		},
 	}
 
 	// run tests

--- a/yaml/testdata/secret/validate/plugin_variable_image.yml
+++ b/yaml/testdata/secret/validate/plugin_variable_image.yml
@@ -1,0 +1,8 @@
+secrets:
+  - origin:
+      name: vault secrets
+      image: target/vela/secret-vault:${VELA_BUILD_COMMIT:0:7}
+      parameters:
+        items:
+          - source: secret/vela/dev/docker
+            path: docker

--- a/yaml/testdata/service/validate/variable_image.yml
+++ b/yaml/testdata/service/validate/variable_image.yml
@@ -1,0 +1,3 @@
+services:
+  - name: postgres
+    image: alpine:${VELA_BUILD_COMMIT:0:7}

--- a/yaml/testdata/step/validate/variable_image.yml
+++ b/yaml/testdata/step/validate/variable_image.yml
@@ -1,0 +1,5 @@
+steps:
+  - name: hello
+    image: alpine:${VELA_BUILD_COMMIT:0:7}
+    commands:
+      - echo "hello vela"


### PR DESCRIPTION
I'm happy to hear other suggestions that utilize a more elegant workaround compared to this.

closes https://github.com/go-vela/community/issues/197