### PR TITLE
fix: use tmp for empty name check

### DIFF
--- a/yaml/secret.go
+++ b/yaml/secret.go
@@ -75,9 +75,14 @@ func (s *SecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
+	tmp := SecretSlice{}
+
 	// iterate through each element in the secret slice
 	for _, secret := range *secretSlice {
-		// implicitly set `key` field if empty
+		if len(secret.Name) == 0 {
+			continue
+		}
+
 		if secret.Origin.Empty() && len(secret.Key) == 0 {
 			secret.Key = secret.Name
 		}
@@ -114,10 +119,12 @@ func (s *SecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		if !secret.Origin.Empty() && strings.EqualFold(secret.Origin.Pull, "false") {
 			secret.Origin.Pull = constants.PullNotPresent
 		}
+
+		tmp = append(tmp, secret)
 	}
 
 	// overwrite existing SecretSlice
-	*s = *secretSlice
+	*s = tmp
 
 	return nil
 }

--- a/yaml/testdata/secret.yml
+++ b/yaml/testdata/secret.yml
@@ -1,4 +1,6 @@
 ---
+- source: foo
+  target: bar
 - name: foo
   key: bar
   engine: native


### PR DESCRIPTION
PR includes the following changes:

- add a check to skips secrets that have empty names

Details:

In certain, situations the compiler can call the marshaller; sometimes when this happens with templates the secrets being passed has a secret array that contains empty secret elements. This change adds extra checking in cases a secret element exists within the secrets block that doesn't have `name:`.