### PR TITLE
fix: add clone to needs if not present

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,67 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+#
+# ******** NOTE ********
+# We have attempted to detect the languages in your repository. Please check
+# the `language` matrix defined below to confirm you have the correct set of
+# supported CodeQL languages.
+#
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ master ]
+  schedule:
+    - cron: '31 2 * * 4'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'go' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python' ]
+        # Learn more:
+        # https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#changing-the-languages-that-are-analyzed
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+    # If this step fails, then you should remove it and run the build manually (see below)
+    - name: Autobuild
+      uses: github/codeql-action/autobuild@v1
+
+    # ℹ️ Command-line programs to run using the OS shell.
+    # 📚 https://git.io/JvXDl
+
+    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+    #    and modify them (or add more) to build your code if your project
+    #    uses a compiled language
+
+    #- run: |
+    #   make bootstrap
+    #   make release
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -263,7 +263,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 					},
 					{
 						Name:  "test",
-						Needs: []string{"clone", "dependencies"},
+						Needs: []string{"dependencies", "clone"},
 						Steps: StepSlice{
 							{
 								Commands: raw.StringSlice{"./gradlew check"},
@@ -298,7 +298,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 					},
 					{
 						Name:  "build",
-						Needs: []string{"clone", "dependencies"},
+						Needs: []string{"dependencies", "clone"},
 						Steps: StepSlice{
 							{
 								Commands: raw.StringSlice{"./gradlew build"},

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -263,7 +263,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 					},
 					{
 						Name:  "test",
-						Needs: []string{"dependencies"},
+						Needs: []string{"clone", "dependencies"},
 						Steps: StepSlice{
 							{
 								Commands: raw.StringSlice{"./gradlew check"},
@@ -298,7 +298,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 					},
 					{
 						Name:  "build",
-						Needs: []string{"dependencies"},
+						Needs: []string{"clone", "dependencies"},
 						Steps: StepSlice{
 							{
 								Commands: raw.StringSlice{"./gradlew build"},

--- a/yaml/stage.go
+++ b/yaml/stage.go
@@ -78,9 +78,17 @@ func (s *StageSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			stage.Name = fmt.Sprintf("%v", v.Key)
 		}
 
-		// implicitly set the stage `needs` if empty
-		if len(stage.Needs) == 0 && stage.Name != "clone" && stage.Name != "init" {
-			stage.Needs = []string{"clone"}
+		// implicitly set the stage `needs`
+		if stage.Name != "clone" && stage.Name != "init" {
+			// add clone if not present
+			stage.Needs = func(needs []string) []string {
+				for _, s := range needs {
+					if s == "clone" {
+						return needs
+					}
+				}
+				return append(needs, "clone")
+			}(stage.Needs)
 		}
 
 		// append stage to stage slice

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -205,7 +205,7 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "test",
-					Needs: []string{"dependencies"},
+					Needs: []string{"clone", "dependencies"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew check"},
@@ -221,7 +221,7 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "build",
-					Needs: []string{"dependencies"},
+					Needs: []string{"clone", "dependencies"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew build"},
@@ -317,7 +317,7 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "test",
-					Needs: []string{"dependencies"},
+					Needs: []string{"clone", "dependencies"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew check"},
@@ -333,7 +333,7 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "build",
-					Needs: []string{"dependencies"},
+					Needs: []string{"clone", "dependencies"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew build"},

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -205,7 +205,7 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "test",
-					Needs: []string{"clone", "dependencies"},
+					Needs: []string{"dependencies", "clone"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew check"},
@@ -221,7 +221,7 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "build",
-					Needs: []string{"clone", "dependencies"},
+					Needs: []string{"dependencies", "clone"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew build"},
@@ -317,7 +317,7 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "test",
-					Needs: []string{"clone", "dependencies"},
+					Needs: []string{"dependencies", "clone"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew check"},
@@ -333,7 +333,7 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 				},
 				{
 					Name:  "build",
-					Needs: []string{"clone", "dependencies"},
+					Needs: []string{"dependencies", "clone"},
 					Steps: StepSlice{
 						{
 							Commands: []string{"./gradlew build"},


### PR DESCRIPTION
fixes the scenario where a user has multiple stages, the first stage is skipped, and the following stage(s) are executed before the `clone` stage can complete.

This bug is a race condition between the platform finishing `clone` and executing a continued stage.
  

For example, the following yaml will sometimes execute `second_stage-second_step` before clone can complete. 
Because the first stage is skipped, and the second stage provides a `needs` block, `clone` will not be added as a dependency. This code fixes that.

```yaml
version: "1"

stages:
  first_stage:
    steps:
      - name: first_step
        ruleset:
          event: pull_request
        image: golang
        commands:
          - echo "hello"
  second_stage:
    needs: [ first_stage ]
    steps:
      - name: second_step
         ruleset:
           event: push
        image: golang
        commands:
          - echo "hello"
```

related worker error:
```
error:
 unable to execute stage: 
 unable to exec step second_step: 
 Error response from daemon: 
 failed to mkdir /var/lib/docker2/volumes/DavidVader_heyvela_1394/_data/src:
 mkdir /var/lib/docker2/volumes/DavidVader_heyvela_1394/_data/src: file exists
```