### PR TITLE
feat(buildqueue): add build queue database and library types

### DIFF
--- a/database/build_queue.go
+++ b/database/build_queue.go
@@ -1,0 +1,45 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package database
+
+import (
+	"database/sql"
+
+	"github.com/go-vela/types/library"
+)
+
+// BuildQueue is the database representation of the builds in the queue.
+type BuildQueue struct {
+	Status   sql.NullString `sql:"status"`
+	Number   sql.NullInt32  `sql:"number"`
+	Created  sql.NullInt64  `sql:"created"`
+	FullName sql.NullString `sql:"full_name"`
+}
+
+// ToLibrary converts the BuildQueue type
+// to a library BuildQueue type.
+func (b *BuildQueue) ToLibrary() *library.BuildQueue {
+	buildQueue := new(library.BuildQueue)
+
+	buildQueue.SetStatus(b.Status.String)
+	buildQueue.SetNumber(b.Number.Int32)
+	buildQueue.SetCreated(b.Created.Int64)
+	buildQueue.SetFullName(b.FullName.String)
+
+	return buildQueue
+}
+
+// BuildQueueFromLibrary converts the library BuildQueue type
+// to a database build queue type.
+func BuildQueueFromLibrary(b *library.BuildQueue) *BuildQueue {
+	buildQueue := &BuildQueue{
+		Status:   sql.NullString{String: b.GetStatus(), Valid: true},
+		Number:   sql.NullInt32{Int32: b.GetNumber(), Valid: true},
+		Created:  sql.NullInt64{Int64: b.GetCreated(), Valid: true},
+		FullName: sql.NullString{String: b.GetFullName(), Valid: true},
+	}
+
+	return buildQueue
+}

--- a/database/build_queue_test.go
+++ b/database/build_queue_test.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package database
+
+import (
+	"database/sql"
+	"reflect"
+	"testing"
+
+	"github.com/go-vela/types/library"
+)
+
+func TestDatabase_BuildQueue_ToLibrary(t *testing.T) {
+	// setup types
+	want := new(library.BuildQueue)
+
+	want.SetNumber(1)
+	want.SetStatus("running")
+	want.SetCreated(1563474076)
+	want.SetFullName("github/octocat")
+
+	// run test
+	got := testBuildQueue().ToLibrary()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("ToLibrary is %v, want %v", got, want)
+	}
+}
+
+func TestDatabase_BuildQueueFromLibrary(t *testing.T) {
+	// setup types
+	b := new(library.BuildQueue)
+
+	b.SetNumber(1)
+	b.SetStatus("running")
+	b.SetCreated(1563474076)
+	b.SetFullName("github/octocat")
+
+	want := testBuildQueue()
+
+	// run test
+	got := BuildQueueFromLibrary(b)
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("BuildQueueFromLibrary is %v, want %v", got, want)
+	}
+}
+
+// testBuildQueue is a test helper function to create a BuildQueue
+// type with all fields set to a fake value.
+func testBuildQueue() *BuildQueue {
+	return &BuildQueue{
+		Number:   sql.NullInt32{Int32: 1, Valid: true},
+		Status:   sql.NullString{String: "running", Valid: true},
+		Created:  sql.NullInt64{Int64: 1563474076, Valid: true},
+		FullName: sql.NullString{String: "github/octocat", Valid: true},
+	}
+}

--- a/library/build_queue.go
+++ b/library/build_queue.go
@@ -1,0 +1,137 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import "fmt"
+
+// BuildQueue is the library representation of the builds in the queue.
+//
+// swagger:model BuildQueue
+type BuildQueue struct {
+	Status   *string `json:"status,omitempty"`
+	Number   *int32  `json:"number,omitempty"`
+	Created  *int64  `json:"created,omitempty"`
+	FullName *string `json:"full_name,omitempty"`
+}
+
+// GetStatus returns the Status field.
+//
+// When the provided BuildQueue type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *BuildQueue) GetStatus() string {
+	// return zero value if BuildQueue type or Status field is nil
+	if b == nil || b.Status == nil {
+		return ""
+	}
+
+	return *b.Status
+}
+
+// GetNumber returns the Number field.
+//
+// When the provided BuildQueue type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *BuildQueue) GetNumber() int32 {
+	// return zero value if BuildQueue type or Number field is nil
+	if b == nil || b.Number == nil {
+		return 0
+	}
+
+	return *b.Number
+}
+
+// GetCreated returns the Created field.
+//
+// When the provided BuildQueue type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *BuildQueue) GetCreated() int64 {
+	// return zero value if BuildQueue type or Created field is nil
+	if b == nil || b.Created == nil {
+		return 0
+	}
+
+	return *b.Created
+}
+
+// GetFullName returns the FullName field.
+//
+// When the provided BuildQueue type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *BuildQueue) GetFullName() string {
+	// return zero value if BuildQueue type or FullName field is nil
+	if b == nil || b.FullName == nil {
+		return ""
+	}
+
+	return *b.FullName
+}
+
+// SetStatus sets the Status field.
+//
+// When the provided BuildQueue type is nil, it
+// will set nothing and immediately return.
+func (b *BuildQueue) SetStatus(v string) {
+	// return if BuildQueue type is nil
+	if b == nil {
+		return
+	}
+
+	b.Status = &v
+}
+
+// SetNumber sets the Number field.
+//
+// When the provided BuildQueue type is nil, it
+// will set nothing and immediately return.
+func (b *BuildQueue) SetNumber(v int32) {
+	// return if BuildQueue type is nil
+	if b == nil {
+		return
+	}
+
+	b.Number = &v
+}
+
+// SetCreated sets the Created field.
+//
+// When the provided BuildQueue type is nil, it
+// will set nothing and immediately return.
+func (b *BuildQueue) SetCreated(v int64) {
+	// return if BuildQueue type is nil
+	if b == nil {
+		return
+	}
+
+	b.Created = &v
+}
+
+// SetFullName sets the FullName field.
+//
+// When the provided BuildQueue type is nil, it
+// will set nothing and immediately return.
+func (b *BuildQueue) SetFullName(v string) {
+	// return if BuildQueue type is nil
+	if b == nil {
+		return
+	}
+
+	b.FullName = &v
+}
+
+// String implements the Stringer interface for the BuildQueue type.
+// nolint:dupl // this is duplicated in the test
+func (b *BuildQueue) String() string {
+	return fmt.Sprintf(`{
+  Created: %d,
+  FullName: %s,
+  Number: %d,
+  Status: %s,
+}`,
+		b.GetCreated(),
+		b.GetFullName(),
+		b.GetNumber(),
+		b.GetStatus(),
+	)
+}

--- a/library/build_queue.go
+++ b/library/build_queue.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore false positive with template.go
 package library
 
 import "fmt"
@@ -121,7 +122,6 @@ func (b *BuildQueue) SetFullName(v string) {
 }
 
 // String implements the Stringer interface for the BuildQueue type.
-// nolint:dupl // this is duplicated in the test
 func (b *BuildQueue) String() string {
 	return fmt.Sprintf(`{
   Created: %d,

--- a/library/build_queue_test.go
+++ b/library/build_queue_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2021 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestLibrary_BuildQueue_Getters(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		buildQueue *BuildQueue
+		want       *BuildQueue
+	}{
+		{
+			buildQueue: testBuildQueue(),
+			want:       testBuildQueue(),
+		},
+		{
+			buildQueue: new(BuildQueue),
+			want:       new(BuildQueue),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+
+		if test.buildQueue.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.buildQueue.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.buildQueue.GetStatus() != test.want.GetStatus() {
+			t.Errorf("GetStatus is %v, want %v", test.buildQueue.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.buildQueue.GetCreated() != test.want.GetCreated() {
+			t.Errorf("GetCreated is %v, want %v", test.buildQueue.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.buildQueue.GetFullName() != test.want.GetFullName() {
+			t.Errorf("GetFullName is %v, want %v", test.buildQueue.GetFullName(), test.want.GetFullName())
+		}
+
+	}
+}
+
+func TestLibrary_BuildQueue_Setters(t *testing.T) {
+	// setup types
+	var b *BuildQueue
+
+	// setup tests
+	tests := []struct {
+		buildQueue *BuildQueue
+		want       *BuildQueue
+	}{
+		{
+			buildQueue: testBuildQueue(),
+			want:       testBuildQueue(),
+		},
+		{
+			buildQueue: b,
+			want:       new(BuildQueue),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		test.buildQueue.SetNumber(test.want.GetNumber())
+		test.buildQueue.SetStatus(test.want.GetStatus())
+		test.buildQueue.SetCreated(test.want.GetCreated())
+		test.buildQueue.SetFullName(test.want.GetFullName())
+
+		if test.buildQueue.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.buildQueue.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.buildQueue.GetStatus() != test.want.GetStatus() {
+			t.Errorf("SetStatus is %v, want %v", test.buildQueue.GetStatus(), test.want.GetStatus())
+		}
+
+		if test.buildQueue.GetCreated() != test.want.GetCreated() {
+			t.Errorf("SetCreated is %v, want %v", test.buildQueue.GetCreated(), test.want.GetCreated())
+		}
+
+		if test.buildQueue.GetFullName() != test.want.GetFullName() {
+			t.Errorf("SetFullName is %v, want %v", test.buildQueue.GetFullName(), test.want.GetFullName())
+		}
+	}
+}
+
+func TestLibrary_BuildQueue_String(t *testing.T) {
+	// setup types
+	b := testBuildQueue()
+
+	want := fmt.Sprintf(`{
+  Created: %d,
+  FullName: %s,
+  Number: %d,
+  Status: %s,
+}`,
+		b.GetCreated(),
+		b.GetFullName(),
+		b.GetNumber(),
+		b.GetStatus(),
+	)
+
+	// run test
+	got := b.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+// testBuildQueue is a test helper function to create a BuildQueue
+// type with all fields set to a fake value.
+func testBuildQueue() *BuildQueue {
+	b := new(BuildQueue)
+
+	b.SetNumber(1)
+	b.SetStatus("running")
+	b.SetCreated(1563474076)
+	b.SetFullName("github/octocat")
+
+	return b
+}

--- a/library/build_queue_test.go
+++ b/library/build_queue_test.go
@@ -28,7 +28,6 @@ func TestLibrary_BuildQueue_Getters(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-
 		if test.buildQueue.GetNumber() != test.want.GetNumber() {
 			t.Errorf("GetNumber is %v, want %v", test.buildQueue.GetNumber(), test.want.GetNumber())
 		}
@@ -44,7 +43,6 @@ func TestLibrary_BuildQueue_Getters(t *testing.T) {
 		if test.buildQueue.GetFullName() != test.want.GetFullName() {
 			t.Errorf("GetFullName is %v, want %v", test.buildQueue.GetFullName(), test.want.GetFullName())
 		}
-
 	}
 }
 

--- a/library/template.go
+++ b/library/template.go
@@ -2,6 +2,7 @@
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
+// nolint: dupl // ignore false positive with build_queue.go
 package library
 
 import (


### PR DESCRIPTION
Based off of https://github.com/go-vela/sdk-go/pull/97#pullrequestreview-625404169

Related to https://github.com/go-vela/server/pull/299, https://github.com/go-vela/sdk-go/pull/97 and https://github.com/go-vela/mock/pull/107

This adds a `BuildQueue{}` type to the `github.com/go-vela/types/database` package:

https://github.com/go-vela/types/blob/63af263fc0b0710d45c31cc345a968c2915ea405/database/build_queue.go#L13-L19

This also adds a `BuildQueue{}` type to the `github.com/go-vela/types/library` package:

https://github.com/go-vela/types/blob/63af263fc0b0710d45c31cc345a968c2915ea405/library/build_queue.go#L9-L17
