### PR TITLE
fix(metadata): moving metadata unmarshaler override to build

### DIFF
--- a/yaml/build.go
+++ b/yaml/build.go
@@ -22,7 +22,7 @@ type Build struct {
 	Templates   TemplateSlice      `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/reference/yaml/templates/"`
 }
 
-// UnmarshalYAML implements the Unmarshaler interface for the Metadata type.
+// UnmarshalYAML implements the Unmarshaler interface for the Build type.
 func (b *Build) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	// build we try unmarshalling to
 	build := new(struct {
@@ -37,16 +37,18 @@ func (b *Build) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		Templates   TemplateSlice
 	})
 
-	// attempt to unmarshal as a metadata type
+	// attempt to unmarshal as a build type
 	err := unmarshal(build)
 	if err != nil {
 		return err
 	}
 
+	// give the documented default value to metadata environment
 	if build.Metadata.Environment == nil {
 		build.Metadata.Environment = []string{"steps", "services", "secrets"}
 	}
 
+	// override the values
 	b.Version = build.Version
 	b.Metadata = build.Metadata
 	b.Environment = build.Environment

--- a/yaml/build.go
+++ b/yaml/build.go
@@ -21,3 +21,41 @@ type Build struct {
 	Steps       StepSlice          `yaml:"steps,omitempty"     json:"steps,omitempty" jsonschema:"oneof_required=steps,description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/"`
 	Templates   TemplateSlice      `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/reference/yaml/templates/"`
 }
+
+// UnmarshalYAML implements the Unmarshaler interface for the Metadata type.
+func (b *Build) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// build we try unmarshalling to
+	build := new(struct {
+		Version     string
+		Metadata    Metadata
+		Environment raw.StringSliceMap
+		Worker      Worker
+		Secrets     SecretSlice
+		Services    ServiceSlice
+		Stages      StageSlice
+		Steps       StepSlice
+		Templates   TemplateSlice
+	})
+
+	// attempt to unmarshal as a metadata type
+	err := unmarshal(build)
+	if err != nil {
+		return err
+	}
+
+	if build.Metadata.Environment == nil {
+		build.Metadata.Environment = []string{"steps", "services", "secrets"}
+	}
+
+	b.Version = build.Version
+	b.Metadata = build.Metadata
+	b.Environment = build.Environment
+	b.Worker = build.Worker
+	b.Secrets = build.Secrets
+	b.Services = build.Services
+	b.Stages = build.Stages
+	b.Steps = build.Steps
+	b.Templates = build.Templates
+
+	return nil
+}

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -441,6 +441,54 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 				},
 			},
 		},
+		{
+			file: "testdata/build_empty_env.yml",
+			want: &Build{
+				Version: "1",
+				Metadata: Metadata{
+					Template:    false,
+					Clone:       nil,
+					Environment: []string{},
+				},
+				Environment: raw.StringSliceMap{
+					"HELLO": "Hello, Global Message",
+				},
+				Worker: Worker{
+					Flavor:   "16cpu8gb",
+					Platform: "gcp"},
+				Steps: StepSlice{
+					{
+						Commands: raw.StringSlice{"./gradlew downloadDependencies"},
+						Environment: raw.StringSliceMap{
+							"GRADLE_OPTS":      "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false",
+							"GRADLE_USER_HOME": ".gradle",
+						},
+						Image: "openjdk:latest",
+						Name:  "install",
+						Pull:  "always",
+						Ruleset: Ruleset{
+							If:       Rules{Event: []string{"push", "pull_request"}},
+							Matcher:  "filepath",
+							Operator: "and",
+						},
+						Ulimits: UlimitSlice{
+							{
+								Name: "foo",
+								Soft: 1024,
+								Hard: 2048,
+							},
+						},
+						Volumes: VolumeSlice{
+							{
+								Source:      "/foo",
+								Destination: "/bar",
+								AccessMode:  "ro",
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	// run tests

--- a/yaml/metadata.go
+++ b/yaml/metadata.go
@@ -47,30 +47,3 @@ func (m *Metadata) HasEnvironment(container string) bool {
 
 	return false
 }
-
-// UnmarshalYAML implements the Unmarshaler interface for the Metadata type.
-func (m *Metadata) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	// metadata we try unmarshalling to
-	metadata := new(struct {
-		Template    bool
-		Clone       *bool
-		Environment []string
-	})
-
-	// attempt to unmarshal as a metadata type
-	err := unmarshal(metadata)
-	if err != nil {
-		return err
-	}
-
-	if len(metadata.Environment) == 0 {
-		metadata.Environment = []string{"steps", "services", "secrets"}
-	}
-
-	// overwrite existing metadata environment details
-	m.Template = metadata.Template
-	m.Clone = metadata.Clone
-	m.Environment = metadata.Environment
-
-	return nil
-}

--- a/yaml/metadata_test.go
+++ b/yaml/metadata_test.go
@@ -5,13 +5,10 @@
 package yaml
 
 import (
-	"io/ioutil"
 	"reflect"
 	"testing"
 
 	"github.com/go-vela/types/pipeline"
-
-	"github.com/buildkite/yaml"
 )
 
 func TestYaml_Metadata_ToPipeline(t *testing.T) {
@@ -106,52 +103,6 @@ func TestYaml_Metadata_HasEnvironment(t *testing.T) {
 
 		if !reflect.DeepEqual(got, test.want) {
 			t.Errorf("ToPipeline is %v, want %v", got, test.want)
-		}
-	}
-}
-
-func TestYaml_Metadata_UnmarshalYAML(t *testing.T) {
-	// setup tests
-	tests := []struct {
-		failure bool
-		file    string
-		want    *Metadata
-	}{
-		{
-			failure: false,
-			file:    "testdata/metadata.yml",
-			want: &Metadata{
-				Template:    false,
-				Clone:       nil,
-				Environment: []string{"steps", "services", "secrets"},
-			},
-		},
-		{
-			file: "testdata/metadata_env.yml",
-			want: &Metadata{
-				Template:    false,
-				Clone:       nil,
-				Environment: []string{"steps"},
-			},
-		},
-	}
-
-	// run tests
-	for _, test := range tests {
-		got := new(Metadata)
-
-		b, err := ioutil.ReadFile(test.file)
-		if err != nil {
-			t.Errorf("Reading file for UnmarshalYAML returned err: %v", err)
-		}
-
-		err = yaml.Unmarshal(b, got)
-		if err != nil {
-			t.Errorf("UnmarshalYAML returned err: %v", err)
-		}
-
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("UnmarshalYAML is %v, want %v", got, test.want)
 		}
 	}
 }

--- a/yaml/testdata/build.yml
+++ b/yaml/testdata/build.yml
@@ -1,9 +1,6 @@
 ---
 version: "1"
 
-metadata:
-  template: false
-
 environment:
   HELLO: "Hello, Global Message"  
 

--- a/yaml/testdata/build_empty_env.yml
+++ b/yaml/testdata/build_empty_env.yml
@@ -1,0 +1,27 @@
+---
+version: "1"
+
+metadata:
+  template: false
+  environment: []
+
+environment:
+  HELLO: "Hello, Global Message"  
+
+worker:
+  flavor: 16cpu8gb
+  platform: gcp    
+
+steps:
+  - name: install
+    commands:
+      - ./gradlew downloadDependencies
+    environment:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false -Dorg.gradle.workers.max=1 -Dorg.gradle.parallel=false
+      GRADLE_USER_HOME: .gradle
+    image: openjdk:latest
+    pull: true
+    ruleset:
+      event: [ push, pull_request ]
+    volumes: [ /foo:/bar:ro ]
+    ulimits: [ foo=1024:2048 ]


### PR DESCRIPTION
Closes https://github.com/go-vela/community/issues/514

When a user does not supply the `metadata` tag, the unmarshaling routine would not trigger the custom unmarshaler we had in place to populate the environment with the appropriate containers. By moving the custom unmarshaler, we get a broader scope and thus can check the `metadata` after it has been unmarshaled. 

By changing the slice length check to a slice nil check, files written with `metadata.Environment = []` will be processed as expected: environment will not be injected into _any_ container. 