### PR TITLE
fix(schema): add 'go' as enum for template format

### DIFF
--- a/yaml/template.go
+++ b/yaml/template.go
@@ -19,7 +19,7 @@ type (
 	Template struct {
 		Name   string `yaml:"name,omitempty"   json:"name,omitempty"  jsonschema:"required,minLength=1,description=Unique identifier for the template.\nReference: https://go-vela.github.io/docs/templates/"`
 		Source string `yaml:"source,omitempty" json:"source,omitempty" jsonschema:"required,minLength=1,description=Path to template in remote system.\nReference: https://go-vela.github.io/docs/templates/"`
-		Format string `yaml:"format,omitempty"   json:"format,omitempty" jsonschema:"enum=starlark,enum=golang,default=go,minLength=1,description=language used within the template file \nReference: https://go-vela.github.io/docs/templates/#format"`
+		Format string `yaml:"format,omitempty"   json:"format,omitempty" jsonschema:"enum=starlark,enum=golang,enum=go,default=go,minLength=1,description=language used within the template file \nReference: https://go-vela.github.io/docs/templates/#format"`
 		Type   string `yaml:"type,omitempty"   json:"type,omitempty" jsonschema:"minLength=1,example=github,description=Type of template provided from the remote system.\nReference: https://go-vela.github.io/docs/templates/"`
 	}
 


### PR DESCRIPTION
currently, the schema will mark a pipeline as invalid if you are defining `go` as the template format, eg. (taken from https://go-vela.github.io/docs/templates/):

```yaml
templates:
  - name: go
    source: github.com/octocat/hello-world/.vela/build.yml
    format: go
    type: github
```

This is, in fact, a valid option.