### PR TITLE
enhance(container): support slash (/) in names

### DIFF
--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -260,6 +260,10 @@ func (c *Container) Sanitize(driver string) *Container {
 			c.ID = strings.ReplaceAll(c.ID, " ", "-")
 		}
 
+		if strings.Contains(c.ID, "/") {
+			c.ID = strings.ReplaceAll(c.ID, "/", "-")
+		}
+
 		return container
 	// sanitize container for Kubernetes
 	case constants.DriverKubernetes:
@@ -273,6 +277,10 @@ func (c *Container) Sanitize(driver string) *Container {
 
 		if strings.Contains(c.ID, ".") {
 			container.ID = strings.ReplaceAll(c.ID, ".", "-")
+		}
+
+		if strings.Contains(c.ID, "/") {
+			c.ID = strings.ReplaceAll(c.ID, "/", "-")
 		}
 
 		return container

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -907,7 +907,7 @@ func testContainers() *ContainerSlice {
 			Pull:        "always",
 		},
 		{
-			ID:          "step_github octocat._1_echo",
+			ID:          "step_github/octocat._1_echo",
 			Commands:    []string{"echo hello"},
 			Directory:   "/home/github/octocat",
 			Environment: map[string]string{"FOO": "bar"},


### PR DESCRIPTION
This updates the `github.com/go-vela/types/pipeline.Container.Sanitize()` function.

This change will ensure that if a `service` or `step` contains a slash (`/`) in the name, Vela can support it.

This is accomplished by checking if container has a slash in the name, and if so, replacing it with a dash (`-`).

This is similar logic to how we handle other special characters such as spaces (` `), periods (`.`) or underscores (`_`).