### PR TITLE
feat(secrets): adding logging mask constant 

### DIFF
--- a/constants/secret.go
+++ b/constants/secret.go
@@ -17,4 +17,7 @@ const (
 
 	// SecretMask defines the secret mask to be used in place of secret values returned to users.
 	SecretMask = "[secure]"
+
+	// SecretLogMask defines the secret mask to be used when distributing logs that contain secrets.
+	SecretLogMask = "***"
 )


### PR DESCRIPTION
[Related Issue](https://github.com/go-vela/community/issues/136)

Jenkins and Drone both manage to mask secrets in their logs using the mask `***`. I understand there may be concern of redundancy with the `SecretMask` constant, so I'm open to discussion on whether we should use that instead. However, it may be nice to have that consistency with other CI/CD platforms.

Usage in [this PR](https://github.com/go-vela/worker/pull/254)