### PR TITLE
feat(library): add ServiceFromBuildContainer()

### DIFF
--- a/library/service.go
+++ b/library/service.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/go-vela/types/constants"
+
 	"github.com/go-vela/types/pipeline"
 )
 
@@ -498,11 +500,38 @@ func (s *Service) String() string {
 	)
 }
 
-// ServiceFromContainer converts the pipeline
-// Container type to a library Service type.
+// ServiceFromBuildContainer creates a new Service based on a Build and pipeline Container.
+func ServiceFromBuildContainer(build *Build, ctn *pipeline.Container) *Service {
+	// create new service type we want to return
+	s := new(Service)
+
+	// default status to Pending
+	s.SetStatus(constants.StatusPending)
+
+	// copy fields from build
+	if build != nil {
+		// set values from the build
+		s.SetHost(build.GetHost())
+		s.SetRuntime(build.GetRuntime())
+		s.SetDistribution(build.GetDistribution())
+	}
+
+	// copy fields from container
+	if ctn != nil && ctn.Name != "" {
+		// set values from the container
+		s.SetName(ctn.Name)
+		s.SetNumber(ctn.Number)
+		s.SetImage(ctn.Image)
+	}
+
+	return s
+}
+
+// ServiceFromContainerEnvironment converts the pipeline Container
+// to a library Service using the container's Environment.
 //
 // nolint: funlen // ignore function length due to comments and conditionals
-func ServiceFromContainer(ctn *pipeline.Container) *Service {
+func ServiceFromContainerEnvironment(ctn *pipeline.Container) *Service {
 	// check if container or container environment are nil
 	if ctn == nil || ctn.Environment == nil {
 		return nil

--- a/library/service.go
+++ b/library/service.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/go-vela/types/constants"
-
 	"github.com/go-vela/types/pipeline"
 )
 

--- a/library/service_test.go
+++ b/library/service_test.go
@@ -286,30 +286,109 @@ func TestLibrary_Service_String(t *testing.T) {
 	}
 }
 
-func TestLibrary_ServiceFromContainer(t *testing.T) {
+func TestLibrary_ServiceFromBuildContainer(t *testing.T) {
+	// setup types
+	s := testService()
+	s.SetStatus("pending")
+
+	// modify fields that aren't set
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+	s.ExitCode = nil
+	s.Created = nil
+	s.Started = nil
+	s.Finished = nil
+
+	tests := []struct {
+		name      string
+		container *pipeline.Container
+		build     *Build
+		want      *Service
+	}{
+		{
+			name:      "nil container with nil build",
+			container: nil,
+			build:     nil,
+			want:      &Service{Status: s.Status},
+		},
+		{
+			name:      "empty container with nil build",
+			container: new(pipeline.Container),
+			build:     nil,
+			want:      &Service{Status: s.Status},
+		},
+		{
+			name:      "nil container with build",
+			container: nil,
+			build:     testBuild(),
+			want: &Service{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name:      "empty container with build",
+			container: new(pipeline.Container),
+			build:     testBuild(),
+			want: &Service{
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
+			},
+		},
+		{
+			name: "container with build",
+			container: &pipeline.Container{
+				Name:   s.GetName(),
+				Number: s.GetNumber(),
+				Image:  s.GetImage(),
+			},
+			build: testBuild(),
+			want:  s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := ServiceFromBuildContainer(test.build, test.container)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("ServiceFromBuildContainer for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+func TestLibrary_ServiceFromContainerEnvironment(t *testing.T) {
 	// setup types
 	s := testService()
 
-	// modify fields that aren't set
-	// via environment variables
+	// modify fields that aren't set via environment variables
 	s.ID = nil
 	s.BuildID = nil
 	s.RepoID = nil
 
 	// setup tests
 	tests := []struct {
+		name      string
 		container *pipeline.Container
 		want      *Service
 	}{
 		{
+			name:      "nil container",
 			container: nil,
 			want:      nil,
 		},
 		{
+			name:      "empty container",
 			container: new(pipeline.Container),
 			want:      nil,
 		},
 		{
+			name: "container",
 			container: &pipeline.Container{
 				Environment: map[string]string{
 					"VELA_SERVICE_CREATED":      "1563474076",
@@ -331,10 +410,10 @@ func TestLibrary_ServiceFromContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		got := ServiceFromContainer(test.container)
+		got := ServiceFromContainerEnvironment(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("ServiceFromContainer is %v, want %v", got, test.want)
+			t.Errorf("ServiceFromContainerEnvironment for %s is %v, want %v", test.name, got, test.want)
 		}
 	}
 }

--- a/library/step.go
+++ b/library/step.go
@@ -528,8 +528,7 @@ func (s *Step) String() string {
 	)
 }
 
-// StepFromBuildContainer creates new Step type based on
-// a Build and one of its Containers.
+// StepFromBuildContainer creates a new Step based on a Build and pipeline Container.
 func StepFromBuildContainer(build *Build, ctn *pipeline.Container) *Step {
 	// create new step type we want to return
 	s := new(Step)
@@ -559,11 +558,12 @@ func StepFromBuildContainer(build *Build, ctn *pipeline.Container) *Step {
 			s.SetStage(value)
 		}
 	}
+
 	return s
 }
 
-// StepFromContainerEnvironment converts the pipeline
-// Container type to a library Step type using the container's Environment.
+// StepFromContainerEnvironment converts the pipeline Container
+// to a library Step using the container's Environment.
 //
 // nolint: funlen // ignore function length due to comments and conditionals
 func StepFromContainerEnvironment(ctn *pipeline.Container) *Step {

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -298,66 +298,67 @@ func TestLibrary_Step_String(t *testing.T) {
 	}
 }
 
-func TestLibrary_Step_StepFromBuildContainer(t *testing.T) {
-	// some strings used in the tests (not const, as we need the address)
-	defaultStatus := "pending"
-	exampleHost := "example.company.com"
-	exampleRuntime := "docker"
-	exampleDistribution := "linux"
-
+func TestLibrary_StepFromBuildContainer(t *testing.T) {
 	// setup types
-	s := new(Step)
-
-	// add dummy values for values managed by StepFromContainer
-	s.SetName("clone")
-	s.SetNumber(1)
-	s.SetImage("target/vela-git:v0.3.0")
+	s := testStep()
 	s.SetStage("clone")
-	s.SetHost(exampleHost)
-	s.SetRuntime(exampleRuntime)
-	s.SetDistribution(exampleDistribution)
-	s.SetStatus(defaultStatus)
+	s.SetStatus("pending")
+
+	// modify fields that aren't set
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+	s.ExitCode = nil
+	s.Created = nil
+	s.Started = nil
+	s.Finished = nil
 
 	tests := []struct {
+		name      string
 		container *pipeline.Container
 		build     *Build
 		want      *Step
 	}{
 		{
+			name:      "nil container with nil build",
 			container: nil,
 			build:     nil,
-			want:      &Step{Status: &defaultStatus},
+			want:      &Step{Status: s.Status},
 		},
 		{
+			name:      "empty container with nil build",
 			container: new(pipeline.Container),
 			build:     nil,
-			want:      &Step{Status: &defaultStatus},
+			want:      &Step{Status: s.Status},
 		},
 		{
+			name:      "nil container with build",
 			container: nil,
 			build:     testBuild(),
 			want: &Step{
-				Status:       &defaultStatus,
-				Host:         &exampleHost,
-				Runtime:      &exampleRuntime,
-				Distribution: &exampleDistribution,
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
 			},
 		},
 		{
+			name:      "empty container with build",
 			container: new(pipeline.Container),
 			build:     testBuild(),
 			want: &Step{
-				Status:       &defaultStatus,
-				Host:         &exampleHost,
-				Runtime:      &exampleRuntime,
-				Distribution: &exampleDistribution,
+				Status:       s.Status,
+				Host:         s.Host,
+				Runtime:      s.Runtime,
+				Distribution: s.Distribution,
 			},
 		},
 		{
+			name: "container with build",
 			container: &pipeline.Container{
-				Name:   "clone",
-				Number: 1,
-				Image:  "target/vela-git:v0.3.0",
+				Name:   s.GetName(),
+				Number: s.GetNumber(),
+				Image:  s.GetImage(),
 				Environment: map[string]string{
 					"VELA_STEP_STAGE": "clone",
 				},
@@ -369,10 +370,10 @@ func TestLibrary_Step_StepFromBuildContainer(t *testing.T) {
 
 	// run tests
 	for _, test := range tests {
-		step := StepFromBuildContainer(test.build, test.container)
+		got := StepFromBuildContainer(test.build, test.container)
 
-		if !reflect.DeepEqual(step, test.want) {
-			t.Errorf("Step.StepFromBuildContainer made %v, want %v", step, test.want)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("StepFromBuildContainer for %s is %v, want %v", test.name, got, test.want)
 		}
 	}
 }
@@ -380,28 +381,31 @@ func TestLibrary_Step_StepFromBuildContainer(t *testing.T) {
 func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
 	// setup types
 	s := testStep()
+	s.SetStage("clone")
 
-	// modify fields that aren't set
-	// via environment variables
+	// modify fields that aren't set via environment variables
 	s.ID = nil
 	s.BuildID = nil
 	s.RepoID = nil
-	s.SetStage("clone")
 
 	// setup tests
 	tests := []struct {
+		name      string
 		container *pipeline.Container
 		want      *Step
 	}{
 		{
+			name:      "nil container",
 			container: nil,
 			want:      nil,
 		},
 		{
+			name:      "empty container",
 			container: new(pipeline.Container),
 			want:      nil,
 		},
 		{
+			name: "container",
 			container: &pipeline.Container{
 				Environment: map[string]string{
 					"VELA_STEP_CREATED":      "1563474076",
@@ -427,7 +431,7 @@ func TestLibrary_StepFromContainerEnvironment(t *testing.T) {
 		got := StepFromContainerEnvironment(test.container)
 
 		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("StepFromContainerEnvironment is %v, want %v", got, test.want)
+			t.Errorf("StepFromContainerEnvironment for %s is %v, want %v", test.name, got, test.want)
 		}
 	}
 }


### PR DESCRIPTION
Essentially a copy of https://github.com/go-vela/types/pull/205

This adds a `ServiceFromBuildContainer()` function to the `github.com/go-vela/types/library` package:

https://github.com/go-vela/types/blob/240fd4a9d453bc9a377e33447144dfb6602ab31a/library/service.go#L503-L528

Similar to `StepFromBuildContainer()`, that was added in the above PR, this will be used in the [go-vela/worker](https://github.com/go-vela/worker) codebase.

Also, following along with the above PR, `ServiceFromContainer` was renamed to `ServiceFromContainerEnvironment`.