### PR TITLE
feat: add environment tag for global injection

### DIFF
--- a/pipeline/build.go
+++ b/pipeline/build.go
@@ -8,20 +8,22 @@ import (
 	"strings"
 
 	"github.com/go-vela/types/constants"
+	"github.com/go-vela/types/raw"
 )
 
 // Build is the pipeline representation of a build for a pipeline.
 //
 // swagger:model PipelineBuild
 type Build struct {
-	ID       string         `json:"id,omitempty"       yaml:"id,omitempty"`
-	Version  string         `json:"version,omitempty"  yaml:"version,omitempty"`
-	Metadata Metadata       `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Worker   Worker         `json:"worker,omitempty"   yaml:"worker,omitempty"`
-	Secrets  SecretSlice    `json:"secrets,omitempty"  yaml:"secrets,omitempty"`
-	Services ContainerSlice `json:"services,omitempty" yaml:"services,omitempty"`
-	Stages   StageSlice     `json:"stages,omitempty"   yaml:"stages,omitempty"`
-	Steps    ContainerSlice `json:"steps,omitempty"    yaml:"steps,omitempty"`
+	ID          string             `json:"id,omitempty"       yaml:"id,omitempty"`
+	Version     string             `json:"version,omitempty"  yaml:"version,omitempty"`
+	Metadata    Metadata           `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Environment raw.StringSliceMap `json:"environment,omitempty" yaml:"environment,omitempty"`
+	Worker      Worker             `json:"worker,omitempty"   yaml:"worker,omitempty"`
+	Secrets     SecretSlice        `json:"secrets,omitempty"  yaml:"secrets,omitempty"`
+	Services    ContainerSlice     `json:"services,omitempty" yaml:"services,omitempty"`
+	Stages      StageSlice         `json:"stages,omitempty"   yaml:"stages,omitempty"`
+	Steps       ContainerSlice     `json:"steps,omitempty"    yaml:"steps,omitempty"`
 }
 
 // Purge removes the steps, in every stage, that contain a ruleset

--- a/pipeline/build_test.go
+++ b/pipeline/build_test.go
@@ -205,8 +205,9 @@ func TestPipeline_Build_Sanitize(t *testing.T) {
 
 func testBuildStages() *Build {
 	return &Build{
-		Version: "1",
-		ID:      "github octocat._1",
+		Version:     "1",
+		ID:          "github octocat._1",
+		Environment: map[string]string{"HELLO": "Hello, Global Message"},
 		Services: ContainerSlice{
 			{
 				ID:          "service_github octocat._1_postgres",
@@ -287,8 +288,9 @@ func testBuildStages() *Build {
 
 func testBuildSteps() *Build {
 	return &Build{
-		Version: "1",
-		ID:      "github octocat._1",
+		Version:     "1",
+		ID:          "github octocat._1",
+		Environment: map[string]string{"HELLO": "Hello, Global Message"},
 		Services: ContainerSlice{
 			{
 				ID:          "service_github octocat._1_postgres",

--- a/pipeline/metadata.go
+++ b/pipeline/metadata.go
@@ -8,6 +8,7 @@ package pipeline
 //
 // swagger:model PipelineMetadata
 type Metadata struct {
-	Template bool `json:"template,omitempty" yaml:"template,omitempty"`
-	Clone    bool `json:"clone,omitempty" yaml:"clone,omitempty"`
+	Template    bool     `json:"template,omitempty" yaml:"template,omitempty"`
+	Clone       bool     `json:"clone,omitempty" yaml:"clone,omitempty"`
+	Environment []string `json:"environment,omitempty" yaml:"environment,omitempty"`
 }

--- a/yaml/build.go
+++ b/yaml/build.go
@@ -4,15 +4,20 @@
 
 package yaml
 
+import (
+	"github.com/go-vela/types/raw"
+)
+
 // Build is the yaml representation of a build for a pipeline.
 // nolint:lll // jsonschema will cause long lines
 type Build struct {
-	Version   string        `yaml:"version,omitempty"   json:"version,omitempty"  jsonschema:"required,minLength=1,description=Provide syntax version used to evaluate the pipeline.\nReference: https://go-vela.github.io/docs/reference/yaml/version/"`
-	Metadata  Metadata      `yaml:"metadata,omitempty"  json:"metadata,omitempty" jsonschema:"description=Pass extra information.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/"`
-	Worker    Worker        `yaml:"worker,omitempty"    json:"worker,omitempty" jsonschema:"description=Limit the pipeline to certain types of workers.\nReference: https://go-vela.github.io/docs/reference/yaml/worker/"`
-	Secrets   SecretSlice   `yaml:"secrets,omitempty"   json:"secrets,omitempty" jsonschema:"description=Provide sensitive information.\nReference: https://go-vela.github.io/docs/reference/yaml/secrets/"`
-	Services  ServiceSlice  `yaml:"services,omitempty"  json:"services,omitempty" jsonschema:"description=Provide detached (headless) execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/services/"`
-	Stages    StageSlice    `yaml:"stages,omitempty"    json:"stages,omitempty" jsonschema:"oneof_required=stages,description=Provide parallel execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/stages/"`
-	Steps     StepSlice     `yaml:"steps,omitempty"     json:"steps,omitempty" jsonschema:"oneof_required=steps,description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/"`
-	Templates TemplateSlice `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/reference/yaml/templates/"`
+	Version     string             `yaml:"version,omitempty"   json:"version,omitempty"  jsonschema:"required,minLength=1,description=Provide syntax version used to evaluate the pipeline.\nReference: https://go-vela.github.io/docs/reference/yaml/version/"`
+	Metadata    Metadata           `yaml:"metadata,omitempty"  json:"metadata,omitempty" jsonschema:"description=Pass extra information.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/"`
+	Environment raw.StringSliceMap `yaml:"environment,omitempty" json:"environment,omitempty" jsonschema:"description=Provide global environment variables injected into the container environment.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/#the-environment-tag"`
+	Worker      Worker             `yaml:"worker,omitempty"    json:"worker,omitempty" jsonschema:"description=Limit the pipeline to certain types of workers.\nReference: https://go-vela.github.io/docs/reference/yaml/worker/"`
+	Secrets     SecretSlice        `yaml:"secrets,omitempty"   json:"secrets,omitempty" jsonschema:"description=Provide sensitive information.\nReference: https://go-vela.github.io/docs/reference/yaml/secrets/"`
+	Services    ServiceSlice       `yaml:"services,omitempty"  json:"services,omitempty" jsonschema:"description=Provide detached (headless) execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/services/"`
+	Stages      StageSlice         `yaml:"stages,omitempty"    json:"stages,omitempty" jsonschema:"oneof_required=stages,description=Provide parallel execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/stages/"`
+	Steps       StepSlice          `yaml:"steps,omitempty"     json:"steps,omitempty" jsonschema:"oneof_required=steps,description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/"`
+	Templates   TemplateSlice      `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/reference/yaml/templates/"`
 }

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -5,7 +5,6 @@
 package yaml
 
 import (
-	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -25,7 +24,9 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 			want: &Build{
 				Version: "1",
 				Metadata: Metadata{
-					Template: false,
+					Template:    false,
+					Clone:       nil,
+					Environment: []string{"steps", "services", "secrets"},
 				},
 				Environment: raw.StringSliceMap{
 					"HELLO": "Hello, Global Message",
@@ -227,7 +228,9 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 			want: &Build{
 				Version: "1",
 				Metadata: Metadata{
-					Template: false,
+					Template:    false,
+					Clone:       nil,
+					Environment: []string{"steps", "services", "secrets"},
 				},
 				Stages: StageSlice{
 					{
@@ -343,7 +346,9 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 			want: &Build{
 				Version: "1",
 				Metadata: Metadata{
-					Template: false,
+					Template:    false,
+					Clone:       nil,
+					Environment: []string{"steps", "services", "secrets"},
 				},
 				Steps: StepSlice{
 					{
@@ -448,8 +453,6 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 		}
 
 		err = yaml.Unmarshal(b, got)
-
-		fmt.Println("GOT: ", got.Environment)
 
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -5,6 +5,7 @@
 package yaml
 
 import (
+	"fmt"
 	"io/ioutil"
 	"reflect"
 	"testing"
@@ -25,6 +26,9 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 				Version: "1",
 				Metadata: Metadata{
 					Template: false,
+				},
+				Environment: raw.StringSliceMap{
+					"HELLO": "Hello, Global Message",
 				},
 				Worker: Worker{
 					Flavor:   "16cpu8gb",
@@ -444,6 +448,8 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 		}
 
 		err = yaml.Unmarshal(b, got)
+
+		fmt.Println("GOT: ", got.Environment)
 
 		if err != nil {
 			t.Errorf("UnmarshalYAML returned err: %v", err)

--- a/yaml/metadata.go
+++ b/yaml/metadata.go
@@ -4,11 +4,7 @@
 
 package yaml
 
-import (
-	"fmt"
-
-	"github.com/go-vela/types/pipeline"
-)
+import "github.com/go-vela/types/pipeline"
 
 type (
 	// Metadata is the yaml representation of
@@ -73,10 +69,9 @@ func (m *Metadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	// overwrite existing metadata environment details
-	m = (*Metadata)(metadata)
-
-	fmt.Println("m ENV: ", m.Environment)
-	fmt.Println("m CLONE", *m.Clone)
+	m.Template = metadata.Template
+	m.Clone = metadata.Clone
+	m.Environment = metadata.Environment
 
 	return nil
 }

--- a/yaml/metadata.go
+++ b/yaml/metadata.go
@@ -4,15 +4,27 @@
 
 package yaml
 
-import "github.com/go-vela/types/pipeline"
+import (
+	"fmt"
 
-// Metadata is the yaml representation of
-// the metadata block for a pipeline.
-// nolint:lll // jsonschema will cause long lines
-type Metadata struct {
-	Template bool  `yaml:"template,omitempty" json:"template,omitempty" jsonschema:"description=Enables compiling the pipeline as a template.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/#the-template-tag"`
-	Clone    *bool `yaml:"clone,omitempty" json:"clone,omitempty" jsonschema:"default=true,description=Enables injecting the default clone process.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/#the-clone-tag"`
-}
+	"github.com/go-vela/types/pipeline"
+)
+
+type (
+	// Metadata is the yaml representation of
+	// the metadata block for a pipeline.
+	// nolint:lll // jsonschema will cause long lines
+	Metadata struct {
+		Template    bool     `yaml:"template,omitempty" json:"template,omitempty" jsonschema:"description=Enables compiling the pipeline as a template.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/#the-template-tag"`
+		Clone       *bool    `yaml:"clone,omitempty" json:"clone,omitempty" jsonschema:"default=true,description=Enables injecting the default clone process.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/#the-clone-tag"`
+		Environment []string `yaml:"environment,omitempty" json:"environment,omitempty" jsonschema:"default=true,description=Controls which containers processes can have global env injected.\nReference: https://go-vela.github.io/docs/reference/yaml/metadata/#the-environment-tag"`
+	}
+
+	// helper type that allows the unmarshaler interface
+	// to add default values back into metadata. Using the
+	// Metadata type directly will result in a reflection error
+	_metadata Metadata
+)
 
 // ToPipeline converts the Metadata type
 // to a pipeline Metadata type.
@@ -23,8 +35,48 @@ func (m *Metadata) ToPipeline() *pipeline.Metadata {
 	} else {
 		clone = *m.Clone
 	}
+
 	return &pipeline.Metadata{
-		Template: m.Template,
-		Clone:    clone,
+		Template:    m.Template,
+		Clone:       clone,
+		Environment: m.Environment,
 	}
+}
+
+// HasEnvironment checks if the container type
+// is contained within the environment list.
+func (m *Metadata) HasEnvironment(container string) bool {
+	for _, e := range m.Environment {
+		if e == container {
+			return true
+		}
+	}
+
+	return false
+}
+
+// UnmarshalYAML implements the Unmarshaler interface for the Metadata type.
+func (m *Metadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// metadata we try unmarshalling to
+	metadata := new(_metadata)
+
+	// attempt to unmarshal as a metadata type
+	err := unmarshal(metadata)
+	if err != nil {
+		return err
+	}
+
+	if len(metadata.Environment) == 0 {
+		metadata.Environment = []string{"steps", "services", "secrets"}
+	} else {
+		metadata.Environment = m.Environment
+	}
+
+	// overwrite existing metadata environment details
+	m = (*Metadata)(metadata)
+
+	fmt.Println("m ENV: ", m.Environment)
+	fmt.Println("m CLONE", *m.Clone)
+
+	return nil
 }

--- a/yaml/metadata_test.go
+++ b/yaml/metadata_test.go
@@ -24,32 +24,38 @@ func TestYaml_Metadata_ToPipeline(t *testing.T) {
 	}{
 		{
 			metadata: &Metadata{
-				Template: false,
-				Clone:    &fBool,
+				Template:    false,
+				Clone:       &fBool,
+				Environment: nil,
 			},
 			want: &pipeline.Metadata{
-				Template: false,
-				Clone:    false,
+				Template:    false,
+				Clone:       false,
+				Environment: []string{"steps", "services", "secrets"},
 			},
 		},
 		{
 			metadata: &Metadata{
-				Template: false,
-				Clone:    &tBool,
+				Template:    false,
+				Clone:       &tBool,
+				Environment: []string{"steps", "services"},
 			},
 			want: &pipeline.Metadata{
-				Template: false,
-				Clone:    true,
+				Template:    false,
+				Clone:       true,
+				Environment: []string{"steps", "services"},
 			},
 		},
 		{
 			metadata: &Metadata{
-				Template: false,
-				Clone:    nil,
+				Template:    false,
+				Clone:       nil,
+				Environment: []string{"steps"},
 			},
 			want: &pipeline.Metadata{
-				Template: false,
-				Clone:    true,
+				Template:    false,
+				Clone:       true,
+				Environment: []string{"steps"},
 			},
 		},
 	}
@@ -57,6 +63,46 @@ func TestYaml_Metadata_ToPipeline(t *testing.T) {
 	// run tests
 	for _, test := range tests {
 		got := test.metadata.ToPipeline()
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ToPipeline is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestYaml_Metadata_HasEnvironment(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		metadata  *Metadata
+		container string
+		want      bool
+	}{
+		{
+			metadata: &Metadata{
+				Environment: []string{"steps", "services", "secrets"},
+			},
+			container: "steps",
+			want:      true,
+		},
+		{
+			metadata: &Metadata{
+				Environment: []string{"services", "secrets"},
+			},
+			container: "services",
+			want:      true,
+		},
+		{
+			metadata: &Metadata{
+				Environment: []string{"steps", "services", "secrets"},
+			},
+			container: "notacontainer",
+			want:      false,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.metadata.HasEnvironment(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("ToPipeline is %v, want %v", got, test.want)

--- a/yaml/metadata_test.go
+++ b/yaml/metadata_test.go
@@ -26,7 +26,7 @@ func TestYaml_Metadata_ToPipeline(t *testing.T) {
 			metadata: &Metadata{
 				Template:    false,
 				Clone:       &fBool,
-				Environment: nil,
+				Environment: []string{"steps", "services", "secrets"},
 			},
 			want: &pipeline.Metadata{
 				Template:    false,
@@ -119,8 +119,9 @@ func TestYaml_Metadata_UnmarshalYAML(t *testing.T) {
 		{
 			file: "testdata/metadata.yml",
 			want: &Metadata{
-				Template: false,
-				Clone:    nil,
+				Template:    false,
+				Clone:       nil,
+				Environment: []string{"steps", "services", "secrets"},
 			},
 		},
 	}

--- a/yaml/testdata/build.yml
+++ b/yaml/testdata/build.yml
@@ -4,6 +4,9 @@ version: "1"
 metadata:
   template: false
 
+environment:
+  HELLO: "Hello, Global Message"  
+
 templates:
   - name: docker_publish
     source: github.com/go-vela/atlas/stable/docker_publish


### PR DESCRIPTION
PR includes the following changes:

- Add `environment:` to metadata block enables controlling which containers can get global config
- Add `environment:` to the base of YAML allows setting what config is globally injected
- New helper function on metadata struct for compiler injection control

Story for additionally context https://github.com/go-vela/community/issues/304

Additional related PRs:
- 