### PR TITLE
chore(linter): remove magic number rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,7 +81,6 @@ linters:
     - gofmt
     - goimports
     - golint
-    - gomnd
     - goprintffuncname
     - gosec
     - gosimple # enabled by default
@@ -114,6 +113,7 @@ linters:
   # - gocritic
   # - godox
   # - goerr113
+  # - gomnd
   # - interfacer
   # - nestif
   # - noctx

--- a/pipeline/secret.go
+++ b/pipeline/secret.go
@@ -117,7 +117,6 @@ func (s *Secret) ParseOrg(org string) (string, string, error) {
 	parts := strings.SplitN(path, "/", 2)
 
 	// secret is invalid
-	// nolint:gomnd // accepting magic number
 	if len(parts) != 2 {
 		return "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}
@@ -147,7 +146,6 @@ func (s *Secret) ParseRepo(org, repo string) (string, string, string, error) {
 		parts := strings.SplitN(path, "/", 3)
 
 		// secret is invalid
-		// nolint:gomnd // accepting magic number
 		if len(parts) != 3 {
 			return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 		}
@@ -193,7 +191,6 @@ func (s *Secret) ParseShared() (string, string, string, error) {
 	parts := strings.SplitN(path, "/", 3)
 
 	// secret is invalid
-	// nolint:gomnd // accepting magic number
 	if len(parts) != 3 {
 		return "", "", "", fmt.Errorf("%s: %s ", ErrInvalidPath, path)
 	}

--- a/raw/map.go
+++ b/raw/map.go
@@ -52,9 +52,9 @@ func (s *StringSliceMap) UnmarshalJSON(b []byte) error {
 		// iterate through each element in the json slice
 		for _, v := range jsonSlice {
 			// split each slice element into key/value pairs
-			kvPair := strings.SplitN(v, "=", 2) // nolint:gomnd // accepting magic number
+			kvPair := strings.SplitN(v, "=", 2)
 
-			if len(kvPair) != 2 { // nolint:gomnd // accepting magic number
+			if len(kvPair) != 2 {
 				return errors.New("unable to unmarshal into StringSliceMap")
 			}
 
@@ -103,9 +103,9 @@ func (s *StringSliceMap) UnmarshalYAML(unmarshal func(interface{}) error) error 
 		// iterate through each element in the yaml slice
 		for _, v := range yamlSlice {
 			// split each slice element into key/value pairs
-			kvPair := strings.SplitN(v, "=", 2) // nolint:gomnd // accepting magic number
+			kvPair := strings.SplitN(v, "=", 2)
 
-			if len(kvPair) != 2 { // nolint:gomnd // accepting magic number
+			if len(kvPair) != 2 {
 				return errors.New("unable to unmarshal into StringSliceMap")
 			}
 

--- a/yaml/ulimit.go
+++ b/yaml/ulimit.go
@@ -59,7 +59,6 @@ func (u *UlimitSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		for _, ulimit := range *stringSlice {
 			// split each slice element into key/value pairs
 			parts := strings.Split(ulimit, "=")
-			// nolint:gomnd // accepting magic number
 			if len(parts) != 2 {
 				return fmt.Errorf("ulimit %s must contain 1 `=` (equal)", ulimit)
 			}
@@ -83,7 +82,7 @@ func (u *UlimitSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				})
 
 				continue
-			case len(limitParts) == 2: // nolint:gomnd // accepting magic number
+			case len(limitParts) == 2:
 				// capture value for soft limit
 				firstValue, err := strconv.ParseInt(limitParts[0], 10, 64)
 				if err != nil {

--- a/yaml/volume.go
+++ b/yaml/volume.go
@@ -69,7 +69,7 @@ func (v *VolumeSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				})
 
 				continue
-			case len(parts) == 2: // nolint:gomnd // accepting magic number
+			case len(parts) == 2:
 				// append the element to the volume slice
 				*v = append(*v, &Volume{
 					Source:      parts[0],
@@ -78,7 +78,7 @@ func (v *VolumeSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 				})
 
 				continue
-			case len(parts) == 3: // nolint:gomnd // accepting magic number
+			case len(parts) == 3:
 				// append the element to the volume slice
 				*v = append(*v, &Volume{
 					Source:      parts[0],


### PR DESCRIPTION
Made some changes to disable the magic number rule from the golangci linter. While working on attempting to address all the instances of the rule being broken, I noticed that there were several instances of the rule being manually disabled. I would love some feedback and conversation to make sure this would be a change worth making. Thanks!