### PR TITLE
feat(hook): add hook id to hook object

### DIFF
--- a/database/hook.go
+++ b/database/hook.go
@@ -23,6 +23,10 @@ var (
 	// ErrEmptyHookSourceID defines the error type when a
 	// Hook type has an empty SourceID field provided.
 	ErrEmptyHookSourceID = errors.New("empty webhook source_id provided")
+
+	// ErrEmptyHookAddress defines the error type when a
+	// Hook type has an empty Address field provided.
+	ErrEmptyHookAddress = errors.New("empty webhook address provided")
 )
 
 // Hook is the database representation of a webhook for a repo.
@@ -39,6 +43,7 @@ type Hook struct {
 	Error    sql.NullString `sql:"error"`
 	Status   sql.NullString `sql:"status"`
 	Link     sql.NullString `sql:"link"`
+	Address  sql.NullInt64  `sql:"address"`
 }
 
 // Nullify ensures the valid flag for
@@ -112,6 +117,11 @@ func (h *Hook) Nullify() *Hook {
 		h.Link.Valid = false
 	}
 
+	// check if the Address field should be false
+	if h.Address.Int64 == 0 {
+		h.Address.Valid = false
+	}
+
 	return h
 }
 
@@ -132,6 +142,7 @@ func (h *Hook) ToLibrary() *library.Hook {
 	hook.SetError(h.Error.String)
 	hook.SetStatus(h.Status.String)
 	hook.SetLink(h.Link.String)
+	hook.SetAddress(h.Address.Int64)
 
 	return hook
 }
@@ -152,6 +163,11 @@ func (h *Hook) Validate() error {
 	// verify the SourceID field is populated
 	if len(h.SourceID.String) <= 0 {
 		return ErrEmptyHookSourceID
+	}
+
+	// verify the Address field is populated
+	if h.Address.Int64 <= 0 {
+		return ErrEmptyHookAddress
 	}
 
 	// ensure that all Hook string fields
@@ -184,6 +200,7 @@ func HookFromLibrary(h *library.Hook) *Hook {
 		Error:    sql.NullString{String: h.GetError(), Valid: true},
 		Status:   sql.NullString{String: h.GetStatus(), Valid: true},
 		Link:     sql.NullString{String: h.GetLink(), Valid: true},
+		Address:  sql.NullInt64{Int64: h.GetAddress(), Valid: true},
 	}
 
 	return hook.Nullify()

--- a/database/hook.go
+++ b/database/hook.go
@@ -24,26 +24,26 @@ var (
 	// Hook type has an empty SourceID field provided.
 	ErrEmptyHookSourceID = errors.New("empty webhook source_id provided")
 
-	// ErrEmptyHookAddress defines the error type when a
-	// Hook type has an empty Address field provided.
-	ErrEmptyHookAddress = errors.New("empty webhook address provided")
+	// ErrEmptyHookWebhookID defines the error type when a
+	// Hook type has an empty WebhookID field provided.
+	ErrEmptyHookWebhookID = errors.New("empty webhook webhook_id provided")
 )
 
 // Hook is the database representation of a webhook for a repo.
 type Hook struct {
-	ID       sql.NullInt64  `sql:"id"`
-	RepoID   sql.NullInt64  `sql:"repo_id"`
-	BuildID  sql.NullInt64  `sql:"build_id"`
-	Number   sql.NullInt32  `sql:"number"`
-	SourceID sql.NullString `sql:"source_id"`
-	Created  sql.NullInt64  `sql:"created"`
-	Host     sql.NullString `sql:"host"`
-	Event    sql.NullString `sql:"event"`
-	Branch   sql.NullString `sql:"branch"`
-	Error    sql.NullString `sql:"error"`
-	Status   sql.NullString `sql:"status"`
-	Link     sql.NullString `sql:"link"`
-	Address  sql.NullInt64  `sql:"address"`
+	ID        sql.NullInt64  `sql:"id"`
+	RepoID    sql.NullInt64  `sql:"repo_id"`
+	BuildID   sql.NullInt64  `sql:"build_id"`
+	Number    sql.NullInt32  `sql:"number"`
+	SourceID  sql.NullString `sql:"source_id"`
+	Created   sql.NullInt64  `sql:"created"`
+	Host      sql.NullString `sql:"host"`
+	Event     sql.NullString `sql:"event"`
+	Branch    sql.NullString `sql:"branch"`
+	Error     sql.NullString `sql:"error"`
+	Status    sql.NullString `sql:"status"`
+	Link      sql.NullString `sql:"link"`
+	WebhookID sql.NullInt64  `sql:"webhook_id"`
 }
 
 // Nullify ensures the valid flag for
@@ -117,9 +117,9 @@ func (h *Hook) Nullify() *Hook {
 		h.Link.Valid = false
 	}
 
-	// check if the Address field should be false
-	if h.Address.Int64 == 0 {
-		h.Address.Valid = false
+	// check if the WebhookID field should be false
+	if h.WebhookID.Int64 == 0 {
+		h.WebhookID.Valid = false
 	}
 
 	return h
@@ -142,7 +142,7 @@ func (h *Hook) ToLibrary() *library.Hook {
 	hook.SetError(h.Error.String)
 	hook.SetStatus(h.Status.String)
 	hook.SetLink(h.Link.String)
-	hook.SetAddress(h.Address.Int64)
+	hook.SetWebhookID(h.WebhookID.Int64)
 
 	return hook
 }
@@ -165,9 +165,9 @@ func (h *Hook) Validate() error {
 		return ErrEmptyHookSourceID
 	}
 
-	// verify the Address field is populated
-	if h.Address.Int64 <= 0 {
-		return ErrEmptyHookAddress
+	// verify the WebhookID field is populated
+	if h.WebhookID.Int64 <= 0 {
+		return ErrEmptyHookWebhookID
 	}
 
 	// ensure that all Hook string fields
@@ -188,19 +188,19 @@ func (h *Hook) Validate() error {
 // to a library Hook type.
 func HookFromLibrary(h *library.Hook) *Hook {
 	hook := &Hook{
-		ID:       sql.NullInt64{Int64: h.GetID(), Valid: true},
-		RepoID:   sql.NullInt64{Int64: h.GetRepoID(), Valid: true},
-		BuildID:  sql.NullInt64{Int64: h.GetBuildID(), Valid: true},
-		Number:   sql.NullInt32{Int32: int32(h.GetNumber()), Valid: true},
-		SourceID: sql.NullString{String: h.GetSourceID(), Valid: true},
-		Created:  sql.NullInt64{Int64: h.GetCreated(), Valid: true},
-		Host:     sql.NullString{String: h.GetHost(), Valid: true},
-		Event:    sql.NullString{String: h.GetEvent(), Valid: true},
-		Branch:   sql.NullString{String: h.GetBranch(), Valid: true},
-		Error:    sql.NullString{String: h.GetError(), Valid: true},
-		Status:   sql.NullString{String: h.GetStatus(), Valid: true},
-		Link:     sql.NullString{String: h.GetLink(), Valid: true},
-		Address:  sql.NullInt64{Int64: h.GetAddress(), Valid: true},
+		ID:        sql.NullInt64{Int64: h.GetID(), Valid: true},
+		RepoID:    sql.NullInt64{Int64: h.GetRepoID(), Valid: true},
+		BuildID:   sql.NullInt64{Int64: h.GetBuildID(), Valid: true},
+		Number:    sql.NullInt32{Int32: int32(h.GetNumber()), Valid: true},
+		SourceID:  sql.NullString{String: h.GetSourceID(), Valid: true},
+		Created:   sql.NullInt64{Int64: h.GetCreated(), Valid: true},
+		Host:      sql.NullString{String: h.GetHost(), Valid: true},
+		Event:     sql.NullString{String: h.GetEvent(), Valid: true},
+		Branch:    sql.NullString{String: h.GetBranch(), Valid: true},
+		Error:     sql.NullString{String: h.GetError(), Valid: true},
+		Status:    sql.NullString{String: h.GetStatus(), Valid: true},
+		Link:      sql.NullString{String: h.GetLink(), Valid: true},
+		WebhookID: sql.NullInt64{Int64: h.GetWebhookID(), Valid: true},
 	}
 
 	return hook.Nullify()

--- a/database/hook_test.go
+++ b/database/hook_test.go
@@ -30,6 +30,7 @@ func TestDatabase_Hook_Nullify(t *testing.T) {
 		Error:    sql.NullString{String: "", Valid: false},
 		Status:   sql.NullString{String: "", Valid: false},
 		Link:     sql.NullString{String: "", Valid: false},
+		Address:  sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -76,6 +77,7 @@ func TestDatabase_Hook_ToLibrary(t *testing.T) {
 	want.SetError("")
 	want.SetStatus("success")
 	want.SetLink("https://github.com/github/octocat/settings/hooks/1")
+	want.SetAddress(123456)
 
 	h := &Hook{
 		ID:       sql.NullInt64{Int64: 1, Valid: true},
@@ -90,6 +92,7 @@ func TestDatabase_Hook_ToLibrary(t *testing.T) {
 		Error:    sql.NullString{String: "", Valid: true},
 		Status:   sql.NullString{String: "success", Valid: true},
 		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		Address:  sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	// run test
@@ -116,6 +119,7 @@ func TestDatabase_Hook_Validate(t *testing.T) {
 				ID:       sql.NullInt64{Int64: 1, Valid: true},
 				RepoID:   sql.NullInt64{Int64: 1, Valid: true},
 				SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+				Address:  sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
 		{ // no repo_id set for hook
@@ -124,14 +128,25 @@ func TestDatabase_Hook_Validate(t *testing.T) {
 				ID:       sql.NullInt64{Int64: 1, Valid: true},
 				Number:   sql.NullInt32{Int32: 1, Valid: true},
 				SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+				Address:  sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
 		{ // no source_id set for hook
 			failure: true,
 			hook: &Hook{
-				ID:     sql.NullInt64{Int64: 1, Valid: true},
-				Number: sql.NullInt32{Int32: 1, Valid: true},
-				RepoID: sql.NullInt64{Int64: 1, Valid: true},
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				Number:  sql.NullInt32{Int32: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				Address: sql.NullInt64{Int64: 1, Valid: true},
+			},
+		},
+		{ // no address set for hook
+			failure: true,
+			hook: &Hook{
+				ID:       sql.NullInt64{Int64: 1, Valid: true},
+				Number:   sql.NullInt32{Int32: 1, Valid: true},
+				RepoID:   sql.NullInt64{Int64: 1, Valid: true},
+				SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
 			},
 		},
 	}
@@ -169,6 +184,7 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 		Error:    sql.NullString{String: "", Valid: false},
 		Status:   sql.NullString{String: "success", Valid: true},
 		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		Address:  sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	h := new(library.Hook)
@@ -184,6 +200,7 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 	h.SetError("")
 	h.SetStatus("success")
 	h.SetLink("https://github.com/github/octocat/settings/hooks/1")
+	h.SetAddress(123456)
 
 	// run test
 	got := HookFromLibrary(h)
@@ -209,5 +226,6 @@ func testHook() *Hook {
 		Error:    sql.NullString{String: "", Valid: false},
 		Status:   sql.NullString{String: "success", Valid: true},
 		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		Address:  sql.NullInt64{Int64: 123456, Valid: true},
 	}
 }

--- a/database/hook_test.go
+++ b/database/hook_test.go
@@ -18,19 +18,19 @@ func TestDatabase_Hook_Nullify(t *testing.T) {
 	var h *Hook
 
 	want := &Hook{
-		ID:       sql.NullInt64{Int64: 0, Valid: false},
-		RepoID:   sql.NullInt64{Int64: 0, Valid: false},
-		BuildID:  sql.NullInt64{Int64: 0, Valid: false},
-		Number:   sql.NullInt32{Int32: 0, Valid: false},
-		SourceID: sql.NullString{String: "", Valid: false},
-		Created:  sql.NullInt64{Int64: 0, Valid: false},
-		Host:     sql.NullString{String: "", Valid: false},
-		Event:    sql.NullString{String: "", Valid: false},
-		Branch:   sql.NullString{String: "", Valid: false},
-		Error:    sql.NullString{String: "", Valid: false},
-		Status:   sql.NullString{String: "", Valid: false},
-		Link:     sql.NullString{String: "", Valid: false},
-		Address:  sql.NullInt64{Int64: 0, Valid: false},
+		ID:        sql.NullInt64{Int64: 0, Valid: false},
+		RepoID:    sql.NullInt64{Int64: 0, Valid: false},
+		BuildID:   sql.NullInt64{Int64: 0, Valid: false},
+		Number:    sql.NullInt32{Int32: 0, Valid: false},
+		SourceID:  sql.NullString{String: "", Valid: false},
+		Created:   sql.NullInt64{Int64: 0, Valid: false},
+		Host:      sql.NullString{String: "", Valid: false},
+		Event:     sql.NullString{String: "", Valid: false},
+		Branch:    sql.NullString{String: "", Valid: false},
+		Error:     sql.NullString{String: "", Valid: false},
+		Status:    sql.NullString{String: "", Valid: false},
+		Link:      sql.NullString{String: "", Valid: false},
+		WebhookID: sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -77,22 +77,22 @@ func TestDatabase_Hook_ToLibrary(t *testing.T) {
 	want.SetError("")
 	want.SetStatus("success")
 	want.SetLink("https://github.com/github/octocat/settings/hooks/1")
-	want.SetAddress(123456)
+	want.SetWebhookID(123456)
 
 	h := &Hook{
-		ID:       sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:   sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:  sql.NullInt64{Int64: 1, Valid: true},
-		Number:   sql.NullInt32{Int32: 1, Valid: true},
-		SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:  sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:     sql.NullString{String: "github.com", Valid: true},
-		Event:    sql.NullString{String: "push", Valid: true},
-		Branch:   sql.NullString{String: "master", Valid: true},
-		Error:    sql.NullString{String: "", Valid: true},
-		Status:   sql.NullString{String: "success", Valid: true},
-		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		Address:  sql.NullInt64{Int64: 123456, Valid: true},
+		ID:        sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
+		Number:    sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:      sql.NullString{String: "github.com", Valid: true},
+		Event:     sql.NullString{String: "push", Valid: true},
+		Branch:    sql.NullString{String: "master", Valid: true},
+		Error:     sql.NullString{String: "", Valid: true},
+		Status:    sql.NullString{String: "success", Valid: true},
+		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	// run test
@@ -116,31 +116,31 @@ func TestDatabase_Hook_Validate(t *testing.T) {
 		{ // no number set for hook
 			failure: true,
 			hook: &Hook{
-				ID:       sql.NullInt64{Int64: 1, Valid: true},
-				RepoID:   sql.NullInt64{Int64: 1, Valid: true},
-				SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-				Address:  sql.NullInt64{Int64: 1, Valid: true},
+				ID:        sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+				SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+				WebhookID: sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
 		{ // no repo_id set for hook
 			failure: true,
 			hook: &Hook{
-				ID:       sql.NullInt64{Int64: 1, Valid: true},
-				Number:   sql.NullInt32{Int32: 1, Valid: true},
-				SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-				Address:  sql.NullInt64{Int64: 1, Valid: true},
+				ID:        sql.NullInt64{Int64: 1, Valid: true},
+				Number:    sql.NullInt32{Int32: 1, Valid: true},
+				SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+				WebhookID: sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
 		{ // no source_id set for hook
 			failure: true,
 			hook: &Hook{
-				ID:      sql.NullInt64{Int64: 1, Valid: true},
-				Number:  sql.NullInt32{Int32: 1, Valid: true},
-				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
-				Address: sql.NullInt64{Int64: 1, Valid: true},
+				ID:        sql.NullInt64{Int64: 1, Valid: true},
+				Number:    sql.NullInt32{Int32: 1, Valid: true},
+				RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+				WebhookID: sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
-		{ // no address set for hook
+		{ // no webhook_id set for hook
 			failure: true,
 			hook: &Hook{
 				ID:       sql.NullInt64{Int64: 1, Valid: true},
@@ -172,19 +172,19 @@ func TestDatabase_Hook_Validate(t *testing.T) {
 func TestDatabase_HookFromLibrary(t *testing.T) {
 	// setup types
 	want := &Hook{
-		ID:       sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:   sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:  sql.NullInt64{Int64: 1, Valid: true},
-		Number:   sql.NullInt32{Int32: 1, Valid: true},
-		SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:  sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:     sql.NullString{String: "github.com", Valid: true},
-		Event:    sql.NullString{String: "push", Valid: true},
-		Branch:   sql.NullString{String: "master", Valid: true},
-		Error:    sql.NullString{String: "", Valid: false},
-		Status:   sql.NullString{String: "success", Valid: true},
-		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		Address:  sql.NullInt64{Int64: 123456, Valid: true},
+		ID:        sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
+		Number:    sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:      sql.NullString{String: "github.com", Valid: true},
+		Event:     sql.NullString{String: "push", Valid: true},
+		Branch:    sql.NullString{String: "master", Valid: true},
+		Error:     sql.NullString{String: "", Valid: false},
+		Status:    sql.NullString{String: "success", Valid: true},
+		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	h := new(library.Hook)
@@ -200,7 +200,7 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 	h.SetError("")
 	h.SetStatus("success")
 	h.SetLink("https://github.com/github/octocat/settings/hooks/1")
-	h.SetAddress(123456)
+	h.SetWebhookID(123456)
 
 	// run test
 	got := HookFromLibrary(h)
@@ -214,18 +214,18 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 // type with all fields set to a fake value.
 func testHook() *Hook {
 	return &Hook{
-		ID:       sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:   sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:  sql.NullInt64{Int64: 1, Valid: true},
-		Number:   sql.NullInt32{Int32: 1, Valid: true},
-		SourceID: sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:  sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:     sql.NullString{String: "github.com", Valid: true},
-		Event:    sql.NullString{String: "push", Valid: true},
-		Branch:   sql.NullString{String: "master", Valid: true},
-		Error:    sql.NullString{String: "", Valid: false},
-		Status:   sql.NullString{String: "success", Valid: true},
-		Link:     sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		Address:  sql.NullInt64{Int64: 123456, Valid: true},
+		ID:        sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
+		Number:    sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:      sql.NullString{String: "github.com", Valid: true},
+		Event:     sql.NullString{String: "push", Valid: true},
+		Branch:    sql.NullString{String: "master", Valid: true},
+		Error:     sql.NullString{String: "", Valid: false},
+		Status:    sql.NullString{String: "success", Valid: true},
+		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
 	}
 }

--- a/library/build.go
+++ b/library/build.go
@@ -561,7 +561,7 @@ func (b *Build) GetRuntime() string {
 	return *b.Runtime
 }
 
-// GetDistribution returns the Runtime field.
+// GetDistribution returns the Distribution field.
 //
 // When the provided Build type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
@@ -938,7 +938,7 @@ func (b *Build) SetRuntime(v string) {
 	b.Runtime = &v
 }
 
-// SetDistribution sets the Runtime field.
+// SetDistribution sets the Distribution field.
 //
 // When the provided Build type is nil, it
 // will set nothing and immediately return.

--- a/library/hook.go
+++ b/library/hook.go
@@ -24,6 +24,7 @@ type Hook struct {
 	Error    *string `json:"error,omitempty"`
 	Status   *string `json:"status,omitempty"`
 	Link     *string `json:"link,omitempty"`
+	Address  *int64  `json:"address,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -182,6 +183,19 @@ func (h *Hook) GetLink() string {
 	return *h.Link
 }
 
+// GetAddress returns the Address field.
+//
+// When the provided Hook type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (h *Hook) GetAddress() int64 {
+	// return zero value if Hook type or Address field is nil
+	if h == nil || h.ID == nil {
+		return 0
+	}
+
+	return *h.Address
+}
+
 // SetID sets the ID field.
 //
 // When the provided Hook type is nil, it
@@ -337,9 +351,23 @@ func (h *Hook) SetLink(v string) {
 	h.Link = &v
 }
 
+// SetAddress sets the Address field.
+//
+// When the provided Hook type is nil, it
+// will set nothing and immediately return.
+func (h *Hook) SetAddress(v int64) {
+	// return if Hook type is nil
+	if h == nil {
+		return
+	}
+
+	h.Address = &v
+}
+
 // String implements the Stringer interface for the Hook type.
 func (h *Hook) String() string {
 	return fmt.Sprintf(`{
+  Address: %d,
   Branch: %s,
   BuildID: %d,
   Created: %d,
@@ -353,6 +381,7 @@ func (h *Hook) String() string {
   SourceID: %s,
   Status: %s,
 }`,
+		h.GetAddress(),
 		h.GetBranch(),
 		h.GetBuildID(),
 		h.GetCreated(),

--- a/library/hook.go
+++ b/library/hook.go
@@ -12,19 +12,19 @@ import (
 //
 // swagger:model Webhook
 type Hook struct {
-	ID       *int64  `json:"id,omitempty"`
-	RepoID   *int64  `json:"repo_id,omitempty"`
-	BuildID  *int64  `json:"build_id,omitempty"`
-	Number   *int    `json:"number,omitempty"`
-	SourceID *string `json:"source_id,omitempty"`
-	Created  *int64  `json:"created,omitempty"`
-	Host     *string `json:"host,omitempty"`
-	Event    *string `json:"event,omitempty"`
-	Branch   *string `json:"branch,omitempty"`
-	Error    *string `json:"error,omitempty"`
-	Status   *string `json:"status,omitempty"`
-	Link     *string `json:"link,omitempty"`
-	Address  *int64  `json:"address,omitempty"`
+	ID        *int64  `json:"id,omitempty"`
+	RepoID    *int64  `json:"repo_id,omitempty"`
+	BuildID   *int64  `json:"build_id,omitempty"`
+	Number    *int    `json:"number,omitempty"`
+	SourceID  *string `json:"source_id,omitempty"`
+	Created   *int64  `json:"created,omitempty"`
+	Host      *string `json:"host,omitempty"`
+	Event     *string `json:"event,omitempty"`
+	Branch    *string `json:"branch,omitempty"`
+	Error     *string `json:"error,omitempty"`
+	Status    *string `json:"status,omitempty"`
+	Link      *string `json:"link,omitempty"`
+	WebhookID *int64  `json:"webhook_id,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -183,17 +183,17 @@ func (h *Hook) GetLink() string {
 	return *h.Link
 }
 
-// GetAddress returns the Address field.
+// GetWebhookID returns the WebhookID field.
 //
 // When the provided Hook type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
-func (h *Hook) GetAddress() int64 {
-	// return zero value if Hook type or Address field is nil
-	if h == nil || h.ID == nil {
+func (h *Hook) GetWebhookID() int64 {
+	// return zero value if Hook type or WebhookID field is nil
+	if h == nil || h.WebhookID == nil {
 		return 0
 	}
 
-	return *h.Address
+	return *h.WebhookID
 }
 
 // SetID sets the ID field.
@@ -352,23 +352,22 @@ func (h *Hook) SetLink(v string) {
 	h.Link = &v
 }
 
-// SetAddress sets the Address field.
+// SetWebhookID sets the WebhookID field.
 //
 // When the provided Hook type is nil, it
 // will set nothing and immediately return.
-func (h *Hook) SetAddress(v int64) {
+func (h *Hook) SetWebhookID(v int64) {
 	// return if Hook type is nil
 	if h == nil {
 		return
 	}
 
-	h.Address = &v
+	h.WebhookID = &v
 }
 
 // String implements the Stringer interface for the Hook type.
 func (h *Hook) String() string {
 	return fmt.Sprintf(`{
-  Address: %d,
   Branch: %s,
   BuildID: %d,
   Created: %d,
@@ -381,8 +380,8 @@ func (h *Hook) String() string {
   RepoID: %d,
   SourceID: %s,
   Status: %s,
+  WebhookID: %d,
 }`,
-		h.GetAddress(),
 		h.GetBranch(),
 		h.GetBuildID(),
 		h.GetCreated(),
@@ -395,5 +394,6 @@ func (h *Hook) String() string {
 		h.GetRepoID(),
 		h.GetSourceID(),
 		h.GetStatus(),
+		h.GetWebhookID(),
 	)
 }

--- a/library/hook_test.go
+++ b/library/hook_test.go
@@ -77,8 +77,8 @@ func TestLibrary_Hook_Getters(t *testing.T) {
 			t.Errorf("GetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
 		}
 
-		if test.hook.GetAddress() != test.want.GetAddress() {
-			t.Errorf("GetAddress is %v, want %v", test.hook.GetAddress(), test.want.GetAddress())
+		if test.hook.GetWebhookID() != test.want.GetWebhookID() {
+			t.Errorf("GetWebhookID is %v, want %v", test.hook.GetWebhookID(), test.want.GetWebhookID())
 		}
 	}
 }
@@ -116,7 +116,7 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 		test.hook.SetError(test.want.GetError())
 		test.hook.SetStatus(test.want.GetStatus())
 		test.hook.SetLink(test.want.GetLink())
-		test.hook.SetAddress(test.want.GetAddress())
+		test.hook.SetWebhookID(test.want.GetWebhookID())
 
 		if test.hook.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.hook.GetID(), test.want.GetID())
@@ -166,8 +166,8 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 			t.Errorf("SetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
 		}
 
-		if test.hook.GetAddress() != test.want.GetAddress() {
-			t.Errorf("SetAddress is %v, want %v", test.hook.GetAddress(), test.want.GetAddress())
+		if test.hook.GetWebhookID() != test.want.GetWebhookID() {
+			t.Errorf("SetWebhookID is %v, want %v", test.hook.GetWebhookID(), test.want.GetWebhookID())
 		}
 	}
 }
@@ -177,7 +177,6 @@ func TestLibrary_Hook_String(t *testing.T) {
 	h := testHook()
 
 	want := fmt.Sprintf(`{
-  Address: %d,
   Branch: %s,
   BuildID: %d,
   Created: %d,
@@ -190,8 +189,8 @@ func TestLibrary_Hook_String(t *testing.T) {
   RepoID: %d,
   SourceID: %s,
   Status: %s,
+  WebhookID: %d,
 }`,
-		h.GetAddress(),
 		h.GetBranch(),
 		h.GetBuildID(),
 		h.GetCreated(),
@@ -204,6 +203,7 @@ func TestLibrary_Hook_String(t *testing.T) {
 		h.GetRepoID(),
 		h.GetSourceID(),
 		h.GetStatus(),
+		h.GetWebhookID(),
 	)
 
 	// run test
@@ -231,7 +231,7 @@ func testHook() *Hook {
 	h.SetError("")
 	h.SetStatus("success")
 	h.SetLink("https://github.com/github/octocat/settings/hooks/1")
-	h.SetAddress(123456)
+	h.SetWebhookID(123456)
 
 	return h
 }

--- a/library/hook_test.go
+++ b/library/hook_test.go
@@ -76,6 +76,10 @@ func TestLibrary_Hook_Getters(t *testing.T) {
 		if test.hook.GetLink() != test.want.GetLink() {
 			t.Errorf("GetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
 		}
+
+		if test.hook.GetAddress() != test.want.GetAddress() {
+			t.Errorf("GetAddress is %v, want %v", test.hook.GetAddress(), test.want.GetAddress())
+		}
 	}
 }
 
@@ -112,6 +116,7 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 		test.hook.SetError(test.want.GetError())
 		test.hook.SetStatus(test.want.GetStatus())
 		test.hook.SetLink(test.want.GetLink())
+		test.hook.SetAddress(test.want.GetAddress())
 
 		if test.hook.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.hook.GetID(), test.want.GetID())
@@ -160,6 +165,10 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 		if test.hook.GetLink() != test.want.GetLink() {
 			t.Errorf("SetLink is %v, want %v", test.hook.GetLink(), test.want.GetLink())
 		}
+
+		if test.hook.GetAddress() != test.want.GetAddress() {
+			t.Errorf("SetAddress is %v, want %v", test.hook.GetAddress(), test.want.GetAddress())
+		}
 	}
 }
 
@@ -168,6 +177,7 @@ func TestLibrary_Hook_String(t *testing.T) {
 	h := testHook()
 
 	want := fmt.Sprintf(`{
+  Address: %d,
   Branch: %s,
   BuildID: %d,
   Created: %d,
@@ -181,6 +191,7 @@ func TestLibrary_Hook_String(t *testing.T) {
   SourceID: %s,
   Status: %s,
 }`,
+		h.GetAddress(),
 		h.GetBranch(),
 		h.GetBuildID(),
 		h.GetCreated(),
@@ -220,6 +231,7 @@ func testHook() *Hook {
 	h.SetError("")
 	h.SetStatus("success")
 	h.SetLink("https://github.com/github/octocat/settings/hooks/1")
+	h.SetAddress(123456)
 
 	return h
 }


### PR DESCRIPTION
Couple related issues: https://github.com/go-vela/community/issues/459 and https://github.com/go-vela/community/issues/416

The `hook_id` is the field needed from GitHub to not only reach that deliveries page but also interact with any of their API endpoints related to hook deliveries. A `hook_id` is unique to any one hook within a repo, but since we already have an `id` field as well as a `repo_id` field, I chose `address` as the name. If anyone has a suggestion for another name, I am all ears! 

I also cleaned up a couple of typos I noticed in the comments of `build.go`