### PR TITLE
enhance(library): update Duration() return values

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -53,6 +53,7 @@ type Build struct {
 func (b *Build) Duration() string {
 	// check if the build doesn't have a started timestamp
 	if b.GetStarted() == 0 {
+		// nolint: goconst // ignore making a constant
 		return "..."
 	}
 

--- a/library/build.go
+++ b/library/build.go
@@ -51,21 +51,30 @@ type Build struct {
 // Duration calculates and returns the total amount of
 // time the build ran for in a human-readable format.
 func (b *Build) Duration() string {
-	// check if the build doesn't have a started or finished timestamp
-	if b.GetStarted() == 0 || b.GetFinished() == 0 {
-		// return zero value for time.Duration (0s)
-		return new(time.Duration).String()
+	// check if the build doesn't have a started timestamp
+	if b.GetStarted() == 0 {
+		return "..."
+	}
+
+	// capture started unix timestamp from the build
+	started := time.Unix(b.GetStarted(), 0)
+
+	// check if the build doesn't have a finished timestamp
+	if b.GetFinished() == 0 {
+		// return the duration in a human-readable form by
+		// subtracting the build started time from the
+		// current time rounded to the nearest second
+		return time.Since(started).Round(time.Second).String()
 	}
 
 	// capture finished unix timestamp from the build
 	finished := time.Unix(b.GetFinished(), 0)
-	// capture started unix timestamp from the build
-	started := time.Unix(b.GetStarted(), 0)
+
 	// calculate the duration by subtracting the build
 	// started time from the build finished time
 	duration := finished.Sub(started)
 
-	// return duration in a human-readable form
+	// return the duration in a human-readable form
 	return duration.String()
 }
 

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -8,11 +8,16 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-vela/types/raw"
 )
 
 func TestLibrary_Build_Duration(t *testing.T) {
+	// setup types
+	unfinished := testBuild()
+	unfinished.SetFinished(0)
+
 	// setup tests
 	tests := []struct {
 		build *Build
@@ -23,8 +28,12 @@ func TestLibrary_Build_Duration(t *testing.T) {
 			want:  "1s",
 		},
 		{
+			build: unfinished,
+			want:  time.Since(time.Unix(unfinished.GetStarted(), 0)).Round(time.Second).String(),
+		},
+		{
 			build: new(Build),
-			want:  "0s",
+			want:  "...",
 		},
 	}
 

--- a/library/service.go
+++ b/library/service.go
@@ -36,21 +36,30 @@ type Service struct {
 // Duration calculates and returns the total amount of
 // time the service ran for in a human-readable format.
 func (s *Service) Duration() string {
-	// check if the service doesn't have a started or finished timestamp
-	if s.GetStarted() == 0 || s.GetFinished() == 0 {
-		// return zero value for time.Duration (0s)
-		return new(time.Duration).String()
+	// check if the service doesn't have a started timestamp
+	if s.GetStarted() == 0 {
+		return "..."
+	}
+
+	// capture started unix timestamp from the service
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the service doesn't have a finished timestamp
+	if s.GetFinished() == 0 {
+		// return the duration in a human-readable form by
+		// subtracting the service started time from the
+		// current time rounded to the nearest second
+		return time.Since(started).Round(time.Second).String()
 	}
 
 	// capture finished unix timestamp from the service
 	finished := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from the service
-	started := time.Unix(s.GetStarted(), 0)
+
 	// calculate the duration by subtracting the service
 	// started time from the service finished time
 	duration := finished.Sub(started)
 
-	// return duration in a human-readable form
+	// return the duration in a human-readable form
 	return duration.String()
 }
 

--- a/library/service.go
+++ b/library/service.go
@@ -38,7 +38,6 @@ type Service struct {
 func (s *Service) Duration() string {
 	// check if the service doesn't have a started timestamp
 	if s.GetStarted() == 0 {
-		// nolint: goconst // ignore making a constant
 		return "..."
 	}
 

--- a/library/service.go
+++ b/library/service.go
@@ -38,6 +38,7 @@ type Service struct {
 func (s *Service) Duration() string {
 	// check if the service doesn't have a started timestamp
 	if s.GetStarted() == 0 {
+		// nolint: goconst // ignore making a constant
 		return "..."
 	}
 

--- a/library/service_test.go
+++ b/library/service_test.go
@@ -8,11 +8,16 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-vela/types/pipeline"
 )
 
 func TestLibrary_Service_Duration(t *testing.T) {
+	// setup types
+	unfinished := testService()
+	unfinished.SetFinished(0)
+
 	// setup tests
 	tests := []struct {
 		service *Service
@@ -23,8 +28,12 @@ func TestLibrary_Service_Duration(t *testing.T) {
 			want:    "1s",
 		},
 		{
+			service: unfinished,
+			want:    time.Since(time.Unix(unfinished.GetStarted(), 0)).Round(time.Second).String(),
+		},
+		{
 			service: new(Service),
-			want:    "0s",
+			want:    "...",
 		},
 	}
 

--- a/library/step.go
+++ b/library/step.go
@@ -38,21 +38,30 @@ type Step struct {
 // Duration calculates and returns the total amount of
 // time the step ran for in a human-readable format.
 func (s *Step) Duration() string {
-	// check if the step doesn't have a started or finished timestamp
-	if s.GetStarted() == 0 || s.GetFinished() == 0 {
-		// return zero value for time.Duration (0s)
-		return new(time.Duration).String()
+	// check if the step doesn't have a started timestamp
+	if s.GetStarted() == 0 {
+		return "..."
+	}
+
+	// capture started unix timestamp from the step
+	started := time.Unix(s.GetStarted(), 0)
+
+	// check if the step doesn't have a finished timestamp
+	if s.GetFinished() == 0 {
+		// return the duration in a human-readable form by
+		// subtracting the step started time from the
+		// current time rounded to the nearest second
+		return time.Since(started).Round(time.Second).String()
 	}
 
 	// capture finished unix timestamp from the step
 	finished := time.Unix(s.GetFinished(), 0)
-	// capture started unix timestamp from the step
-	started := time.Unix(s.GetStarted(), 0)
+
 	// calculate the duration by subtracting the step
 	// started time from the step finished time
 	duration := finished.Sub(started)
 
-	// return duration in a human-readable form
+	// return the duration in a human-readable form
 	return duration.String()
 }
 

--- a/library/step.go
+++ b/library/step.go
@@ -40,7 +40,6 @@ type Step struct {
 func (s *Step) Duration() string {
 	// check if the step doesn't have a started timestamp
 	if s.GetStarted() == 0 {
-		// nolint: goconst // ignore making a constant
 		return "..."
 	}
 

--- a/library/step.go
+++ b/library/step.go
@@ -40,6 +40,7 @@ type Step struct {
 func (s *Step) Duration() string {
 	// check if the step doesn't have a started timestamp
 	if s.GetStarted() == 0 {
+		// nolint: goconst // ignore making a constant
 		return "..."
 	}
 

--- a/library/step_test.go
+++ b/library/step_test.go
@@ -8,11 +8,16 @@ import (
 	"fmt"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-vela/types/pipeline"
 )
 
 func TestLibrary_Step_Duration(t *testing.T) {
+	// setup types
+	unfinished := testStep()
+	unfinished.SetFinished(0)
+
 	// setup tests
 	tests := []struct {
 		step *Step
@@ -23,8 +28,12 @@ func TestLibrary_Step_Duration(t *testing.T) {
 			want: "1s",
 		},
 		{
+			step: unfinished,
+			want: time.Since(time.Unix(unfinished.GetStarted(), 0)).Round(time.Second).String(),
+		},
+		{
 			step: new(Step),
-			want: "0s",
+			want: "...",
 		},
 	}
 


### PR DESCRIPTION
Based off feedback from https://github.com/go-vela/types/pull/222#issuecomment-1003031343

This updates the value returned from `Duration()` for resources in the `github.com/go-vela/types/library` package.

The following resources have this function:

* [build](https://github.com/go-vela/types/blob/c491e96440a50566b68980de606748ec7c469acd/library/build.go#L51-L70)
* [service](https://github.com/go-vela/types/blob/c491e96440a50566b68980de606748ec7c469acd/library/service.go#L36-L55)
* [step](https://github.com/go-vela/types/blob/c491e96440a50566b68980de606748ec7c469acd/library/step.go#L38-L57)

Previously, we were returning `0s` if the `started` or `finished` timestamps weren't set for the resource.

Now, If a resource doesn't have a `started` timestamp, then an indeterminate value of `...` is returned.

Otherwise, if a resource doesn't have a `finished` timestamp, then the time since the `started` timestamp is returned.

Otherwise, we return the `finished` timestamp subtracted by the `started` timestamp.