### PR TITLE
feat(environment): add pusher name and email for tag events

### DIFF
--- a/constants/event.go
+++ b/constants/event.go
@@ -20,4 +20,7 @@ const (
 
 	// EventComment defines the event type for comments added to a pull request.
 	EventComment = "comment"
+
+	// EventRepository defines the event type for repository actions such as delete and rename.
+	EventRepository = "repository"
 )

--- a/constants/event.go
+++ b/constants/event.go
@@ -20,7 +20,4 @@ const (
 
 	// EventComment defines the event type for comments added to a pull request.
 	EventComment = "comment"
-
-	// EventRepository defines the event type for repository actions such as delete and rename.
-	EventRepository = "repository"
 )

--- a/library/build.go
+++ b/library/build.go
@@ -45,6 +45,8 @@ type Build struct {
 	Host          *string             `json:"host,omitempty"`
 	Runtime       *string             `json:"runtime,omitempty"`
 	Distribution  *string             `json:"distribution,omitempty"`
+	PusherName    *string             `json:"pusher_name,omitempty"`
+	PusherEmail   *string             `json:"pusher_email,omitempty"`
 }
 
 // Environment returns a list of environment variables
@@ -117,7 +119,6 @@ func (b *Build) Environment(workspace, channel string) map[string]string {
 	if strings.EqualFold(b.GetEvent(), constants.EventDeploy) {
 		// capture the deployment target
 		target := ToString(b.GetDeploy())
-
 		// add the deployment target to the list
 		envs["VELA_BUILD_TARGET"] = target
 		envs["VELA_DEPLOYMENT"] = target
@@ -131,6 +132,8 @@ func (b *Build) Environment(workspace, channel string) map[string]string {
 			// add the tag reference to the list
 			envs["BUILD_TAG"] = tag
 			envs["VELA_BUILD_TAG"] = tag
+			envs["VELA_BUILD_TAG_AUTHOR"] = b.GetPusherName()
+			envs["VELA_BUILD_TAG_AUTHOR_EMAIL"] = b.GetPusherEmail()
 		}
 
 		// add payload data to the list
@@ -160,6 +163,8 @@ func (b *Build) Environment(workspace, channel string) map[string]string {
 		// add the tag reference to the list
 		envs["BUILD_TAG"] = tag
 		envs["VELA_BUILD_TAG"] = tag
+		envs["VELA_BUILD_TAG_AUTHOR"] = b.GetPusherName()
+		envs["VELA_BUILD_TAG_AUTHOR_EMAIL"] = b.GetPusherEmail()
 	}
 
 	return envs
@@ -542,6 +547,22 @@ func (b *Build) GetDistribution() string {
 	return *b.Distribution
 }
 
+func (b *Build) GetPusherName() string {
+	if b == nil || b.PusherName == nil {
+		return ""
+	}
+
+	return *b.PusherName
+}
+
+func (b *Build) GetPusherEmail() string {
+	if b == nil || b.PusherEmail == nil {
+		return ""
+	}
+
+	return *b.PusherEmail
+}
+
 // SetID sets the ID field.
 //
 // When the provided Build type is nil, it
@@ -919,6 +940,22 @@ func (b *Build) SetDistribution(v string) {
 	b.Distribution = &v
 }
 
+func (b *Build) SetPusherName(v string) {
+	if b == nil {
+		return
+	}
+
+	b.PusherName = &v
+}
+
+func (b *Build) SetPusherEmail(v string) {
+	if b == nil {
+		return
+	}
+
+	b.PusherEmail = &v
+}
+
 // String implements the Stringer interface for the Build type.
 // nolint:dupl // this is duplicated in the test
 func (b *Build) String() string {
@@ -944,6 +981,8 @@ func (b *Build) String() string {
   Message: %s,
   Number: %d,
   Parent: %d,
+  PusherName: %s,
+  PusherEmail: %s,
   Ref: %s,
   RepoID: %d,
   Runtime: %s,
@@ -974,6 +1013,8 @@ func (b *Build) String() string {
 		b.GetMessage(),
 		b.GetNumber(),
 		b.GetParent(),
+		b.GetPusherName(),
+		b.GetPusherEmail(),
 		b.GetRef(),
 		b.GetRepoID(),
 		b.GetRuntime(),

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -212,59 +212,61 @@ func TestLibrary_Build_Environment(t *testing.T) {
 		{
 			build: _deployTag,
 			want: map[string]string{
-				"VELA_BUILD_AUTHOR":        "OctoKitty",
-				"VELA_BUILD_AUTHOR_EMAIL":  "OctoKitty@github.com",
-				"VELA_BUILD_BASE_REF":      "",
-				"VELA_BUILD_BRANCH":        "master",
-				"VELA_BUILD_CHANNEL":       "TODO",
-				"VELA_BUILD_CLONE":         "https://github.com/github/octocat.git",
-				"VELA_BUILD_COMMIT":        "48afb5bdc41ad69bf22588491333f7cf71135163",
-				"VELA_BUILD_CREATED":       "1563474076",
-				"VELA_BUILD_DISTRIBUTION":  "linux",
-				"VELA_BUILD_ENQUEUED":      "1563474077",
-				"VELA_BUILD_EVENT":         "deployment",
-				"VELA_BUILD_HOST":          "example.company.com",
-				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
-				"VELA_BUILD_MESSAGE":       "First commit...",
-				"VELA_BUILD_NUMBER":        "1",
-				"VELA_BUILD_PARENT":        "1",
-				"VELA_BUILD_REF":           "refs/tags/v0.1.0",
-				"VELA_BUILD_RUNTIME":       "docker",
-				"VELA_BUILD_SENDER":        "OctoKitty",
-				"VELA_BUILD_STARTED":       "1563474078",
-				"VELA_BUILD_SOURCE":        "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
-				"VELA_BUILD_STATUS":        "running",
-				"VELA_BUILD_TAG":           "v0.1.0",
-				"VELA_BUILD_TARGET":        "production",
-				"VELA_BUILD_TITLE":         "push received from https://github.com/github/octocat",
-				"VELA_BUILD_WORKSPACE":     "TODO",
-				"VELA_DEPLOYMENT":          "production",
-				"BUILD_AUTHOR":             "OctoKitty",
-				"BUILD_AUTHOR_EMAIL":       "OctoKitty@github.com",
-				"BUILD_BASE_REF":           "",
-				"BUILD_BRANCH":             "master",
-				"BUILD_CHANNEL":            "TODO",
-				"BUILD_CLONE":              "https://github.com/github/octocat.git",
-				"BUILD_COMMIT":             "48afb5bdc41ad69bf22588491333f7cf71135163",
-				"BUILD_CREATED":            "1563474076",
-				"BUILD_ENQUEUED":           "1563474077",
-				"BUILD_EVENT":              "deployment",
-				"BUILD_HOST":               "example.company.com",
-				"BUILD_LINK":               "https://example.company.com/github/octocat/1",
-				"BUILD_MESSAGE":            "First commit...",
-				"BUILD_NUMBER":             "1",
-				"BUILD_PARENT":             "1",
-				"BUILD_REF":                "refs/tags/v0.1.0",
-				"BUILD_SENDER":             "OctoKitty",
-				"BUILD_STARTED":            "1563474078",
-				"BUILD_SOURCE":             "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
-				"BUILD_STATUS":             "running",
-				"BUILD_TAG":                "v0.1.0",
-				"BUILD_TARGET":             "production",
-				"BUILD_TITLE":              "push received from https://github.com/github/octocat",
-				"BUILD_WORKSPACE":          "TODO",
-				"DEPLOYMENT_PARAMETER_FOO": "test1",
-				"DEPLOYMENT_PARAMETER_BAR": "test2",
+				"VELA_BUILD_AUTHOR":           "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL":     "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":         "",
+				"VELA_BUILD_BRANCH":           "master",
+				"VELA_BUILD_CHANNEL":          "TODO",
+				"VELA_BUILD_CLONE":            "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":           "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":          "1563474076",
+				"VELA_BUILD_DISTRIBUTION":     "linux",
+				"VELA_BUILD_ENQUEUED":         "1563474077",
+				"VELA_BUILD_EVENT":            "deployment",
+				"VELA_BUILD_HOST":             "example.company.com",
+				"VELA_BUILD_LINK":             "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":          "First commit...",
+				"VELA_BUILD_NUMBER":           "1",
+				"VELA_BUILD_PARENT":           "1",
+				"VELA_BUILD_REF":              "refs/tags/v0.1.0",
+				"VELA_BUILD_RUNTIME":          "docker",
+				"VELA_BUILD_SENDER":           "OctoKitty",
+				"VELA_BUILD_STARTED":          "1563474078",
+				"VELA_BUILD_SOURCE":           "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":           "running",
+				"VELA_BUILD_TAG":              "v0.1.0",
+				"VELA_BUILD_TAG_AUTHOR":       "OctoKitty2",
+				"VELA_BUILD_TAG_AUTHOR_EMAIL": "OctoKitty2@github.com",
+				"VELA_BUILD_TARGET":           "production",
+				"VELA_BUILD_TITLE":            "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":        "TODO",
+				"VELA_DEPLOYMENT":             "production",
+				"BUILD_AUTHOR":                "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":          "OctoKitty@github.com",
+				"BUILD_BASE_REF":              "",
+				"BUILD_BRANCH":                "master",
+				"BUILD_CHANNEL":               "TODO",
+				"BUILD_CLONE":                 "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":                "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":               "1563474076",
+				"BUILD_ENQUEUED":              "1563474077",
+				"BUILD_EVENT":                 "deployment",
+				"BUILD_HOST":                  "example.company.com",
+				"BUILD_LINK":                  "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":               "First commit...",
+				"BUILD_NUMBER":                "1",
+				"BUILD_PARENT":                "1",
+				"BUILD_REF":                   "refs/tags/v0.1.0",
+				"BUILD_SENDER":                "OctoKitty",
+				"BUILD_STARTED":               "1563474078",
+				"BUILD_SOURCE":                "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":                "running",
+				"BUILD_TAG":                   "v0.1.0",
+				"BUILD_TARGET":                "production",
+				"BUILD_TITLE":                 "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":             "TODO",
+				"DEPLOYMENT_PARAMETER_FOO":    "test1",
+				"DEPLOYMENT_PARAMETER_BAR":    "test2",
 			},
 		},
 		{
@@ -326,54 +328,56 @@ func TestLibrary_Build_Environment(t *testing.T) {
 		{
 			build: _tag,
 			want: map[string]string{
-				"VELA_BUILD_AUTHOR":       "OctoKitty",
-				"VELA_BUILD_AUTHOR_EMAIL": "OctoKitty@github.com",
-				"VELA_BUILD_BASE_REF":     "",
-				"VELA_BUILD_BRANCH":       "master",
-				"VELA_BUILD_CHANNEL":      "TODO",
-				"VELA_BUILD_CLONE":        "https://github.com/github/octocat.git",
-				"VELA_BUILD_COMMIT":       "48afb5bdc41ad69bf22588491333f7cf71135163",
-				"VELA_BUILD_CREATED":      "1563474076",
-				"VELA_BUILD_DISTRIBUTION": "linux",
-				"VELA_BUILD_ENQUEUED":     "1563474077",
-				"VELA_BUILD_EVENT":        "tag",
-				"VELA_BUILD_HOST":         "example.company.com",
-				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
-				"VELA_BUILD_MESSAGE":      "First commit...",
-				"VELA_BUILD_NUMBER":       "1",
-				"VELA_BUILD_PARENT":       "1",
-				"VELA_BUILD_REF":          "refs/tags/v0.1.0",
-				"VELA_BUILD_RUNTIME":      "docker",
-				"VELA_BUILD_SENDER":       "OctoKitty",
-				"VELA_BUILD_STARTED":      "1563474078",
-				"VELA_BUILD_SOURCE":       "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
-				"VELA_BUILD_STATUS":       "running",
-				"VELA_BUILD_TAG":          "v0.1.0",
-				"VELA_BUILD_TITLE":        "push received from https://github.com/github/octocat",
-				"VELA_BUILD_WORKSPACE":    "TODO",
-				"BUILD_AUTHOR":            "OctoKitty",
-				"BUILD_AUTHOR_EMAIL":      "OctoKitty@github.com",
-				"BUILD_BASE_REF":          "",
-				"BUILD_BRANCH":            "master",
-				"BUILD_CHANNEL":           "TODO",
-				"BUILD_CLONE":             "https://github.com/github/octocat.git",
-				"BUILD_COMMIT":            "48afb5bdc41ad69bf22588491333f7cf71135163",
-				"BUILD_CREATED":           "1563474076",
-				"BUILD_ENQUEUED":          "1563474077",
-				"BUILD_EVENT":             "tag",
-				"BUILD_HOST":              "example.company.com",
-				"BUILD_LINK":              "https://example.company.com/github/octocat/1",
-				"BUILD_MESSAGE":           "First commit...",
-				"BUILD_NUMBER":            "1",
-				"BUILD_PARENT":            "1",
-				"BUILD_REF":               "refs/tags/v0.1.0",
-				"BUILD_SENDER":            "OctoKitty",
-				"BUILD_STARTED":           "1563474078",
-				"BUILD_SOURCE":            "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
-				"BUILD_STATUS":            "running",
-				"BUILD_TAG":               "v0.1.0",
-				"BUILD_TITLE":             "push received from https://github.com/github/octocat",
-				"BUILD_WORKSPACE":         "TODO",
+				"VELA_BUILD_AUTHOR":           "OctoKitty",
+				"VELA_BUILD_AUTHOR_EMAIL":     "OctoKitty@github.com",
+				"VELA_BUILD_BASE_REF":         "",
+				"VELA_BUILD_BRANCH":           "master",
+				"VELA_BUILD_CHANNEL":          "TODO",
+				"VELA_BUILD_CLONE":            "https://github.com/github/octocat.git",
+				"VELA_BUILD_COMMIT":           "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_CREATED":          "1563474076",
+				"VELA_BUILD_DISTRIBUTION":     "linux",
+				"VELA_BUILD_ENQUEUED":         "1563474077",
+				"VELA_BUILD_EVENT":            "tag",
+				"VELA_BUILD_HOST":             "example.company.com",
+				"VELA_BUILD_LINK":             "https://example.company.com/github/octocat/1",
+				"VELA_BUILD_MESSAGE":          "First commit...",
+				"VELA_BUILD_NUMBER":           "1",
+				"VELA_BUILD_PARENT":           "1",
+				"VELA_BUILD_REF":              "refs/tags/v0.1.0",
+				"VELA_BUILD_RUNTIME":          "docker",
+				"VELA_BUILD_SENDER":           "OctoKitty",
+				"VELA_BUILD_STARTED":          "1563474078",
+				"VELA_BUILD_SOURCE":           "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"VELA_BUILD_STATUS":           "running",
+				"VELA_BUILD_TAG":              "v0.1.0",
+				"VELA_BUILD_TAG_AUTHOR":       "OctoKitty2",
+				"VELA_BUILD_TAG_AUTHOR_EMAIL": "OctoKitty2@github.com",
+				"VELA_BUILD_TITLE":            "push received from https://github.com/github/octocat",
+				"VELA_BUILD_WORKSPACE":        "TODO",
+				"BUILD_AUTHOR":                "OctoKitty",
+				"BUILD_AUTHOR_EMAIL":          "OctoKitty@github.com",
+				"BUILD_BASE_REF":              "",
+				"BUILD_BRANCH":                "master",
+				"BUILD_CHANNEL":               "TODO",
+				"BUILD_CLONE":                 "https://github.com/github/octocat.git",
+				"BUILD_COMMIT":                "48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_CREATED":               "1563474076",
+				"BUILD_ENQUEUED":              "1563474077",
+				"BUILD_EVENT":                 "tag",
+				"BUILD_HOST":                  "example.company.com",
+				"BUILD_LINK":                  "https://example.company.com/github/octocat/1",
+				"BUILD_MESSAGE":               "First commit...",
+				"BUILD_NUMBER":                "1",
+				"BUILD_PARENT":                "1",
+				"BUILD_REF":                   "refs/tags/v0.1.0",
+				"BUILD_SENDER":                "OctoKitty",
+				"BUILD_STARTED":               "1563474078",
+				"BUILD_SOURCE":                "https://github.com/github/octocat/48afb5bdc41ad69bf22588491333f7cf71135163",
+				"BUILD_STATUS":                "running",
+				"BUILD_TAG":                   "v0.1.0",
+				"BUILD_TITLE":                 "push received from https://github.com/github/octocat",
+				"BUILD_WORKSPACE":             "TODO",
 			},
 		},
 	}
@@ -521,6 +525,14 @@ func TestLibrary_Build_Getters(t *testing.T) {
 		if test.build.GetDistribution() != test.want.GetDistribution() {
 			t.Errorf("GetDistribution is %v, want %v", test.build.GetDistribution(), test.want.GetDistribution())
 		}
+
+		if test.build.GetPusherName() != test.want.GetPusherName() {
+			t.Errorf("GetPusherName is %v, want %v", test.build.GetPusherName(), test.want.GetPusherName())
+		}
+
+		if test.build.GetPusherEmail() != test.want.GetPusherEmail() {
+			t.Errorf("GetPusherEmail is %v, want %v", test.build.GetPusherEmail(), test.want.GetPusherEmail())
+		}
 	}
 }
 
@@ -574,6 +586,8 @@ func TestLibrary_Build_Setters(t *testing.T) {
 		test.build.SetHost(test.want.GetHost())
 		test.build.SetRuntime(test.want.GetRuntime())
 		test.build.SetDistribution(test.want.GetDistribution())
+		test.build.SetPusherName(test.want.GetPusherName())
+		test.build.SetPusherEmail(test.want.GetPusherEmail())
 
 		if test.build.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.build.GetID(), test.want.GetID())
@@ -690,6 +704,14 @@ func TestLibrary_Build_Setters(t *testing.T) {
 		if test.build.GetDistribution() != test.want.GetDistribution() {
 			t.Errorf("SetDistribution is %v, want %v", test.build.GetDistribution(), test.want.GetDistribution())
 		}
+
+		if test.build.GetPusherName() != test.want.GetPusherName() {
+			t.Errorf("GetPusherName is %v, want %v", test.build.GetPusherName(), test.want.GetPusherName())
+		}
+
+		if test.build.GetPusherEmail() != test.want.GetPusherEmail() {
+			t.Errorf("GetPusherEmail is %v, want %v", test.build.GetPusherEmail(), test.want.GetPusherEmail())
+		}
 	}
 }
 
@@ -719,6 +741,8 @@ func TestLibrary_Build_String(t *testing.T) {
   Message: %s,
   Number: %d,
   Parent: %d,
+  PusherName: %s,
+  PusherEmail: %s,
   Ref: %s,
   RepoID: %d,
   Runtime: %s,
@@ -749,6 +773,8 @@ func TestLibrary_Build_String(t *testing.T) {
 		b.GetMessage(),
 		b.GetNumber(),
 		b.GetParent(),
+		b.GetPusherName(),
+		b.GetPusherEmail(),
 		b.GetRef(),
 		b.GetRepoID(),
 		b.GetRuntime(),
@@ -801,6 +827,8 @@ func testBuild() *Build {
 	b.SetHost("example.company.com")
 	b.SetRuntime("docker")
 	b.SetDistribution("linux")
+	b.SetPusherName("OctoKitty2")
+	b.SetPusherEmail("OctoKitty2@github.com")
 
 	return b
 }


### PR DESCRIPTION
Currently, when a user drafts a release, the build author remains the person who last committed to the repository. We want to keep this, but we also want to know who tagged the release. Therefore, these additional fields in tandem with the server setting these values from GitHub will expose that information as environment variables. 