### PR TITLE
fix: move Step init logic from executor to library

### DIFF
--- a/library/step.go
+++ b/library/step.go
@@ -6,9 +6,9 @@ package library
 
 import (
 	"fmt"
-	"github.com/go-vela/types/constants"
 	"strconv"
 
+	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
 )
 

--- a/library/step.go
+++ b/library/step.go
@@ -533,11 +533,11 @@ func (s *Step) InitFrom(ctn *pipeline.Container, build *Build) {
 	s.SetStatus(constants.StatusPending)
 }
 
-// StepFromContainer converts the pipeline
+// StepFromContainerEnvironment converts the pipeline
 // Container type to a library Step type using the container's Environment.
 //
 // nolint: funlen // ignore function length due to comments and conditionals
-func StepFromContainer(ctn *pipeline.Container) *Step {
+func StepFromContainerEnvironment(ctn *pipeline.Container) *Step {
 	// check if container or container environment are nil
 	if ctn == nil || ctn.Environment == nil {
 		return nil

--- a/library/step.go
+++ b/library/step.go
@@ -506,51 +506,38 @@ func (s *Step) String() string {
 	)
 }
 
-// StepFromContainer converts the pipeline
-// Container type to a library Step type
-// before the Container's environment is fully populated.
-func StepFromContainer(ctn *pipeline.Container, build *Build) *Step {
-	// check if container is nil or uninitialized
-	if ctn == nil || ctn.Name == "" {
-		return nil
+// InitFrom initializes some Step type fields based on a Container and a Build.
+func (s *Step) InitFrom(ctn *pipeline.Container, build *Build) {
+	if ctn != nil && ctn.Name != "" {
+		// set values from the container
+		s.SetName(ctn.Name)
+		s.SetNumber(ctn.Number)
+		s.SetImage(ctn.Image)
+
+		// check if the VELA_STEP_STAGE environment variable exists
+		value, ok := ctn.Environment["VELA_STEP_STAGE"]
+		if ok {
+			// set the Stage field to the value from environment variable
+			s.SetStage(value)
+		}
 	}
 
-	// create new step type we want to return
-	s := new(Step)
-
-	// set values from the container
-	s.SetName(ctn.Name)
-	s.SetNumber(ctn.Number)
-	s.SetImage(ctn.Image)
-
-	// check if the VELA_STEP_STAGE environment variable exists
-	value, ok := ctn.Environment["VELA_STEP_STAGE"]
-	if ok {
-		// set the Stage field to the value from environment variable
-		s.SetStage(value)
+	if build != nil {
+		// set values from the build
+		s.SetHost(build.GetHost())
+		s.SetRuntime(build.GetRuntime())
+		s.SetDistribution(build.GetDistribution())
 	}
-
-	// check if build is nil
-	if build == nil {
-		return s
-	}
-
-	// set values from the build
-	s.SetHost(build.GetHost())
-	s.SetRuntime(build.GetRuntime())
-	s.SetDistribution(build.GetDistribution())
 
 	// default status to Pending
 	s.SetStatus(constants.StatusPending)
-
-	return s
 }
 
-// StepFromContainerEnvironment converts the pipeline
+// StepFromContainer converts the pipeline
 // Container type to a library Step type using the container's Environment.
 //
 // nolint: funlen // ignore function length due to comments and conditionals
-func StepFromContainerEnvironment(ctn *pipeline.Container) *Step {
+func StepFromContainer(ctn *pipeline.Container) *Step {
 	// check if container or container environment are nil
 	if ctn == nil || ctn.Environment == nil {
 		return nil

--- a/library/step.go
+++ b/library/step.go
@@ -506,8 +506,24 @@ func (s *Step) String() string {
 	)
 }
 
-// InitFrom initializes some Step type fields based on a Container and a Build.
-func (s *Step) InitFrom(ctn *pipeline.Container, build *Build) {
+// StepFromBuildContainer creates new Step type based on
+// a Build and one of its Containers.
+func StepFromBuildContainer(build *Build, ctn *pipeline.Container) *Step {
+	// create new step type we want to return
+	s := new(Step)
+
+	// default status to Pending
+	s.SetStatus(constants.StatusPending)
+
+	// copy fields from build
+	if build != nil {
+		// set values from the build
+		s.SetHost(build.GetHost())
+		s.SetRuntime(build.GetRuntime())
+		s.SetDistribution(build.GetDistribution())
+	}
+
+	// copy fields from container
 	if ctn != nil && ctn.Name != "" {
 		// set values from the container
 		s.SetName(ctn.Name)
@@ -521,16 +537,7 @@ func (s *Step) InitFrom(ctn *pipeline.Container, build *Build) {
 			s.SetStage(value)
 		}
 	}
-
-	if build != nil {
-		// set values from the build
-		s.SetHost(build.GetHost())
-		s.SetRuntime(build.GetRuntime())
-		s.SetDistribution(build.GetDistribution())
-	}
-
-	// default status to Pending
-	s.SetStatus(constants.StatusPending)
+	return s
 }
 
 // StepFromContainerEnvironment converts the pipeline

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -272,7 +272,13 @@ func TestLibrary_Step_String(t *testing.T) {
 	}
 }
 
-func TestLibrary_StepFromContainer(t *testing.T) {
+func TestLibrary_Step_InitFrom(t *testing.T) {
+	// some strings used in the tests (not const, as we need the address)
+	defaultStatus := "pending"
+	exampleHost := "example.company.com"
+	exampleRuntime := "docker"
+	exampleDistribution := "linux"
+
 	// setup types
 	s := new(Step)
 
@@ -281,10 +287,10 @@ func TestLibrary_StepFromContainer(t *testing.T) {
 	s.SetNumber(1)
 	s.SetImage("target/vela-git:v0.3.0")
 	s.SetStage("clone")
-	s.SetHost("example.company.com")
-	s.SetRuntime("docker")
-	s.SetDistribution("linux")
-	s.SetStatus("pending")
+	s.SetHost(exampleHost)
+	s.SetRuntime(exampleRuntime)
+	s.SetDistribution(exampleDistribution)
+	s.SetStatus(defaultStatus)
 
 	tests := []struct {
 		container *pipeline.Container
@@ -294,22 +300,32 @@ func TestLibrary_StepFromContainer(t *testing.T) {
 		{
 			container: nil,
 			build:     nil,
-			want:      nil,
+			want:      &Step{Status: &defaultStatus},
 		},
 		{
 			container: new(pipeline.Container),
 			build:     nil,
-			want:      nil,
+			want:      &Step{Status: &defaultStatus},
 		},
 		{
 			container: nil,
 			build:     testBuild(),
-			want:      nil,
+			want: &Step{
+				Status:       &defaultStatus,
+				Host:         &exampleHost,
+				Runtime:      &exampleRuntime,
+				Distribution: &exampleDistribution,
+			},
 		},
 		{
 			container: new(pipeline.Container),
 			build:     testBuild(),
-			want:      nil,
+			want: &Step{
+				Status:       &defaultStatus,
+				Host:         &exampleHost,
+				Runtime:      &exampleRuntime,
+				Distribution: &exampleDistribution,
+			},
 		},
 		{
 			container: &pipeline.Container{
@@ -327,15 +343,16 @@ func TestLibrary_StepFromContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := StepFromContainer(test.container, test.build)
+		step := new(Step)
+		step.InitFrom(test.container, test.build)
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("StepFromContainer is %v, want %v", got, test.want)
+		if !reflect.DeepEqual(step, test.want) {
+			t.Errorf("Step.InitFrom made %v, want %v", step, test.want)
 		}
 	}
 }
 
-func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
+func TestLibrary_StepFromContainer(t *testing.T) {
 	// setup types
 	s := testStep()
 
@@ -381,10 +398,10 @@ func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := StepFromContainerEnvironment(test.container)
+		got := StepFromContainer(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("StepFromContainerEnvironment is %v, want %v", got, test.want)
+			t.Errorf("StepFromContainer is %v, want %v", got, test.want)
 		}
 	}
 }

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -352,7 +352,7 @@ func TestLibrary_Step_InitFrom(t *testing.T) {
 	}
 }
 
-func TestLibrary_StepFromContainer(t *testing.T) {
+func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
 	// setup types
 	s := testStep()
 
@@ -398,10 +398,10 @@ func TestLibrary_StepFromContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := StepFromContainer(test.container)
+		got := StepFromContainerEnvironment(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("StepFromContainer is %v, want %v", got, test.want)
+			t.Errorf("StepFromContainerEnvironment is %v, want %v", got, test.want)
 		}
 	}
 }

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -272,7 +272,7 @@ func TestLibrary_Step_String(t *testing.T) {
 	}
 }
 
-func TestLibrary_Step_InitFrom(t *testing.T) {
+func TestLibrary_Step_StepFromBuildContainer(t *testing.T) {
 	// some strings used in the tests (not const, as we need the address)
 	defaultStatus := "pending"
 	exampleHost := "example.company.com"
@@ -343,11 +343,10 @@ func TestLibrary_Step_InitFrom(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		step := new(Step)
-		step.InitFrom(test.container, test.build)
+		step := StepFromBuildContainer(test.build, test.container)
 
 		if !reflect.DeepEqual(step, test.want) {
-			t.Errorf("Step.InitFrom made %v, want %v", step, test.want)
+			t.Errorf("Step.StepFromBuildContainer made %v, want %v", step, test.want)
 		}
 	}
 }

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -274,6 +274,69 @@ func TestLibrary_Step_String(t *testing.T) {
 
 func TestLibrary_StepFromContainer(t *testing.T) {
 	// setup types
+	s := new(Step)
+
+	// add dummy values for values managed by StepFromContainer
+	s.SetName("clone")
+	s.SetNumber(1)
+	s.SetImage("target/vela-git:v0.3.0")
+	s.SetStage("clone")
+	s.SetHost("example.company.com")
+	s.SetRuntime("docker")
+	s.SetDistribution("linux")
+	s.SetStatus("pending")
+
+	tests := []struct {
+		container *pipeline.Container
+		build     *Build
+		want      *Step
+	}{
+		{
+			container: nil,
+			build:     nil,
+			want:      nil,
+		},
+		{
+			container: new(pipeline.Container),
+			build:     nil,
+			want:      nil,
+		},
+		{
+			container: nil,
+			build:     testBuild(),
+			want:      nil,
+		},
+		{
+			container: new(pipeline.Container),
+			build:     testBuild(),
+			want:      nil,
+		},
+		{
+			container: &pipeline.Container{
+				Name:   "clone",
+				Number: 1,
+				Image:  "target/vela-git:v0.3.0",
+				Environment: map[string]string{
+					"VELA_STEP_STAGE": "clone",
+				},
+			},
+			build: testBuild(),
+			want:  s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := StepFromContainer(test.container, test.build)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("StepFromContainer is %v, want %v", got, test.want)
+		}
+	}
+}
+
+func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
+	// setup types
 	s := testStep()
 
 	// modify fields that aren't set
@@ -318,10 +381,10 @@ func TestLibrary_StepFromContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := StepFromContainer(test.container)
+		got := StepFromContainerEnvironment(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("StepFromContainer is %v, want %v", got, test.want)
+			t.Errorf("StepFromContainerEnvironment is %v, want %v", got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
Both the local and linux executors have to init a step object in a couple of places. This moves that logic into `library` to facilitate reuse.

The executor can't use `StepFromContainer` because that relies on the container Environment which is not configured yet.  So, we rename `StepFromContainer` to `StepFromContainerEnvironment` to more accurately represent what it does. Then we add a new `StepFromBuildContainer` function to create a new Step and initialize it using data from a `library.Build` and a `pipeline.Container`.

For background, see the conversation here: https://github.com/go-vela/pkg-executor/pull/179#discussion_r735875710

This should be merged before https://github.com/go-vela/worker/pull/239