### PR TITLE
enhance(database): support setting different compression level

### DIFF
--- a/constants/compress.go
+++ b/constants/compress.go
@@ -1,8 +1,0 @@
-// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
-//
-// Use of this source code is governed by the LICENSE file in this repository.
-
-package constants
-
-// compression level for log data stored in the database.
-const CompressionLevel = 3

--- a/constants/compression.go
+++ b/constants/compression.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package constants
+
+// Log Compression Levels.
+const (
+	// The default compression level for the compress/zlib library
+	// for log data stored in the database.
+	CompressionNegOne = -1
+
+	// Enables no compression for log data stored in the database.
+	//
+	// This produces no compression for the log data.
+	CompressionZero = 0
+
+	// Enables the best speed for log data stored in the database.
+	//
+	// This produces compression for the log data the fastest but
+	// has a tradeoff of producing the largest amounts of data.
+	CompressionOne = 1
+
+	// Second compression level for log data stored in the database.
+	CompressionTwo = 2
+
+	// Third compression level for log data stored in the database.
+	CompressionThree = 3
+
+	// Fourth compression level for log data stored in the database.
+	CompressionFour = 4
+
+	// Enables an even balance of speed and compression for log
+	// data stored in the database.
+	//
+	// This produces compression for the log data with an even
+	// balance of speed while producing smaller amounts of data.
+	CompressionFive = 5
+
+	// Sixth compression level for log data stored in the database.
+	CompressionSix = 6
+
+	// Seventh compression level for log data stored in the database.
+	CompressionSeven = 7
+
+	// Eighth compression level for log data stored in the database.
+	CompressionEight = 8
+
+	// Enables the best compression for log data stored in the database.
+	//
+	// This produces compression for the log data the slowest but
+	// has a tradeoff of producing the smallest amounts of data.
+	CompressionNine = 9
+)

--- a/database/log.go
+++ b/database/log.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"io/ioutil"
 
-	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 	"github.com/sirupsen/logrus"
 )
@@ -44,12 +43,12 @@ type Log struct {
 // log entry by compressing that data. This produces
 // a significantly smaller amount of data that is
 // required to store in the system.
-func (l *Log) Compress() error {
+func (l *Log) Compress(level int) error {
 	// create new buffer for storing compressed log data
 	b := new(bytes.Buffer)
 
 	// create new writer for writing compressed log data
-	w, err := zlib.NewWriterLevel(b, constants.CompressionLevel)
+	w, err := zlib.NewWriterLevel(b, level)
 	if err != nil {
 		return err
 	}

--- a/database/log_test.go
+++ b/database/log_test.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library"
 )
 
@@ -16,17 +17,69 @@ func TestDatabase_Log_Compress(t *testing.T) {
 	// setup tests
 	tests := []struct {
 		failure bool
+		level   int
 		log     *Log
 	}{
 		{
 			failure: false,
+			level:   constants.CompressionNegOne,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionZero,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionOne,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionTwo,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionThree,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionFour,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionFive,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionSix,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionSeven,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionEight,
+			log:     testLog(),
+		},
+		{
+			failure: false,
+			level:   constants.CompressionNine,
 			log:     testLog(),
 		},
 	}
 
 	// run tests
 	for _, test := range tests {
-		err := test.log.Compress()
+		err := test.log.Compress(test.level)
 
 		if test.failure {
 			if err == nil {
@@ -45,7 +98,7 @@ func TestDatabase_Log_Compress(t *testing.T) {
 func TestDatabase_Log_Decompress(t *testing.T) {
 	// setup types
 	l := testLog()
-	err := l.Compress()
+	err := l.Compress(constants.CompressionThree)
 	if err != nil {
 		t.Errorf("unable to compress log: %v", err)
 	}


### PR DESCRIPTION
Based off of https://github.com/go-vela/types/pull/154

Related to https://github.com/go-vela/server/pull/297

This enables us to pass an `int` (compression level) to the `go-vela/types/database.Log.Compress()` function.

The intention is to set the compression level as a flag on the server which will be passed to this function.

This also has an added benefit of being able to "turn off" log compression by passing a compression level of `0`.

Also added constants for all the supported compression levels:

* `CompressionNegOne`: `-1`
* `CompressionZero`: `0` - NOTE: This disables compression i.e. log data will not be compressed
* `CompressionOne`: `1`
* `CompressionTwo`: `2`
* `CompressionThree`: `3`
* `CompressionFour`: `4`
* `CompressionFive`: `5`
* `CompressionSix`: `6`
* `CompressionSeven`: `7`
* `CompressionEight`: `8`
* `CompressionNine`: `9`