### PR TITLE
feat: enable setting ulimits for services

### DIFF
--- a/yaml/service.go
+++ b/yaml/service.go
@@ -28,6 +28,7 @@ type (
 		Environment raw.StringSliceMap `yaml:"environment,omitempty" json:"environment,omitempty" jsonschema:"description=Variables to inject into the container environment.\nReference: https://go-vela.github.io/docs/reference/yaml/services/#the-environment-tag"`
 		Ports       raw.StringSlice    `yaml:"ports,omitempty"       json:"ports,omitempty" jsonschema:"description=List of ports to map for the container in the pipeline.\nReference: https://go-vela.github.io/docs/reference/yaml/services/#the-ports-tag"`
 		Pull        string             `yaml:"pull,omitempty"        json:"pull,omitempty" jsonschema:"enum=always,enum=not_present,enum=on_start,enum=never,default=not_present,description=Declaration to configure if and when the Docker image is pulled.\nReference: https://go-vela.github.io/docs/reference/yaml/services/#the-pul-tag"`
+		Ulimits     UlimitSlice        `yaml:"ulimits,omitempty"     json:"ulimits,omitempty" jsonschema:"description=Set the user limits for the container.\nReference: https://go-vela.github.io/docs/reference/yaml/services/#the-ulimits-tag"`
 	}
 )
 
@@ -48,6 +49,7 @@ func (s *ServiceSlice) ToPipeline() *pipeline.ContainerSlice {
 			Environment: service.Environment,
 			Ports:       service.Ports,
 			Pull:        service.Pull,
+			Ulimits:     *service.Ulimits.ToPipeline(),
 		})
 	}
 


### PR DESCRIPTION
completes go-vela/community/issues/267

pkg-runtime already has the ability to set ulimits for steps, this PR enables the compiler to set ulimits for services.