### PR TITLE
feat(database): use struct tags for custom types in gorm

### DIFF
--- a/database/build.go
+++ b/database/build.go
@@ -43,7 +43,7 @@ type Build struct {
 	Started       sql.NullInt64      `sql:"started"`
 	Finished      sql.NullInt64      `sql:"finished"`
 	Deploy        sql.NullString     `sql:"deploy"`
-	DeployPayload raw.StringSliceMap `sql:"deploy_payload"`
+	DeployPayload raw.StringSliceMap `sql:"deploy_payload" gorm:"type:varchar(2000)"`
 	Clone         sql.NullString     `sql:"clone"`
 	Source        sql.NullString     `sql:"source"`
 	Title         sql.NullString     `sql:"title"`

--- a/database/secret.go
+++ b/database/secret.go
@@ -51,8 +51,8 @@ type Secret struct {
 	Name         sql.NullString `sql:"name"`
 	Value        sql.NullString `sql:"value"`
 	Type         sql.NullString `sql:"type"`
-	Images       pq.StringArray `sql:"images"`
-	Events       pq.StringArray `sql:"events"`
+	Images       pq.StringArray `sql:"images" gorm:"type:varchar(1000)"`
+	Events       pq.StringArray `sql:"events" gorm:"type:varchar(1000)"`
 	AllowCommand sql.NullBool   `sql:"allow_command"`
 }
 
@@ -246,8 +246,8 @@ func SecretFromLibrary(s *library.Secret) *Secret {
 		Name:         sql.NullString{String: s.GetName(), Valid: true},
 		Value:        sql.NullString{String: s.GetValue(), Valid: true},
 		Type:         sql.NullString{String: s.GetType(), Valid: true},
-		Images:       s.GetImages(),
-		Events:       s.GetEvents(),
+		Images:       pq.StringArray(s.GetImages()),
+		Events:       pq.StringArray(s.GetEvents()),
 		AllowCommand: sql.NullBool{Bool: s.GetAllowCommand(), Valid: true},
 	}
 

--- a/database/user.go
+++ b/database/user.go
@@ -52,7 +52,7 @@ type User struct {
 	RefreshToken sql.NullString `sql:"refresh_token"`
 	Token        sql.NullString `sql:"token"`
 	Hash         sql.NullString `sql:"hash"`
-	Favorites    pq.StringArray `sql:"favorites"`
+	Favorites    pq.StringArray `sql:"favorites" gorm:"type:varchar(5000)"`
 	Active       sql.NullBool   `sql:"active"`
 	Admin        sql.NullBool   `sql:"admin"`
 }
@@ -279,7 +279,7 @@ func UserFromLibrary(u *library.User) *User {
 		Hash:         sql.NullString{String: u.GetHash(), Valid: true},
 		Active:       sql.NullBool{Bool: u.GetActive(), Valid: true},
 		Admin:        sql.NullBool{Bool: u.GetAdmin(), Valid: true},
-		Favorites:    u.GetFavorites(),
+		Favorites:    pq.StringArray(u.GetFavorites()),
 	}
 
 	return user.Nullify()

--- a/database/worker.go
+++ b/database/worker.go
@@ -27,7 +27,7 @@ type Worker struct {
 	ID            sql.NullInt64  `sql:"id"`
 	Hostname      sql.NullString `sql:"hostname"`
 	Address       sql.NullString `sql:"address"`
-	Routes        pq.StringArray `sql:"routes"`
+	Routes        pq.StringArray `sql:"routes" gorm:"type:varchar(1000)"`
 	Active        sql.NullBool   `sql:"active"`
 	LastCheckedIn sql.NullInt64  `sql:"last_checked_in"`
 	BuildLimit    sql.NullInt64  `sql:"build_limit"`
@@ -121,7 +121,7 @@ func WorkerFromLibrary(w *library.Worker) *Worker {
 		ID:            sql.NullInt64{Int64: w.GetID(), Valid: true},
 		Hostname:      sql.NullString{String: w.GetHostname(), Valid: true},
 		Address:       sql.NullString{String: w.GetAddress(), Valid: true},
-		Routes:        w.GetRoutes(),
+		Routes:        pq.StringArray(w.GetRoutes()),
 		Active:        sql.NullBool{Bool: w.GetActive(), Valid: true},
 		LastCheckedIn: sql.NullInt64{Int64: w.GetLastCheckedIn(), Valid: true},
 		BuildLimit:    sql.NullInt64{Int64: w.GetBuildLimit(), Valid: true},


### PR DESCRIPTION
Part of the effort for https://github.com/go-vela/community/issues/248

This enables us to use the following custom data types with the `gorm.io/gorm` (V2 of GORM) package:

* `github.com/go-vela/types/raw.StringSliceMap`
* `github.com/lib/pq.StringArray{}`

Currently when attempting to store a `Build{}`, `Secret{}`, `User{}` or `Worker{}` in the database, you'll see an error like:

```
[error] unsupported data type: &[]
```

This error is returned because GORM is unsure what the underlying data types should be in the database for these.

In order to resolve this, we have to explicitly tell GORM what data types to use so it can store them in the database.

The official GORM documentation on this can be found here:

https://gorm.io/docs/data_types.html

There was also an issue posted on this subject matter:

https://github.com/go-gorm/gorm/issues/1588#issuecomment-351268997

There is also a Stack Overflow post discussing this:

https://stackoverflow.com/a/64035166/14275726