### PR TITLE
enhance(build): set tag env vars for deployments

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -123,6 +123,16 @@ func (b *Build) Environment(workspace, channel string) map[string]string {
 		envs["VELA_DEPLOYMENT"] = target
 		envs["BUILD_TARGET"] = target
 
+		// handle when deployment event is for a tag
+		if strings.HasPrefix(b.GetRef(), "refs/tags/") {
+			// capture the tag reference
+			tag := ToString(strings.SplitN(b.GetRef(), "refs/tags/", 2)[1])
+
+			// add the tag reference to the list
+			envs["BUILD_TAG"] = tag
+			envs["VELA_BUILD_TAG"] = tag
+		}
+
 		// add payload data to the list
 		for key, value := range b.GetDeployPayload() {
 			envs[fmt.Sprintf("DEPLOYMENT_PARAMETER_%s", strings.ToUpper(key))] = value

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -26,6 +26,15 @@ func TestLibrary_Build_Environment(t *testing.T) {
 		"bar": "test2",
 	})
 
+	_deployTag := testBuild()
+	_deployTag.SetRef("refs/tags/v0.1.0")
+	_deployTag.SetEvent("deployment")
+	_deployTag.SetDeploy("production")
+	_deployTag.SetDeployPayload(map[string]string{
+		"foo": "test1",
+		"bar": "test2",
+	})
+
 	_pull := testBuild()
 	_pull.SetEvent("pull_request")
 	_pull.SetRef("refs/pulls/1/head")
@@ -194,6 +203,64 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"BUILD_STARTED":            "1563474078",
 				"BUILD_SOURCE":             "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
 				"BUILD_STATUS":             "running",
+				"BUILD_TITLE":              "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":          "TODO",
+				"DEPLOYMENT_PARAMETER_FOO": "test1",
+				"DEPLOYMENT_PARAMETER_BAR": "test2",
+			},
+		},
+		{
+			build: _deployTag,
+			want: map[string]string{
+				"VELA_BUILD_AUTHOR":        "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL":  "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":      "",
+				"VELA_BUILD_BRANCH":        "master",
+				"VELA_BUILD_CHANNEL":       "TODO",
+				"VELA_BUILD_CLONE":         "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":        "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":       "1563474076",
+				"VELA_BUILD_DISTRIBUTION":  "linux",
+				"VELA_BUILD_ENQUEUED":      "1563474077",
+				"VELA_BUILD_EVENT":         "deployment",
+				"VELA_BUILD_HOST":          "example.company.com",
+				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":       "First commit...",
+				"VELA_BUILD_NUMBER":        "1",
+				"VELA_BUILD_PARENT":        "1",
+				"VELA_BUILD_REF":           "refs/tags/v0.1.0",
+				"VELA_BUILD_RUNTIME":       "docker",
+				"VELA_BUILD_SENDER":        "OctoKitty",
+				"VELA_BUILD_STARTED":       "1563474078",
+				"VELA_BUILD_SOURCE":        "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":        "running",
+				"VELA_BUILD_TAG":           "v0.1.0",
+				"VELA_BUILD_TARGET":        "production",
+				"VELA_BUILD_TITLE":         "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":     "TODO",
+				"VELA_DEPLOYMENT":          "production",
+				"BUILD_AUTHOR":             "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":       "OctoKitty@github.com",
+				"BUILD_BASE_REF":           "",
+				"BUILD_BRANCH":             "master",
+				"BUILD_CHANNEL":            "TODO",
+				"BUILD_CLONE":              "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":             "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":            "1563474076",
+				"BUILD_ENQUEUED":           "1563474077",
+				"BUILD_EVENT":              "deployment",
+				"BUILD_HOST":               "example.company.com",
+				"BUILD_LINK":               "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":            "First commit...",
+				"BUILD_NUMBER":             "1",
+				"BUILD_PARENT":             "1",
+				"BUILD_REF":                "refs/tags/v0.1.0",
+				"BUILD_SENDER":             "OctoKitty",
+				"BUILD_STARTED":            "1563474078",
+				"BUILD_SOURCE":             "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":             "running",
+				"BUILD_TAG":                "v0.1.0",
+				"BUILD_TARGET":             "production",
 				"BUILD_TITLE":              "push received from https://github.com/github/octocat",
 				"BUILD_WORKSPACE":          "TODO",
 				"DEPLOYMENT_PARAMETER_FOO": "test1",


### PR DESCRIPTION
This updates the `github.com/go-vela/types/library.Build.Environment()` function for the `deployment` event.

This change will ensure that if a `deployment` is created from a tag on a repo:

```sh
vela add deployment --org myOrg --repo myRepo --ref refs/tags/v0.1.0
```

That the `BUILD_TAG` and `VELA_BUILD_TAG` environment variables will be set for that build.

This is accomplished by checking if the `ref` for the build object contains the prefix `refs/tags/`.