### PR TITLE
fix(comment): skip worker from evaluating comment for comment events

### DIFF
--- a/library/repo.go
+++ b/library/repo.go
@@ -306,7 +306,7 @@ func (r *Repo) GetAllowTag() bool {
 	return *r.AllowTag
 }
 
-// GetAllowComment returns the AllowTag field.
+// GetAllowComment returns the AllowComment field.
 //
 // When the provided Repo type is nil, or the field within
 // the type is nil, it returns the zero value for the field.

--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -160,6 +160,19 @@ func (c *Container) Execute(r *RuleData) bool {
 		c.Ruleset.If.Path = []string{}
 		c.Ruleset.Unless.Path = []string{}
 
+		// skip evaluating comment in ruleset
+		//
+		// the compiler is the component responsible for
+		// choosing whether a container will run based
+		// off the PR comment matching the pipeline comment
+		//
+		// the worker doesn't have any record of
+		// the PR comment so we
+		// should "skip" evaluating what the
+		// user provided for the PR comment
+		c.Ruleset.If.Comment = []string{}
+		c.Ruleset.Unless.Comment = []string{}
+
 		// return if the container ruleset matches the conditions
 		return c.Ruleset.Match(r)
 	}

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -409,6 +409,69 @@ func TestPipeline_Container_Execute(t *testing.T) {
 			},
 			want: false,
 		},
+		{ // branch/event/comment container with build running
+			container: &Container{
+				Name:     "branch/event/comment-running",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch:  []string{"develop"},
+						Event:   []string{constants.EventComment},
+						Comment: []string{"run vela"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "develop",
+				Event:  "comment",
+				Repo:   "foo/bar",
+				Status: "running",
+			},
+			want: true,
+		},
+		{ // branch/event/comment container with build success
+			container: &Container{
+				Name:     "branch/event/comment-success",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch:  []string{"develop"},
+						Event:   []string{constants.EventComment},
+						Comment: []string{"run vela"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "develop",
+				Event:  "comment",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
+		{ // branch/event/comment container with build failure
+			container: &Container{
+				Name:     "branch/event/comment-failure",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch:  []string{"develop"},
+						Event:   []string{constants.EventComment},
+						Comment: []string{"run vela"},
+					},
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "develop",
+				Event:  "comment",
+				Repo:   "foo/bar",
+				Status: "failure",
+			},
+			want: false,
+		},
 		{ // branch/event/status container with build running
 			container: &Container{
 				Name:     "branch/event/status-running",


### PR DESCRIPTION
Part of https://github.com/go-vela/community/issues/118

This PR updates the `go-vela/types/pipeline/Execute()` to enable the worker to skip evaluation of the comment in a ruleset, as it does not have awareness of that field. The server will already determine if the step should be run.

https://github.com/go-vela/types/blob/03af8e851d87933bc28764dcc82ea3188cdbbb59/pipeline/container.go#L163-L174

With this fix, the pipeline below helps illustrate when a comment step will run and not:
```yaml
version: "1"

steps:
  # this step runs no matter what the event
  - name: always run
    image: alpine:latest
    commands:
      - echo "hi"

  # this step runs for any event that isn't a comment event
  - name: only run when not a comment event
    image: alpine:latest
    commands:
      - echo "hi"
    ruleset:
      event: [push, pull_request, tag, deploy]

  # this step runs only for a comment event and the exact patterns of "run vela" or "run ci" comment is added in a pr
  # this step will not run for any of these scenarios:
  # - when a comment with alt capitalization, such as "RUN CI", is added in a pr
  # - when an incomplete comment, such as "run", is added in a pr
  # - when a different comment, such as "hello", is added in a pr
  # - when a comment, such as "run ci", is added along with other comment content in a pr
  - name: only run when a comment event and run vela in pr comment
    image: alpine:latest
    commands:
      - echo "hi"
    ruleset:
      event: [comment]
      comment: ["run vela", "run ci"]
```