### PR TITLE
chore: fix schema generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,4 +141,6 @@ bump-deps-full: check
 schema:
 	@echo
 	@echo "### Creating schema"
+	@go get github.com/alecthomas/jsonschema
+	@go get github.com/iancoleman/orderedmap
 	@go run cmd/schema/main.go > schema.json


### PR DESCRIPTION
looks like with https://github.com/go-vela/types/releases/tag/v0.9.0-rc2 the schema was not getting bundled with the release anymore. this is a quick fix for that. we might consider a submodule maybe?