### PR TITLE
chore/fix(log): moving secret masking to log type

### DIFF
--- a/library/log.go
+++ b/library/log.go
@@ -7,7 +7,6 @@ package library
 import (
 	"fmt"
 	"regexp"
-	"strings"
 
 	"github.com/go-vela/types/constants"
 )
@@ -46,41 +45,29 @@ func (l *Log) AppendData(data []byte) {
 // all values provided in the string slice. If the
 // log is empty, we do nothing.
 func (l *Log) MaskData(secrets []string) {
-	// convert data to string
-	strData := string(l.GetData())
+	data := l.GetData()
 	for _, secret := range secrets {
 		// escape regexp meta characters if they exist within value of secret
-		sanitizedStr := regexp.QuoteMeta(secret)
+		//
+		// https://pkg.go.dev/regexp#QuoteMeta
+		escaped := regexp.QuoteMeta(secret)
 
-		// find matches in logs for secrets surrounded by whitespace, start of string,
-		// quotation, colon, period, comma, and end of string.
-		// this prevents partial masking of secrets that contain a substring of another
-		// secret.
-		re := regexp.MustCompile((`(\s|^|"|:|'|\.|,)` + sanitizedStr + `(\s|$|"|:|'|\.|,)`))
-		matches := re.FindAllString(strData, -1)
+		// create regexp to match secrets in the log data surrounded by regexp metacharacters
+		//
+		// https://pkg.go.dev/regexp#MustCompile
+		re := regexp.MustCompile((`(\s|^|"|:|'|\.|,)` + escaped + `(\s|$|"|:|'|\.|,)`))
 
-		// take all matches and mask them
-		for _, match := range matches {
-			// construct mask
-			mask := ""
+		// create a mask for the secret
+		mask := fmt.Sprintf("$1%s$2", constants.SecretLogMask)
 
-			// if secret was logged as the very first or last thing in the log, don't add
-			// boundary mask values.
-			if match[0] != secret[0] {
-				mask += string(match[0])
-			}
-			mask += constants.SecretLogMask
-			if match[len(match)-1] != secret[len(secret)-1] {
-				mask += string(match[len(match)-1])
-			}
-
-			// replace log with new mask
-			strData = strings.Replace(strData, match, mask, 1)
-		}
+		// replace all regexp matches of secret with mask
+		//
+		// https://pkg.go.dev/regexp#Regexp.ReplaceAll
+		data = re.ReplaceAll(data, []byte(mask))
 	}
 
 	// update data field to masked logs
-	l.SetData([]byte(strData))
+	l.SetData(data)
 }
 
 // GetID returns the ID field.

--- a/library/log.go
+++ b/library/log.go
@@ -49,8 +49,7 @@ func (l *Log) MaskData(secrets []string) {
 	// convert data to string
 	strData := string(l.GetData())
 	for _, secret := range secrets {
-		sanitize := regexp.MustCompile(`[-[\]{}()*+?.,\\^$|#\s]`)
-		secret = sanitize.ReplaceAllString(secret, "\\$0")
+		secret = regexp.QuoteMeta(secret)
 		re := regexp.MustCompile((`(\s|^|"|:|'|\.|,)` + secret + `(\s|$|"|:|'|\.|,)`))
 		matches := re.FindAllString(strData, -1)
 		for _, match := range matches {

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -42,6 +42,55 @@ func TestLibrary_Log_AppendData(t *testing.T) {
 	}
 }
 
+func TestLibrary_Log_MaskData(t *testing.T) {
+	// set up test secrets
+	sVals := []string{"secret", "((%.YY245***pP.><@@}}", "littlesecret", "extrasecret"}
+
+	// set up test logs
+	s1 := "$ echo $NO_SECRET\nnosecret\n"
+	s2 := "$ echo $SECRET\n((%.YY245***pP.><@@}}\n"
+	s2Masked := "$ echo $SECRET\n***\n"
+	s3 := "$ echo $SECRET1\n((%.YY245***pP.><@@}}\n$ echo $SECRET2\nlittlesecret\n"
+	s3Masked := "$ echo $SECRET1\n***\n$ echo $SECRET2\n***\n"
+
+	tests := []struct {
+		want    []byte
+		log     []byte
+		secrets []string
+	}{
+		{ // no secrets in log
+			want:    []byte(s1),
+			log:     []byte(s1),
+			secrets: sVals,
+		},
+		{ // one secret in log
+			want:    []byte(s2Masked),
+			log:     []byte(s2),
+			secrets: sVals,
+		},
+		{ // multiple secrets in log
+			want:    []byte(s3Masked),
+			log:     []byte(s3),
+			secrets: sVals,
+		},
+		{ // empty secrets slice
+			want:    []byte(s3),
+			log:     []byte(s3),
+			secrets: []string{},
+		},
+	}
+	// run tests
+	l := testLog()
+	for _, test := range tests {
+		l.SetData(test.log)
+		l.MaskData(test.secrets)
+		got := l.GetData()
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("maskSecrets is %v, want %v", string(got), string(test.want))
+		}
+	}
+}
+
 func TestLibrary_Log_Getters(t *testing.T) {
 	// setup tests
 	tests := []struct {

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -48,8 +48,8 @@ func TestLibrary_Log_MaskData(t *testing.T) {
 
 	// set up test logs
 	s1 := "$ echo $NO_SECRET\nnosecret\n"
-	s2 := "$ echo $SECRET\n((%.YY245***pP.><@@}}\n"
-	s2Masked := "$ echo $SECRET\n***\n"
+	s2 := "((%.YY245***pP.><@@}}"
+	s2Masked := "***"
 	s3 := "$ echo $SECRET1\n((%.YY245***pP.><@@}}\n$ echo $SECRET2\nlittlesecret\n"
 	s3Masked := "$ echo $SECRET1\n***\n$ echo $SECRET2\n***\n"
 
@@ -86,7 +86,7 @@ func TestLibrary_Log_MaskData(t *testing.T) {
 		l.MaskData(test.secrets)
 		got := l.GetData()
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("maskSecrets is %v, want %v", string(got), string(test.want))
+			t.Errorf("MaskData is %v, want %v", string(got), string(test.want))
 		}
 	}
 }


### PR DESCRIPTION
Moving the secret masking from the worker to be a method within `library.Log`. Also made it much more robust with its pattern matching with some go-regexp fun stuff.