### PR TITLE
enhance(repo): pr event customization

### DIFF
--- a/database/repo.go
+++ b/database/repo.go
@@ -40,29 +40,30 @@ var (
 
 // Repo is the database representation of a repo.
 type Repo struct {
-	ID           sql.NullInt64  `sql:"id"`
-	UserID       sql.NullInt64  `sql:"user_id"`
-	Hash         sql.NullString `sql:"hash"`
-	Org          sql.NullString `sql:"org"`
-	Name         sql.NullString `sql:"name"`
-	FullName     sql.NullString `sql:"full_name"`
-	Link         sql.NullString `sql:"link"`
-	Clone        sql.NullString `sql:"clone"`
-	Branch       sql.NullString `sql:"branch"`
-	BuildLimit   sql.NullInt64  `sql:"build_limit"`
-	Timeout      sql.NullInt64  `sql:"timeout"`
-	Counter      sql.NullInt32  `sql:"counter"`
-	Visibility   sql.NullString `sql:"visibility"`
-	Private      sql.NullBool   `sql:"private"`
-	Trusted      sql.NullBool   `sql:"trusted"`
-	Active       sql.NullBool   `sql:"active"`
-	AllowPull    sql.NullBool   `sql:"allow_pull"`
-	AllowPush    sql.NullBool   `sql:"allow_push"`
-	AllowDeploy  sql.NullBool   `sql:"allow_deploy"`
-	AllowTag     sql.NullBool   `sql:"allow_tag"`
-	AllowComment sql.NullBool   `sql:"allow_comment"`
-	PipelineType sql.NullString `sql:"pipeline_type"`
-	PreviousName sql.NullString `sql:"previous_name"`
+	ID            sql.NullInt64  `sql:"id"`
+	UserID        sql.NullInt64  `sql:"user_id"`
+	Hash          sql.NullString `sql:"hash"`
+	Org           sql.NullString `sql:"org"`
+	Name          sql.NullString `sql:"name"`
+	FullName      sql.NullString `sql:"full_name"`
+	Link          sql.NullString `sql:"link"`
+	Clone         sql.NullString `sql:"clone"`
+	Branch        sql.NullString `sql:"branch"`
+	BuildLimit    sql.NullInt64  `sql:"build_limit"`
+	Timeout       sql.NullInt64  `sql:"timeout"`
+	Counter       sql.NullInt32  `sql:"counter"`
+	Visibility    sql.NullString `sql:"visibility"`
+	Private       sql.NullBool   `sql:"private"`
+	Trusted       sql.NullBool   `sql:"trusted"`
+	Active        sql.NullBool   `sql:"active"`
+	AllowPull     sql.NullBool   `sql:"allow_pull"`
+	AllowPullEdit sql.NullBool   `sql:"allow_pull_edit"`
+	AllowPush     sql.NullBool   `sql:"allow_push"`
+	AllowDeploy   sql.NullBool   `sql:"allow_deploy"`
+	AllowTag      sql.NullBool   `sql:"allow_tag"`
+	AllowComment  sql.NullBool   `sql:"allow_comment"`
+	PipelineType  sql.NullString `sql:"pipeline_type"`
+	PreviousName  sql.NullString `sql:"previous_name"`
 }
 
 // Decrypt will manipulate the existing repo hash by
@@ -218,6 +219,7 @@ func (r *Repo) ToLibrary() *library.Repo {
 	repo.SetTrusted(r.Trusted.Bool)
 	repo.SetActive(r.Active.Bool)
 	repo.SetAllowPull(r.AllowPull.Bool)
+	repo.SetAllowPullEdit(r.AllowPullEdit.Bool)
 	repo.SetAllowPush(r.AllowPush.Bool)
 	repo.SetAllowDeploy(r.AllowDeploy.Bool)
 	repo.SetAllowTag(r.AllowTag.Bool)
@@ -281,29 +283,30 @@ func (r *Repo) Validate() error {
 // to a database repo type.
 func RepoFromLibrary(r *library.Repo) *Repo {
 	repo := &Repo{
-		ID:           sql.NullInt64{Int64: r.GetID(), Valid: true},
-		UserID:       sql.NullInt64{Int64: r.GetUserID(), Valid: true},
-		Hash:         sql.NullString{String: r.GetHash(), Valid: true},
-		Org:          sql.NullString{String: r.GetOrg(), Valid: true},
-		Name:         sql.NullString{String: r.GetName(), Valid: true},
-		FullName:     sql.NullString{String: r.GetFullName(), Valid: true},
-		Link:         sql.NullString{String: r.GetLink(), Valid: true},
-		Clone:        sql.NullString{String: r.GetClone(), Valid: true},
-		Branch:       sql.NullString{String: r.GetBranch(), Valid: true},
-		BuildLimit:   sql.NullInt64{Int64: r.GetBuildLimit(), Valid: true},
-		Timeout:      sql.NullInt64{Int64: r.GetTimeout(), Valid: true},
-		Counter:      sql.NullInt32{Int32: int32(r.GetCounter()), Valid: true},
-		Visibility:   sql.NullString{String: r.GetVisibility(), Valid: true},
-		Private:      sql.NullBool{Bool: r.GetPrivate(), Valid: true},
-		Trusted:      sql.NullBool{Bool: r.GetTrusted(), Valid: true},
-		Active:       sql.NullBool{Bool: r.GetActive(), Valid: true},
-		AllowPull:    sql.NullBool{Bool: r.GetAllowPull(), Valid: true},
-		AllowPush:    sql.NullBool{Bool: r.GetAllowPush(), Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: r.GetAllowDeploy(), Valid: true},
-		AllowTag:     sql.NullBool{Bool: r.GetAllowTag(), Valid: true},
-		AllowComment: sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
-		PipelineType: sql.NullString{String: r.GetPipelineType(), Valid: true},
-		PreviousName: sql.NullString{String: r.GetPreviousName(), Valid: true},
+		ID:            sql.NullInt64{Int64: r.GetID(), Valid: true},
+		UserID:        sql.NullInt64{Int64: r.GetUserID(), Valid: true},
+		Hash:          sql.NullString{String: r.GetHash(), Valid: true},
+		Org:           sql.NullString{String: r.GetOrg(), Valid: true},
+		Name:          sql.NullString{String: r.GetName(), Valid: true},
+		FullName:      sql.NullString{String: r.GetFullName(), Valid: true},
+		Link:          sql.NullString{String: r.GetLink(), Valid: true},
+		Clone:         sql.NullString{String: r.GetClone(), Valid: true},
+		Branch:        sql.NullString{String: r.GetBranch(), Valid: true},
+		BuildLimit:    sql.NullInt64{Int64: r.GetBuildLimit(), Valid: true},
+		Timeout:       sql.NullInt64{Int64: r.GetTimeout(), Valid: true},
+		Counter:       sql.NullInt32{Int32: int32(r.GetCounter()), Valid: true},
+		Visibility:    sql.NullString{String: r.GetVisibility(), Valid: true},
+		Private:       sql.NullBool{Bool: r.GetPrivate(), Valid: true},
+		Trusted:       sql.NullBool{Bool: r.GetTrusted(), Valid: true},
+		Active:        sql.NullBool{Bool: r.GetActive(), Valid: true},
+		AllowPull:     sql.NullBool{Bool: r.GetAllowPull(), Valid: true},
+		AllowPullEdit: sql.NullBool{Bool: r.GetAllowPullEdit(), Valid: true},
+		AllowPush:     sql.NullBool{Bool: r.GetAllowPush(), Valid: true},
+		AllowDeploy:   sql.NullBool{Bool: r.GetAllowDeploy(), Valid: true},
+		AllowTag:      sql.NullBool{Bool: r.GetAllowTag(), Valid: true},
+		AllowComment:  sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
+		PipelineType:  sql.NullString{String: r.GetPipelineType(), Valid: true},
+		PreviousName:  sql.NullString{String: r.GetPreviousName(), Valid: true},
 	}
 
 	return repo.Nullify()

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -172,6 +172,7 @@ func TestDatabase_Repo_ToLibrary(t *testing.T) {
 	want.SetTrusted(false)
 	want.SetActive(true)
 	want.SetAllowPull(false)
+	want.SetAllowPullEdit(false)
 	want.SetAllowPush(true)
 	want.SetAllowDeploy(false)
 	want.SetAllowTag(false)
@@ -304,6 +305,7 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 	r.SetTrusted(false)
 	r.SetActive(true)
 	r.SetAllowPull(false)
+	r.SetAllowPullEdit(false)
 	r.SetAllowPush(true)
 	r.SetAllowDeploy(false)
 	r.SetAllowTag(false)
@@ -325,28 +327,29 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 // type with all fields set to a fake value.
 func testRepo() *Repo {
 	return &Repo{
-		ID:           sql.NullInt64{Int64: 1, Valid: true},
-		UserID:       sql.NullInt64{Int64: 1, Valid: true},
-		Hash:         sql.NullString{String: "superSecretHash", Valid: true},
-		Org:          sql.NullString{String: "github", Valid: true},
-		Name:         sql.NullString{String: "octocat", Valid: true},
-		FullName:     sql.NullString{String: "github/octocat", Valid: true},
-		Link:         sql.NullString{String: "https://github.com/github/octocat", Valid: true},
-		Clone:        sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
-		Branch:       sql.NullString{String: "master", Valid: true},
-		BuildLimit:   sql.NullInt64{Int64: 10, Valid: true},
-		Timeout:      sql.NullInt64{Int64: 30, Valid: true},
-		Counter:      sql.NullInt32{Int32: 0, Valid: true},
-		Visibility:   sql.NullString{String: "public", Valid: true},
-		Private:      sql.NullBool{Bool: false, Valid: true},
-		Trusted:      sql.NullBool{Bool: false, Valid: true},
-		Active:       sql.NullBool{Bool: true, Valid: true},
-		AllowPull:    sql.NullBool{Bool: false, Valid: true},
-		AllowPush:    sql.NullBool{Bool: true, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
-		AllowTag:     sql.NullBool{Bool: false, Valid: true},
-		AllowComment: sql.NullBool{Bool: false, Valid: true},
-		PipelineType: sql.NullString{String: "yaml", Valid: true},
-		PreviousName: sql.NullString{String: "oldName", Valid: true},
+		ID:            sql.NullInt64{Int64: 1, Valid: true},
+		UserID:        sql.NullInt64{Int64: 1, Valid: true},
+		Hash:          sql.NullString{String: "superSecretHash", Valid: true},
+		Org:           sql.NullString{String: "github", Valid: true},
+		Name:          sql.NullString{String: "octocat", Valid: true},
+		FullName:      sql.NullString{String: "github/octocat", Valid: true},
+		Link:          sql.NullString{String: "https://github.com/github/octocat", Valid: true},
+		Clone:         sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
+		Branch:        sql.NullString{String: "master", Valid: true},
+		BuildLimit:    sql.NullInt64{Int64: 10, Valid: true},
+		Timeout:       sql.NullInt64{Int64: 30, Valid: true},
+		Counter:       sql.NullInt32{Int32: 0, Valid: true},
+		Visibility:    sql.NullString{String: "public", Valid: true},
+		Private:       sql.NullBool{Bool: false, Valid: true},
+		Trusted:       sql.NullBool{Bool: false, Valid: true},
+		Active:        sql.NullBool{Bool: true, Valid: true},
+		AllowPull:     sql.NullBool{Bool: false, Valid: true},
+		AllowPullEdit: sql.NullBool{Bool: false, Valid: true},
+		AllowPush:     sql.NullBool{Bool: true, Valid: true},
+		AllowDeploy:   sql.NullBool{Bool: false, Valid: true},
+		AllowTag:      sql.NullBool{Bool: false, Valid: true},
+		AllowComment:  sql.NullBool{Bool: false, Valid: true},
+		PipelineType:  sql.NullString{String: "yaml", Valid: true},
+		PreviousName:  sql.NullString{String: "oldName", Valid: true},
 	}
 }

--- a/library/repo.go
+++ b/library/repo.go
@@ -12,53 +12,55 @@ import (
 //
 // swagger:model Repo
 type Repo struct {
-	ID           *int64  `json:"id,omitempty"`
-	UserID       *int64  `json:"user_id,omitempty"`
-	Hash         *string `json:"-"`
-	Org          *string `json:"org,omitempty"`
-	Name         *string `json:"name,omitempty"`
-	FullName     *string `json:"full_name,omitempty"`
-	Link         *string `json:"link,omitempty"`
-	Clone        *string `json:"clone,omitempty"`
-	Branch       *string `json:"branch,omitempty"`
-	BuildLimit   *int64  `json:"build_limit,omitempty"`
-	Timeout      *int64  `json:"timeout,omitempty"`
-	Counter      *int    `json:"counter,omitempty"`
-	Visibility   *string `json:"visibility,omitempty"`
-	Private      *bool   `json:"private,omitempty"`
-	Trusted      *bool   `json:"trusted,omitempty"`
-	Active       *bool   `json:"active,omitempty"`
-	AllowPull    *bool   `json:"allow_pull,omitempty"`
-	AllowPush    *bool   `json:"allow_push,omitempty"`
-	AllowDeploy  *bool   `json:"allow_deploy,omitempty"`
-	AllowTag     *bool   `json:"allow_tag,omitempty"`
-	AllowComment *bool   `json:"allow_comment,omitempty"`
-	PipelineType *string `json:"pipeline_type,omitempty"`
-	PreviousName *string `json:"previous_name,omitempty"`
+	ID            *int64  `json:"id,omitempty"`
+	UserID        *int64  `json:"user_id,omitempty"`
+	Hash          *string `json:"-"`
+	Org           *string `json:"org,omitempty"`
+	Name          *string `json:"name,omitempty"`
+	FullName      *string `json:"full_name,omitempty"`
+	Link          *string `json:"link,omitempty"`
+	Clone         *string `json:"clone,omitempty"`
+	Branch        *string `json:"branch,omitempty"`
+	BuildLimit    *int64  `json:"build_limit,omitempty"`
+	Timeout       *int64  `json:"timeout,omitempty"`
+	Counter       *int    `json:"counter,omitempty"`
+	Visibility    *string `json:"visibility,omitempty"`
+	Private       *bool   `json:"private,omitempty"`
+	Trusted       *bool   `json:"trusted,omitempty"`
+	Active        *bool   `json:"active,omitempty"`
+	AllowPull     *bool   `json:"allow_pull,omitempty"`
+	AllowPullEdit *bool   `json:"allow_pull_edit,omitempty"`
+	AllowPush     *bool   `json:"allow_push,omitempty"`
+	AllowDeploy   *bool   `json:"allow_deploy,omitempty"`
+	AllowTag      *bool   `json:"allow_tag,omitempty"`
+	AllowComment  *bool   `json:"allow_comment,omitempty"`
+	PipelineType  *string `json:"pipeline_type,omitempty"`
+	PreviousName  *string `json:"previous_name,omitempty"`
 }
 
 // Environment returns a list of environment variables
 // provided from the fields of the Repo type.
 func (r *Repo) Environment() map[string]string {
 	return map[string]string{
-		"VELA_REPO_ACTIVE":        ToString(r.GetActive()),
-		"VELA_REPO_ALLOW_COMMENT": ToString(r.GetAllowComment()),
-		"VELA_REPO_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
-		"VELA_REPO_ALLOW_PULL":    ToString(r.GetAllowPull()),
-		"VELA_REPO_ALLOW_PUSH":    ToString(r.GetAllowPush()),
-		"VELA_REPO_ALLOW_TAG":     ToString(r.GetAllowTag()),
-		"VELA_REPO_BRANCH":        ToString(r.GetBranch()),
-		"VELA_REPO_BUILD_LIMIT":   ToString(r.GetBuildLimit()),
-		"VELA_REPO_CLONE":         ToString(r.GetClone()),
-		"VELA_REPO_FULL_NAME":     ToString(r.GetFullName()),
-		"VELA_REPO_LINK":          ToString(r.GetLink()),
-		"VELA_REPO_NAME":          ToString(r.GetName()),
-		"VELA_REPO_ORG":           ToString(r.GetOrg()),
-		"VELA_REPO_PRIVATE":       ToString(r.GetPrivate()),
-		"VELA_REPO_TIMEOUT":       ToString(r.GetTimeout()),
-		"VELA_REPO_TRUSTED":       ToString(r.GetTrusted()),
-		"VELA_REPO_VISIBILITY":    ToString(r.GetVisibility()),
-		"VELA_REPO_PIPELINE_TYPE": ToString(r.GetPipelineType()),
+		"VELA_REPO_ACTIVE":          ToString(r.GetActive()),
+		"VELA_REPO_ALLOW_COMMENT":   ToString(r.GetAllowComment()),
+		"VELA_REPO_ALLOW_DEPLOY":    ToString(r.GetAllowDeploy()),
+		"VELA_REPO_ALLOW_PULL":      ToString(r.GetAllowPull()),
+		"VELA_REPO_ALLOW_PULL_EDIT": ToString(r.GetAllowPullEdit()),
+		"VELA_REPO_ALLOW_PUSH":      ToString(r.GetAllowPush()),
+		"VELA_REPO_ALLOW_TAG":       ToString(r.GetAllowTag()),
+		"VELA_REPO_BRANCH":          ToString(r.GetBranch()),
+		"VELA_REPO_BUILD_LIMIT":     ToString(r.GetBuildLimit()),
+		"VELA_REPO_CLONE":           ToString(r.GetClone()),
+		"VELA_REPO_FULL_NAME":       ToString(r.GetFullName()),
+		"VELA_REPO_LINK":            ToString(r.GetLink()),
+		"VELA_REPO_NAME":            ToString(r.GetName()),
+		"VELA_REPO_ORG":             ToString(r.GetOrg()),
+		"VELA_REPO_PRIVATE":         ToString(r.GetPrivate()),
+		"VELA_REPO_TIMEOUT":         ToString(r.GetTimeout()),
+		"VELA_REPO_TRUSTED":         ToString(r.GetTrusted()),
+		"VELA_REPO_VISIBILITY":      ToString(r.GetVisibility()),
+		"VELA_REPO_PIPELINE_TYPE":   ToString(r.GetPipelineType()),
 
 		// deprecated environment variables
 		"REPOSITORY_ACTIVE":        ToString(r.GetActive()),
@@ -299,6 +301,19 @@ func (r *Repo) GetAllowPull() bool {
 	}
 
 	return *r.AllowPull
+}
+
+// GetAllowPullEdit returns the AllowPullEdit field.
+//
+// When the provided Repo type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (r *Repo) GetAllowPullEdit() bool {
+	// return zero value if Repo type or AllowPullEdit field is nil
+	if r == nil || r.AllowPullEdit == nil {
+		return false
+	}
+
+	return *r.AllowPullEdit
 }
 
 // GetAllowPush returns the AllowPush field.
@@ -600,6 +615,19 @@ func (r *Repo) SetAllowPull(v bool) {
 	r.AllowPull = &v
 }
 
+// SetAllowPullEdit sets the AllowPullEdit field.
+//
+// When the provided Repo type is nil, it
+// will set nothing and immediately return.
+func (r *Repo) SetAllowPullEdit(v bool) {
+	// return if Repo type is nil
+	if r == nil {
+		return
+	}
+
+	r.AllowPullEdit = &v
+}
+
 // SetAllowPush sets the AllowPush field.
 //
 // When the provided Repo type is nil, it
@@ -685,6 +713,7 @@ func (r *Repo) String() string {
   AllowComment: %t,
   AllowDeploy: %t,
   AllowPull: %t,
+  AllowPullEdit: %t,
   AllowPush: %t,
   AllowTag: %t,
   Branch: %s,
@@ -708,6 +737,7 @@ func (r *Repo) String() string {
 		r.GetAllowComment(),
 		r.GetAllowDeploy(),
 		r.GetAllowPull(),
+		r.GetAllowPullEdit(),
 		r.GetAllowPush(),
 		r.GetAllowTag(),
 		r.GetBranch(),

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -13,40 +13,41 @@ import (
 func TestLibrary_Repo_Environment(t *testing.T) {
 	// setup types
 	want := map[string]string{
-		"VELA_REPO_ACTIVE":         "true",
-		"VELA_REPO_ALLOW_COMMENT":  "false",
-		"VELA_REPO_ALLOW_DEPLOY":   "false",
-		"VELA_REPO_ALLOW_PULL":     "false",
-		"VELA_REPO_ALLOW_PUSH":     "true",
-		"VELA_REPO_ALLOW_TAG":      "false",
-		"VELA_REPO_BRANCH":         "master",
-		"VELA_REPO_BUILD_LIMIT":    "10",
-		"VELA_REPO_CLONE":          "https://github.com/github/octocat.git",
-		"VELA_REPO_FULL_NAME":      "github/octocat",
-		"VELA_REPO_LINK":           "https://github.com/github/octocat",
-		"VELA_REPO_NAME":           "octocat",
-		"VELA_REPO_ORG":            "github",
-		"VELA_REPO_PRIVATE":        "false",
-		"VELA_REPO_TIMEOUT":        "30",
-		"VELA_REPO_TRUSTED":        "false",
-		"VELA_REPO_VISIBILITY":     "public",
-		"VELA_REPO_PIPELINE_TYPE":  "",
-		"REPOSITORY_ACTIVE":        "true",
-		"REPOSITORY_ALLOW_COMMENT": "false",
-		"REPOSITORY_ALLOW_DEPLOY":  "false",
-		"REPOSITORY_ALLOW_PULL":    "false",
-		"REPOSITORY_ALLOW_PUSH":    "true",
-		"REPOSITORY_ALLOW_TAG":     "false",
-		"REPOSITORY_BRANCH":        "master",
-		"REPOSITORY_CLONE":         "https://github.com/github/octocat.git",
-		"REPOSITORY_FULL_NAME":     "github/octocat",
-		"REPOSITORY_LINK":          "https://github.com/github/octocat",
-		"REPOSITORY_NAME":          "octocat",
-		"REPOSITORY_ORG":           "github",
-		"REPOSITORY_PRIVATE":       "false",
-		"REPOSITORY_TIMEOUT":       "30",
-		"REPOSITORY_TRUSTED":       "false",
-		"REPOSITORY_VISIBILITY":    "public",
+		"VELA_REPO_ACTIVE":          "true",
+		"VELA_REPO_ALLOW_COMMENT":   "false",
+		"VELA_REPO_ALLOW_DEPLOY":    "false",
+		"VELA_REPO_ALLOW_PULL":      "false",
+		"VELA_REPO_ALLOW_PULL_EDIT": "false",
+		"VELA_REPO_ALLOW_PUSH":      "true",
+		"VELA_REPO_ALLOW_TAG":       "false",
+		"VELA_REPO_BRANCH":          "master",
+		"VELA_REPO_BUILD_LIMIT":     "10",
+		"VELA_REPO_CLONE":           "https://github.com/github/octocat.git",
+		"VELA_REPO_FULL_NAME":       "github/octocat",
+		"VELA_REPO_LINK":            "https://github.com/github/octocat",
+		"VELA_REPO_NAME":            "octocat",
+		"VELA_REPO_ORG":             "github",
+		"VELA_REPO_PRIVATE":         "false",
+		"VELA_REPO_TIMEOUT":         "30",
+		"VELA_REPO_TRUSTED":         "false",
+		"VELA_REPO_VISIBILITY":      "public",
+		"VELA_REPO_PIPELINE_TYPE":   "",
+		"REPOSITORY_ACTIVE":         "true",
+		"REPOSITORY_ALLOW_COMMENT":  "false",
+		"REPOSITORY_ALLOW_DEPLOY":   "false",
+		"REPOSITORY_ALLOW_PULL":     "false",
+		"REPOSITORY_ALLOW_PUSH":     "true",
+		"REPOSITORY_ALLOW_TAG":      "false",
+		"REPOSITORY_BRANCH":         "master",
+		"REPOSITORY_CLONE":          "https://github.com/github/octocat.git",
+		"REPOSITORY_FULL_NAME":      "github/octocat",
+		"REPOSITORY_LINK":           "https://github.com/github/octocat",
+		"REPOSITORY_NAME":           "octocat",
+		"REPOSITORY_ORG":            "github",
+		"REPOSITORY_PRIVATE":        "false",
+		"REPOSITORY_TIMEOUT":        "30",
+		"REPOSITORY_TRUSTED":        "false",
+		"REPOSITORY_VISIBILITY":     "public",
 	}
 
 	// run test
@@ -137,6 +138,10 @@ func TestLibrary_Repo_Getters(t *testing.T) {
 
 		if test.repo.GetAllowPull() != test.want.GetAllowPull() {
 			t.Errorf("GetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
+		}
+
+		if test.repo.GetAllowPullEdit() != test.want.GetAllowPullEdit() {
+			t.Errorf("GetAllowPullEdit is %v, want %v", test.repo.GetAllowPullEdit(), test.want.GetAllowPullEdit())
 		}
 
 		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
@@ -274,6 +279,10 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 			t.Errorf("SetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
 		}
 
+		if test.repo.GetAllowPullEdit() != test.want.GetAllowPullEdit() {
+			t.Errorf("SetAllowPullEdit is %v, want %v", test.repo.GetAllowPullEdit(), test.want.GetAllowPullEdit())
+		}
+
 		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
 			t.Errorf("SetAllowPush is %v, want %v", test.repo.GetAllowPush(), test.want.GetAllowPush())
 		}
@@ -309,6 +318,7 @@ func TestLibrary_Repo_String(t *testing.T) {
   AllowComment: %t,
   AllowDeploy: %t,
   AllowPull: %t,
+  AllowPullEdit: %t,
   AllowPush: %t,
   AllowTag: %t,
   Branch: %s,
@@ -332,6 +342,7 @@ func TestLibrary_Repo_String(t *testing.T) {
 		r.GetAllowComment(),
 		r.GetAllowDeploy(),
 		r.GetAllowPull(),
+		r.GetAllowPullEdit(),
 		r.GetAllowPush(),
 		r.GetAllowTag(),
 		r.GetBranch(),
@@ -380,6 +391,7 @@ func testRepo() *Repo {
 	r.SetTrusted(false)
 	r.SetActive(true)
 	r.SetAllowPull(false)
+	r.SetAllowPullEdit(false)
 	r.SetAllowPush(true)
 	r.SetAllowDeploy(false)
 	r.SetAllowTag(false)


### PR DESCRIPTION
Part of the effort to address [issue 159](https://github.com/go-vela/community/issues/159).

After reading through this issue as well as some of its comments, I arrived at the idea of giving users the option to customize their PR events using 4 consequential subevents: `opened`, `synchronize`, `edited`, and `approved`*.

The way I envision this getting implemented is replacing `AllowPull` with:
```
AllowPullOpen // for PRs being opened
AllowPullEdit // for PR base branch edits as well as title edits
AllowPullSync // for pushed commits to PR
AllowPullApprove // for PR approvals
```

I wanted to start with just `AllowPullEdit` and keep `AllowPull` unchanged to get a temperature check on the overall idea as well as the naming. Would love to hear your thoughts!

* Note: `approved` is actually a `state` of the `submitted` action under the `pull_request_review` event, but for our purposes, I figured we could lump it in as a `pull_request` event and handle the complications server-side.