### PR TITLE
refactor(database): use encrypt() and decrypt() helpers

### DIFF
--- a/database/encrypt.go
+++ b/database/encrypt.go
@@ -1,0 +1,98 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package database
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+)
+
+// decrypt is a helper function to decrypt values. First
+// a AES-256 Galois Counter Mode cipher block is created
+// from the encryption key to decrypt the value. Then, we
+// verify the value isn't smaller than the nonce which
+// would indicate the value isn't encrypted. Finally the
+// cipher block and nonce is used to decrypt the value.
+func decrypt(key string, value []byte) ([]byte, error) {
+	// create a new cipher block from the encryption key
+	//
+	// the key should have a length of 64 bits to ensure
+	// we are using the AES-256 standard
+	//
+	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return value, err
+	}
+
+	// creates a new Galois Counter Mode cipher block
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return value, err
+	}
+
+	// nonce is an arbitrary number used to to ensure that
+	// old communications cannot be reused in replay attacks.
+	//
+	// https://en.wikipedia.org/wiki/Cryptographic_nonce
+	nonceSize := gcm.NonceSize()
+
+	// verify the value has a length greater than the nonce
+	//
+	// if the value is less than the nonce size, then we
+	// can assume the value hasn't been encrypted yet.
+	if len(value) < nonceSize {
+		return value, fmt.Errorf("invalid value length for decrypt provided: %d", len(value))
+	}
+
+	// capture nonce and ciphertext from the value
+	nonce, ciphertext := value[:nonceSize], value[nonceSize:]
+
+	// decrypt the value from the ciphertext
+	return gcm.Open(nil, nonce, ciphertext, nil)
+}
+
+// encrypt is a helper function to encrypt values. First
+// a AES-256 Galois Counter Mode cipher block is created
+// from the encryption key to encrypt the value. Then,
+// we create the nonce from a cryptographically secure
+// random number generator. Finally, the cipher block
+// and nonce is used to encrypt the value.
+func encrypt(key string, value []byte) ([]byte, error) {
+	// create a new cipher block from the encryption key
+	//
+	// the key should have a length of 64 bits to ensure
+	// we are using the AES-256 standard
+	//
+	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+	block, err := aes.NewCipher([]byte(key))
+	if err != nil {
+		return value, err
+	}
+
+	// creates a new Galois Counter Mode cipher block
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return value, err
+	}
+
+	// nonce is an arbitrary number used to to ensure that
+	// old communications cannot be reused in replay attacks.
+	//
+	// https://en.wikipedia.org/wiki/Cryptographic_nonce
+	nonce := make([]byte, gcm.NonceSize())
+
+	// set nonce from a cryptographically secure random number generator
+	_, err = io.ReadFull(rand.Reader, nonce)
+	if err != nil {
+		return value, err
+	}
+
+	// encrypt the value with the randomly generated nonce
+	return gcm.Seal(nonce, nonce, value, nil), nil
+}

--- a/database/encrypt_test.go
+++ b/database/encrypt_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package database
+
+import (
+	"testing"
+)
+
+func TestDatabase_decrypt(t *testing.T) {
+	// setup types
+	key := "C639A572E14D5075C526FDDD43E4ECF6"
+	value := []byte("abc")
+
+	encrypted, err := encrypt(key, value)
+	if err != nil {
+		t.Errorf("unable to encrypt value: %v", err)
+	}
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		key     string
+		value   []byte
+	}{
+		{
+			failure: false,
+			key:     key,
+			value:   encrypted,
+		},
+		{
+			failure: true,
+			key:     "",
+			value:   encrypted,
+		},
+		{
+			failure: true,
+			key:     key,
+			value:   value,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_, err := decrypt(test.key, test.value)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("decrypt should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("decrypt returned err: %v", err)
+		}
+	}
+}
+
+func TestDatabase_encrypt(t *testing.T) {
+	// setup types
+	key := "C639A572E14D5075C526FDDD43E4ECF6"
+	value := []byte("abc")
+
+	// setup tests
+	tests := []struct {
+		failure bool
+		key     string
+		value   []byte
+	}{
+		{
+			failure: false,
+			key:     key,
+			value:   value,
+		},
+		{
+			failure: true,
+			key:     "",
+			value:   value,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		_, err := encrypt(test.key, test.value)
+
+		if test.failure {
+			if err == nil {
+				t.Errorf("encrypt should have returned err")
+			}
+
+			continue
+		}
+
+		if err != nil {
+			t.Errorf("encrypt returned err: %v", err)
+		}
+	}
+}

--- a/database/repo.go
+++ b/database/repo.go
@@ -5,14 +5,9 @@
 package database
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
 	"errors"
-	"fmt"
-	"io"
 
 	"github.com/go-vela/types/library"
 )
@@ -70,8 +65,6 @@ type Repo struct {
 // base64 decoding that value. Then, a AES-256 cipher
 // block is created from the encryption key in order to
 // decrypt the base64 decoded secret value.
-//
-// nolint: dupl // ignore similar code
 func (r *Repo) Decrypt(key string) error {
 	// base64 decode the encrypted repo hash
 	decoded, err := base64.StdEncoding.DecodeString(r.Hash.String)
@@ -79,49 +72,17 @@ func (r *Repo) Decrypt(key string) error {
 		return err
 	}
 
-	// create a new cipher block from the encryption key
-	//
-	// the key should have a length of 64 bits to ensure
-	// we are using the AES-256 standard
-	//
-	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-	block, err := aes.NewCipher([]byte(key))
-	if err != nil {
-		return err
-	}
-
-	// creates a new Galois Counter Mode cipher block
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return err
-	}
-
-	// nonce is an arbitrary number used to to ensure that
-	// old communications cannot be reused in replay attacks.
-	//
-	// https://en.wikipedia.org/wiki/Cryptographic_nonce
-	nonceSize := gcm.NonceSize()
-
-	// verify the decoded repo hash is greater than nonce
-	//
-	// if the base64 decoded repo hash is less than the
-	// nonce size, then we can reasonably assume the repo
-	// hasn't been encrypted yet.
-	if len(decoded) < nonceSize {
-		return fmt.Errorf("invalid length for decoded repo hash")
-	}
-
-	// capture nonce and ciphertext from decoded repo hash
-	nonce, ciphertext := decoded[:nonceSize], decoded[nonceSize:]
-
-	// decrypt the decoded repo hash from the ciphertext
-	decrypted, err := gcm.Open(nil, nonce, ciphertext, nil)
+	// decrypt the base64 decoded repo hash
+	decrypted, err := decrypt(key, decoded)
 	if err != nil {
 		return err
 	}
 
 	// set the decrypted repo hash
-	r.Hash = sql.NullString{String: string(decrypted), Valid: true}
+	r.Hash = sql.NullString{
+		String: string(decrypted),
+		Valid:  true,
+	}
 
 	return nil
 }
@@ -132,40 +93,17 @@ func (r *Repo) Decrypt(key string) error {
 // repo hash is base64 encoded for transport across
 // network boundaries.
 func (r *Repo) Encrypt(key string) error {
-	// create a new cipher block from the encryption key
-	//
-	// the key should have a length of 64 bits to ensure
-	// we are using the AES-256 standard
-	//
-	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-	block, err := aes.NewCipher([]byte(key))
+	// encrypt the repo hash
+	encrypted, err := encrypt(key, []byte(r.Hash.String))
 	if err != nil {
 		return err
 	}
-
-	// creates a new Galois Counter Mode cipher block
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return err
-	}
-
-	// nonce is an arbitrary number used to to ensure that
-	// old communications cannot be reused in replay attacks.
-	//
-	// https://en.wikipedia.org/wiki/Cryptographic_nonce
-	nonce := make([]byte, gcm.NonceSize())
-
-	// set nonce from a cryptographically secure random number generator
-	_, err = io.ReadFull(rand.Reader, nonce)
-	if err != nil {
-		return err
-	}
-
-	// encrypt the data with the randomly generated nonce
-	encrypted := gcm.Seal(nonce, nonce, []byte(r.Hash.String), nil)
 
 	// base64 encode the encrypted repo hash to make it network safe
-	r.Hash = sql.NullString{String: base64.StdEncoding.EncodeToString(encrypted), Valid: true}
+	r.Hash = sql.NullString{
+		String: base64.StdEncoding.EncodeToString(encrypted),
+		Valid:  true,
+	}
 
 	return nil
 }

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -6,7 +6,6 @@ package database
 
 import (
 	"database/sql"
-	"encoding/base64"
 	"reflect"
 	"testing"
 
@@ -15,19 +14,12 @@ import (
 
 func TestDatabase_Repo_Decrypt(t *testing.T) {
 	// setup types
-
 	key := "C639A572E14D5075C526FDDD43E4ECF6"
 
-	r := testRepo()
-	err := r.Encrypt(key)
+	encrypted := testRepo()
+	err := encrypted.Encrypt(key)
 	if err != nil {
-		t.Errorf("unable to encrypt secret: %v", err)
-	}
-
-	unencrypted := testRepo()
-	unencrypted.Hash = sql.NullString{
-		String: base64.StdEncoding.EncodeToString([]byte("b")),
-		Valid:  true,
+		t.Errorf("unable to encrypt repo: %v", err)
 	}
 
 	// setup tests
@@ -39,22 +31,17 @@ func TestDatabase_Repo_Decrypt(t *testing.T) {
 		{
 			failure: false,
 			key:     key,
-			repo:    *r,
+			repo:    *encrypted,
 		},
 		{
 			failure: true,
 			key:     "",
-			repo:    *r,
+			repo:    *encrypted,
 		},
 		{
 			failure: true,
 			key:     key,
 			repo:    *testRepo(),
-		},
-		{
-			failure: true,
-			key:     key,
-			repo:    *unencrypted,
 		},
 	}
 
@@ -78,7 +65,6 @@ func TestDatabase_Repo_Decrypt(t *testing.T) {
 
 func TestDatabase_Repo_Encrypt(t *testing.T) {
 	// setup types
-
 	key := "C639A572E14D5075C526FDDD43E4ECF6"
 
 	// setup tests

--- a/database/secret_test.go
+++ b/database/secret_test.go
@@ -6,7 +6,6 @@ package database
 
 import (
 	"database/sql"
-	"encoding/base64"
 	"reflect"
 	"testing"
 
@@ -15,19 +14,12 @@ import (
 
 func TestDatabase_Secret_Decrypt(t *testing.T) {
 	// setup types
-
 	key := "C639A572E14D5075C526FDDD43E4ECF6"
 
-	s := testSecret()
-	err := s.Encrypt(key)
+	encrypted := testSecret()
+	err := encrypted.Encrypt(key)
 	if err != nil {
 		t.Errorf("unable to encrypt secret: %v", err)
-	}
-
-	unencrypted := testSecret()
-	unencrypted.Value = sql.NullString{
-		String: base64.StdEncoding.EncodeToString([]byte("b")),
-		Valid:  true,
 	}
 
 	// setup tests
@@ -39,22 +31,17 @@ func TestDatabase_Secret_Decrypt(t *testing.T) {
 		{
 			failure: false,
 			key:     key,
-			secret:  *s,
+			secret:  *encrypted,
 		},
 		{
 			failure: true,
 			key:     "",
-			secret:  *s,
+			secret:  *encrypted,
 		},
 		{
 			failure: true,
 			key:     key,
 			secret:  *testSecret(),
-		},
-		{
-			failure: true,
-			key:     key,
-			secret:  *unencrypted,
 		},
 	}
 
@@ -78,7 +65,6 @@ func TestDatabase_Secret_Decrypt(t *testing.T) {
 
 func TestDatabase_Secret_Encrypt(t *testing.T) {
 	// setup types
-
 	key := "C639A572E14D5075C526FDDD43E4ECF6"
 
 	// setup tests

--- a/database/user.go
+++ b/database/user.go
@@ -5,14 +5,9 @@
 package database
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"database/sql"
 	"encoding/base64"
 	"errors"
-	"fmt"
-	"io"
 	"regexp"
 
 	"github.com/go-vela/types/constants"
@@ -67,55 +62,41 @@ type User struct {
 // block is created from the encryption key in order to
 // decrypt the base64 decoded user tokens.
 func (u *User) Decrypt(key string) error {
+	// base64 decode the encrypted user hash
+	decoded, err := base64.StdEncoding.DecodeString(u.Hash.String)
+	if err != nil {
+		return err
+	}
+
+	// decrypt the base64 decoded user hash
+	decrypted, err := decrypt(key, decoded)
+	if err != nil {
+		return err
+	}
+
+	// set the decrypted user refresh token
+	u.Hash = sql.NullString{
+		String: string(decrypted),
+		Valid:  true,
+	}
+
 	// base64 decode the encrypted user token
-	decoded, err := base64.StdEncoding.DecodeString(u.Token.String)
+	decoded, err = base64.StdEncoding.DecodeString(u.Token.String)
 	if err != nil {
 		return err
 	}
 
-	// create a new cipher block from the encryption key
-	//
-	// the key should have a length of 64 bits to ensure
-	// we are using the AES-256 standard
-	//
-	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-	block, err := aes.NewCipher([]byte(key))
-	if err != nil {
-		return err
-	}
-
-	// creates a new Galois Counter Mode cipher block
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return err
-	}
-
-	// nonce is an arbitrary number used to to ensure that
-	// old communications cannot be reused in replay attacks.
-	//
-	// https://en.wikipedia.org/wiki/Cryptographic_nonce
-	nonceSize := gcm.NonceSize()
-
-	// verify the decoded user token length is greater than nonce
-	//
-	// if the base64 decoded user token is less than the
-	// nonce size, then we can reasonably assume the user
-	// hasn't been encrypted yet.
-	if len(decoded) < nonceSize {
-		return fmt.Errorf("invalid length for decoded user token")
-	}
-
-	// capture nonce and ciphertext from decoded user token
-	nonce, ciphertext := decoded[:nonceSize], decoded[nonceSize:]
-
-	// decrypt the decoded user token from the ciphertext
-	decrypted, err := gcm.Open(nil, nonce, ciphertext, nil)
+	// decrypt the base64 decoded user token
+	decrypted, err = decrypt(key, decoded)
 	if err != nil {
 		return err
 	}
 
 	// set the decrypted user token
-	u.Token = sql.NullString{String: string(decrypted), Valid: true}
+	u.Token = sql.NullString{
+		String: string(decrypted),
+		Valid:  true,
+	}
 
 	// base64 decode the encrypted user refresh token
 	decoded, err = base64.StdEncoding.DecodeString(u.RefreshToken.String)
@@ -123,26 +104,17 @@ func (u *User) Decrypt(key string) error {
 		return err
 	}
 
-	// verify the decoded user refresh token length is greater than nonce
-	//
-	// if the base64 decoded user refresh token is less than the
-	// nonce size, then we can reasonably assume the user
-	// hasn't been encrypted yet.
-	if len(decoded) < nonceSize {
-		return fmt.Errorf("invalid length for decoded user refresh token")
-	}
-
-	// capture nonce and ciphertext from decoded user token
-	nonce, ciphertext = decoded[:nonceSize], decoded[nonceSize:]
-
-	// decrypt the decoded user refresh token from the ciphertext
-	decrypted, err = gcm.Open(nil, nonce, ciphertext, nil)
+	// decrypt the base64 decoded user refresh token
+	decrypted, err = decrypt(key, decoded)
 	if err != nil {
 		return err
 	}
 
 	// set the decrypted user refresh token
-	u.RefreshToken = sql.NullString{String: string(decrypted), Valid: true}
+	u.RefreshToken = sql.NullString{
+		String: string(decrypted),
+		Valid:  true,
+	}
 
 	return nil
 }
@@ -153,46 +125,41 @@ func (u *User) Decrypt(key string) error {
 // user tokens are base64 encoded for transport across
 // network boundaries.
 func (u *User) Encrypt(key string) error {
-	// create a new cipher block from the encryption key
-	//
-	// the key should have a length of 64 bits to ensure
-	// we are using the AES-256 standard
-	//
-	// https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
-	block, err := aes.NewCipher([]byte(key))
+	// encrypt the user hash
+	encrypted, err := encrypt(key, []byte(u.Hash.String))
 	if err != nil {
 		return err
 	}
 
-	// creates a new Galois Counter Mode cipher block
-	gcm, err := cipher.NewGCM(block)
+	// base64 encode the encrypted user hash to make it network safe
+	u.Hash = sql.NullString{
+		String: base64.StdEncoding.EncodeToString(encrypted),
+		Valid:  true,
+	}
+
+	// encrypt the user token
+	encrypted, err = encrypt(key, []byte(u.Token.String))
 	if err != nil {
 		return err
 	}
-
-	// nonce is an arbitrary number used to to ensure that
-	// old communications cannot be reused in replay attacks.
-	//
-	// https://en.wikipedia.org/wiki/Cryptographic_nonce
-	nonce := make([]byte, gcm.NonceSize())
-
-	// set nonce from a cryptographically secure random number generator
-	_, err = io.ReadFull(rand.Reader, nonce)
-	if err != nil {
-		return err
-	}
-
-	// encrypt the data with the randomly generated nonce
-	encrypted := gcm.Seal(nonce, nonce, []byte(u.Token.String), nil)
 
 	// base64 encode the encrypted user token to make it network safe
-	u.Token = sql.NullString{String: base64.StdEncoding.EncodeToString(encrypted), Valid: true}
+	u.Token = sql.NullString{
+		String: base64.StdEncoding.EncodeToString(encrypted),
+		Valid:  true,
+	}
 
-	// encrypt the data with the randomly generated nonce
-	encrypted = gcm.Seal(nonce, nonce, []byte(u.RefreshToken.String), nil)
+	// encrypt the user refresh token
+	encrypted, err = encrypt(key, []byte(u.RefreshToken.String))
+	if err != nil {
+		return err
+	}
 
 	// base64 encode the encrypted user refresh token to make it network safe
-	u.RefreshToken = sql.NullString{String: base64.StdEncoding.EncodeToString(encrypted), Valid: true}
+	u.RefreshToken = sql.NullString{
+		String: base64.StdEncoding.EncodeToString(encrypted),
+		Valid:  true,
+	}
 
 	return nil
 }

--- a/database/user_test.go
+++ b/database/user_test.go
@@ -6,7 +6,6 @@ package database
 
 import (
 	"database/sql"
-	"encoding/base64"
 	"reflect"
 	"strconv"
 	"testing"
@@ -18,20 +17,10 @@ func TestDatabase_User_Decrypt(t *testing.T) {
 	// setup types
 	key := "C639A572E14D5075C526FDDD43E4ECF6"
 
-	s := testUser()
-	err := s.Encrypt(key)
+	encrypted := testUser()
+	err := encrypted.Encrypt(key)
 	if err != nil {
-		t.Errorf("unable to encrypt secret: %v", err)
-	}
-
-	unencrypted := testUser()
-	unencrypted.Token = sql.NullString{
-		String: base64.StdEncoding.EncodeToString([]byte("a")),
-		Valid:  true,
-	}
-	unencrypted.RefreshToken = sql.NullString{
-		String: base64.StdEncoding.EncodeToString([]byte("b")),
-		Valid:  true,
+		t.Errorf("unable to encrypt user: %v", err)
 	}
 
 	// setup tests
@@ -43,22 +32,17 @@ func TestDatabase_User_Decrypt(t *testing.T) {
 		{
 			failure: false,
 			key:     key,
-			user:    *s,
+			user:    *encrypted,
 		},
 		{
 			failure: true,
 			key:     "",
-			user:    *s,
+			user:    *encrypted,
 		},
 		{
 			failure: true,
 			key:     key,
 			user:    *testUser(),
-		},
-		{
-			failure: true,
-			key:     key,
-			user:    *unencrypted,
 		},
 	}
 


### PR DESCRIPTION
This adds some helper functions for encrypting and decrypting values in the `go-vela/types/database` package:

* [decrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/encrypt.go#L15-L58)
* [encrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/encrypt.go#L60-L98)

Also updated the types performing encryption to call these helper functions:

* [repo.Decrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/repo.go#L64-L88)
* [repo.Encrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/repo.go#L90-L109)
* [secret.Decrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/secret.go#L59-L83)
* [secret.Encrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/secret.go#L85-L104)
* [user.Decrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/user.go#L60-L120)
* [user.Encrypt()](https://github.com/go-vela/types/blob/refactor/database/encryption_functions/database/user.go#L122-L165)

This benefits us by reducing the non-test LOC for encryption and removing duplicate code in multiple files.

This also ensures all encryption functions follow the same code path making future changes easier.