### PR TITLE
refactor(version): consolidate version package from plugins

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/go-vela/types
 go 1.16
 
 require (
+	github.com/Masterminds/semver/v3 v3.1.1
 	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/drone/envsubst v1.0.3
 	github.com/ghodss/yaml v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/Masterminds/semver/v3 v3.1.1 h1:hLg3sBzpNErnxhQtUy/mmLR2I9foDujNK030IGemrRc=
+github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
 github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=

--- a/version/version.go
+++ b/version/version.go
@@ -6,6 +6,11 @@ package version
 
 import (
 	"fmt"
+	"runtime"
+
+	"github.com/Masterminds/semver/v3"
+
+	"github.com/sirupsen/logrus"
 )
 
 const versionFormat = `{
@@ -23,6 +28,23 @@ const versionFormat = `{
     OperatingSystem: %s,
   }
 }`
+
+var (
+	// Arch represents the architecture information for the package.
+	Arch = runtime.GOARCH
+	// Commit represents the git commit information for the package.
+	Commit string
+	// Compiler represents the compiler information for the package.
+	Compiler = runtime.Compiler
+	// Date represents the build date information for the package.
+	Date string
+	// Go represents the golang version information for the package.
+	Go = runtime.Version()
+	// OS represents the operating system information for the package.
+	OS = runtime.GOOS
+	// Tag represents the git tag information for the package.
+	Tag string
+)
 
 // Version represents application information that
 // follows semantic version guidelines from
@@ -70,4 +92,35 @@ func (v *Version) String() string {
 		v.Metadata.GoVersion,
 		v.Metadata.OperatingSystem,
 	)
+}
+
+func New() *Version {
+	// check if a semantic tag was provided
+	if len(Tag) == 0 {
+		logrus.Warningf("no semantic tag provided - defaulting to v0.0.0")
+
+		// set a fallback default for the tag
+		Tag = "v0.0.0"
+	}
+
+	v, err := semver.NewVersion(Tag)
+	if err != nil {
+		fmt.Println(fmt.Errorf("unable to parse semantic version for %s: %v", Tag, err))
+	}
+
+	return &Version{
+		Canonical:  Tag,
+		Major:      v.Major(),
+		Minor:      v.Minor(),
+		Patch:      v.Patch(),
+		PreRelease: v.Prerelease(),
+		Metadata: Metadata{
+			Architecture:    Arch,
+			BuildDate:       Date,
+			Compiler:        Compiler,
+			GitCommit:       Commit,
+			GoVersion:       Go,
+			OperatingSystem: OS,
+		},
+	}
 }


### PR DESCRIPTION
Moving this information into the `types` package will allow us to use this across [all of the different Vela plugins that use this file](https://github.com/search?q=org%3Ago-vela+filename%3Aversion.go). I have an example of this working in a plugin I'm writing internally at the moment and have dropped a link in the Slack channel. The biggest change is really just that the compile time flags look like this now
```sh
LD_FLAGS = -X github.com/go-vela/types/version.Commit=${GITHUB_SHA} -X github.com/go-vela/types/version.Date=${BUILD_DATE} -X github.com/go-vela/types/version.Go=${GOLANG_VERSION} -X github.com/go-vela/types/version.Tag=${GITHUB_TAG}

```