### PR TITLE
feat(library): add Duration() function to resources

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -7,6 +7,7 @@ package library
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/raw"
@@ -45,6 +46,28 @@ type Build struct {
 	Host          *string             `json:"host,omitempty"`
 	Runtime       *string             `json:"runtime,omitempty"`
 	Distribution  *string             `json:"distribution,omitempty"`
+}
+
+// Duration calculates and returns the total amount of
+// time the build ran for in a human-readable format.
+func (b *Build) Duration() string {
+	// capture finished unix timestamp from the build
+	finished := time.Unix(b.GetFinished(), 0)
+	// capture started unix timestamp from the build
+	started := time.Unix(b.GetStarted(), 0)
+
+	// check if the build doesn't have a started or finished timestamp
+	if b.GetStarted() == 0 || b.GetFinished() == 0 {
+		// return zero value for time.Duration (0s)
+		return new(time.Duration).String()
+	}
+
+	// calculate the duration by subtracting the build
+	// started time from the build finished time
+	duration := finished.Sub(started)
+
+	// return duration in a human-readable form
+	return duration.String()
 }
 
 // Environment returns a list of environment variables

--- a/library/build.go
+++ b/library/build.go
@@ -51,17 +51,16 @@ type Build struct {
 // Duration calculates and returns the total amount of
 // time the build ran for in a human-readable format.
 func (b *Build) Duration() string {
-	// capture finished unix timestamp from the build
-	finished := time.Unix(b.GetFinished(), 0)
-	// capture started unix timestamp from the build
-	started := time.Unix(b.GetStarted(), 0)
-
 	// check if the build doesn't have a started or finished timestamp
 	if b.GetStarted() == 0 || b.GetFinished() == 0 {
 		// return zero value for time.Duration (0s)
 		return new(time.Duration).String()
 	}
 
+	// capture finished unix timestamp from the build
+	finished := time.Unix(b.GetFinished(), 0)
+	// capture started unix timestamp from the build
+	started := time.Unix(b.GetStarted(), 0)
 	// calculate the duration by subtracting the build
 	// started time from the build finished time
 	duration := finished.Sub(started)

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -12,6 +12,32 @@ import (
 	"github.com/go-vela/types/raw"
 )
 
+func TestLibrary_Build_Duration(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		build *Build
+		want  string
+	}{
+		{
+			build: testBuild(),
+			want:  "1s",
+		},
+		{
+			build: new(Build),
+			want:  "0s",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.build.Duration()
+
+		if got != test.want {
+			t.Errorf("Duration is %v, want %v", got, test.want)
+		}
+	}
+}
+
 func TestLibrary_Build_Environment(t *testing.T) {
 	// setup types
 	_comment := testBuild()

--- a/library/service.go
+++ b/library/service.go
@@ -36,17 +36,16 @@ type Service struct {
 // Duration calculates and returns the total amount of
 // time the service ran for in a human-readable format.
 func (s *Service) Duration() string {
-	// capture finished unix timestamp from the service
-	finished := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from the service
-	started := time.Unix(s.GetStarted(), 0)
-
 	// check if the service doesn't have a started or finished timestamp
 	if s.GetStarted() == 0 || s.GetFinished() == 0 {
 		// return zero value for time.Duration (0s)
 		return new(time.Duration).String()
 	}
 
+	// capture finished unix timestamp from the service
+	finished := time.Unix(s.GetFinished(), 0)
+	// capture started unix timestamp from the service
+	started := time.Unix(s.GetStarted(), 0)
 	// calculate the duration by subtracting the service
 	// started time from the service finished time
 	duration := finished.Sub(started)

--- a/library/service.go
+++ b/library/service.go
@@ -7,6 +7,7 @@ package library
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/go-vela/types/pipeline"
 )
@@ -30,6 +31,28 @@ type Service struct {
 	Host         *string `json:"host,omitempty"`
 	Runtime      *string `json:"runtime,omitempty"`
 	Distribution *string `json:"distribution,omitempty"`
+}
+
+// Duration calculates and returns the total amount of
+// time the service ran for in a human-readable format.
+func (s *Service) Duration() string {
+	// capture finished unix timestamp from the service
+	finished := time.Unix(s.GetFinished(), 0)
+	// capture started unix timestamp from the service
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the service doesn't have a started or finished timestamp
+	if s.GetStarted() == 0 || s.GetFinished() == 0 {
+		// return zero value for time.Duration (0s)
+		return new(time.Duration).String()
+	}
+
+	// calculate the duration by subtracting the service
+	// started time from the service finished time
+	duration := finished.Sub(started)
+
+	// return duration in a human-readable form
+	return duration.String()
 }
 
 // Environment returns a list of environment variables

--- a/library/service_test.go
+++ b/library/service_test.go
@@ -12,6 +12,32 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+func TestLibrary_Service_Duration(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		service *Service
+		want    string
+	}{
+		{
+			service: testService(),
+			want:    "1s",
+		},
+		{
+			service: new(Service),
+			want:    "0s",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.service.Duration()
+
+		if got != test.want {
+			t.Errorf("Duration is %v, want %v", got, test.want)
+		}
+	}
+}
+
 func TestLibrary_Service_Environment(t *testing.T) {
 	// setup types
 	want := map[string]string{
@@ -289,6 +315,7 @@ func TestLibrary_ServiceFromContainer(t *testing.T) {
 					"VELA_SERVICE_CREATED":      "1563474076",
 					"VELA_SERVICE_DISTRIBUTION": "linux",
 					"VELA_SERVICE_EXIT_CODE":    "0",
+					"VELA_SERVICE_FINISHED":     "1563474079",
 					"VELA_SERVICE_HOST":         "example.company.com",
 					"VELA_SERVICE_IMAGE":        "postgres:12-alpine",
 					"VELA_SERVICE_NAME":         "postgres",
@@ -327,6 +354,7 @@ func testService() *Service {
 	s.SetExitCode(0)
 	s.SetCreated(1563474076)
 	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
 	s.SetHost("example.company.com")
 	s.SetRuntime("docker")
 	s.SetDistribution("linux")

--- a/library/step.go
+++ b/library/step.go
@@ -38,7 +38,7 @@ type Step struct {
 // Duration calculates and returns the total amount of
 // time the step ran for in a human-readable format.
 func (s *Step) Duration() string {
-	// check if the service doesn't have a started or finished timestamp
+	// check if the step doesn't have a started or finished timestamp
 	if s.GetStarted() == 0 || s.GetFinished() == 0 {
 		// return zero value for time.Duration (0s)
 		return new(time.Duration).String()

--- a/library/step.go
+++ b/library/step.go
@@ -38,17 +38,16 @@ type Step struct {
 // Duration calculates and returns the total amount of
 // time the step ran for in a human-readable format.
 func (s *Step) Duration() string {
-	// capture finished unix timestamp from the step
-	finished := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from the step
-	started := time.Unix(s.GetStarted(), 0)
-
 	// check if the service doesn't have a started or finished timestamp
 	if s.GetStarted() == 0 || s.GetFinished() == 0 {
 		// return zero value for time.Duration (0s)
 		return new(time.Duration).String()
 	}
 
+	// capture finished unix timestamp from the step
+	finished := time.Unix(s.GetFinished(), 0)
+	// capture started unix timestamp from the step
+	started := time.Unix(s.GetStarted(), 0)
 	// calculate the duration by subtracting the step
 	// started time from the step finished time
 	duration := finished.Sub(started)

--- a/library/step.go
+++ b/library/step.go
@@ -7,6 +7,7 @@ package library
 import (
 	"fmt"
 	"strconv"
+	"time"
 
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/pipeline"
@@ -32,6 +33,28 @@ type Step struct {
 	Host         *string `json:"host,omitempty"`
 	Runtime      *string `json:"runtime,omitempty"`
 	Distribution *string `json:"distribution,omitempty"`
+}
+
+// Duration calculates and returns the total amount of
+// time the step ran for in a human-readable format.
+func (s *Step) Duration() string {
+	// capture finished unix timestamp from the step
+	finished := time.Unix(s.GetFinished(), 0)
+	// capture started unix timestamp from the step
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the service doesn't have a started or finished timestamp
+	if s.GetStarted() == 0 || s.GetFinished() == 0 {
+		// return zero value for time.Duration (0s)
+		return new(time.Duration).String()
+	}
+
+	// calculate the duration by subtracting the step
+	// started time from the step finished time
+	duration := finished.Sub(started)
+
+	// return duration in a human-readable form
+	return duration.String()
 }
 
 // Environment returns a list of environment variables

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -12,6 +12,32 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+func TestLibrary_Step_Duration(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		step *Step
+		want string
+	}{
+		{
+			step: testStep(),
+			want: "1s",
+		},
+		{
+			step: new(Step),
+			want: "0s",
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := test.step.Duration()
+
+		if got != test.want {
+			t.Errorf("Duration is %v, want %v", got, test.want)
+		}
+	}
+}
+
 func TestLibrary_Step_Environment(t *testing.T) {
 	// setup types
 	want := map[string]string{
@@ -381,6 +407,7 @@ func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
 					"VELA_STEP_CREATED":      "1563474076",
 					"VELA_STEP_DISTRIBUTION": "linux",
 					"VELA_STEP_EXIT_CODE":    "0",
+					"VELA_STEP_FINISHED":     "1563474079",
 					"VELA_STEP_HOST":         "example.company.com",
 					"VELA_STEP_IMAGE":        "target/vela-git:v0.3.0",
 					"VELA_STEP_NAME":         "clone",
@@ -420,6 +447,7 @@ func testStep() *Step {
 	s.SetExitCode(0)
 	s.SetCreated(1563474076)
 	s.SetStarted(1563474078)
+	s.SetFinished(1563474079)
 	s.SetHost("example.company.com")
 	s.SetRuntime("docker")
 	s.SetDistribution("linux")


### PR DESCRIPTION
Currently, we have logic to calculate the duration (amount of time a resource was running) for various resources.

The following resources have this functionality:

* [build](https://github.com/go-vela/cli/blob/master/action/build/table.go#L135-L158)
* [service](https://github.com/go-vela/cli/blob/master/action/service/table.go#L131-L154)
* [step](https://github.com/go-vela/cli/blob/master/action/step/table.go#L131-L154)

This change introduces a `Duration()` method on each of these resources that will replace the above linked functions:

https://github.com/go-vela/types/blob/16db0dbc3136fa4a3731b2dcc6c8f32271d3f5d2/library/build.go#L51-L70

https://github.com/go-vela/types/blob/16db0dbc3136fa4a3731b2dcc6c8f32271d3f5d2/library/service.go#L36-L55

https://github.com/go-vela/types/blob/16db0dbc3136fa4a3731b2dcc6c8f32271d3f5d2/library/step.go#L38-L57