### PR TITLE
fix: annotate payload for swagger

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -27,6 +27,8 @@ const versionFormat = `{
 // Version represents application information that
 // follows semantic version guidelines from
 // https://semver.org/.
+//
+// swagger:model Version
 type Version struct {
 	// Canonical represents a canonical semantic version for the application.
 	Canonical string `json:"canonical"`


### PR DESCRIPTION
part of https://github.com/go-vela/community/issues/432

`Version` is a payload expected for the `<api-url>/version` endpoint.