### PR TITLE
revert(repo): remove last update field

### DIFF
--- a/database/repo.go
+++ b/database/repo.go
@@ -63,7 +63,6 @@ type Repo struct {
 	AllowComment sql.NullBool   `sql:"allow_comment"`
 	PipelineType sql.NullString `sql:"pipeline_type"`
 	PreviousName sql.NullString `sql:"previous_name"`
-	LastUpdate   sql.NullInt64  `sql:"last_update"`
 }
 
 // Decrypt will manipulate the existing repo hash by
@@ -194,11 +193,6 @@ func (r *Repo) Nullify() *Repo {
 		r.PreviousName.Valid = false
 	}
 
-	// check if the LastUpdate field should be false
-	if r.LastUpdate.Int64 == 0 {
-		r.LastUpdate.Valid = false
-	}
-
 	return r
 }
 
@@ -230,7 +224,6 @@ func (r *Repo) ToLibrary() *library.Repo {
 	repo.SetAllowComment(r.AllowComment.Bool)
 	repo.SetPipelineType(r.PipelineType.String)
 	repo.SetPreviousName(r.PreviousName.String)
-	repo.SetLastUpdate(r.LastUpdate.Int64)
 
 	return repo
 }
@@ -310,7 +303,6 @@ func RepoFromLibrary(r *library.Repo) *Repo {
 		AllowComment: sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
 		PipelineType: sql.NullString{String: r.GetPipelineType(), Valid: true},
 		PreviousName: sql.NullString{String: r.GetPreviousName(), Valid: true},
-		LastUpdate:   sql.NullInt64{Int64: r.GetLastUpdate(), Valid: true},
 	}
 
 	return repo.Nullify()

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -120,7 +120,6 @@ func TestDatabase_Repo_Nullify(t *testing.T) {
 		Timeout:      sql.NullInt64{Int64: 0, Valid: false},
 		Visibility:   sql.NullString{String: "", Valid: false},
 		PipelineType: sql.NullString{String: "", Valid: false},
-		LastUpdate:   sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -179,7 +178,6 @@ func TestDatabase_Repo_ToLibrary(t *testing.T) {
 	want.SetAllowComment(false)
 	want.SetPipelineType("yaml")
 	want.SetPreviousName("oldName")
-	want.SetLastUpdate(1563474076)
 
 	// run test
 	got := testRepo().ToLibrary()
@@ -312,7 +310,6 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 	r.SetAllowComment(false)
 	r.SetPipelineType("yaml")
 	r.SetPreviousName("oldName")
-	r.SetLastUpdate(1563474076)
 
 	want := testRepo()
 
@@ -351,6 +348,5 @@ func testRepo() *Repo {
 		AllowComment: sql.NullBool{Bool: false, Valid: true},
 		PipelineType: sql.NullString{String: "yaml", Valid: true},
 		PreviousName: sql.NullString{String: "oldName", Valid: true},
-		LastUpdate:   sql.NullInt64{Int64: 1563474076, Valid: true},
 	}
 }

--- a/library/repo.go
+++ b/library/repo.go
@@ -35,7 +35,6 @@ type Repo struct {
 	AllowComment *bool   `json:"allow_comment,omitempty"`
 	PipelineType *string `json:"pipeline_type,omitempty"`
 	PreviousName *string `json:"previous_name,omitempty"`
-	LastUpdate   *int64  `json:"last_update,omitempty"`
 }
 
 // Environment returns a list of environment variables
@@ -60,7 +59,6 @@ func (r *Repo) Environment() map[string]string {
 		"VELA_REPO_TRUSTED":       ToString(r.GetTrusted()),
 		"VELA_REPO_VISIBILITY":    ToString(r.GetVisibility()),
 		"VELA_REPO_PIPELINE_TYPE": ToString(r.GetPipelineType()),
-		"VELA_REPO_LAST_UPDATE":   ToString(r.GetLastUpdate()),
 
 		// deprecated environment variables
 		"REPOSITORY_ACTIVE":        ToString(r.GetActive()),
@@ -381,19 +379,6 @@ func (r *Repo) GetPreviousName() string {
 	return *r.PreviousName
 }
 
-// GetLastUpdate returns the LastUpdate field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetLastUpdate() int64 {
-	// return the zero value if Repo type or LastUpdate field is nil
-	if r == nil || r.LastUpdate == nil {
-		return 0
-	}
-
-	return *r.LastUpdate
-}
-
 // SetID sets the ID field.
 //
 // When the provided Repo type is nil, it
@@ -693,19 +678,6 @@ func (r *Repo) SetPreviousName(v string) {
 	r.PreviousName = &v
 }
 
-// SetLastUpdate sets the LastUpdate field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetLastUpdate(v int64) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.LastUpdate = &v
-}
-
 // String implements the Stringer interface for the Repo type.
 func (r *Repo) String() string {
 	return fmt.Sprintf(`{
@@ -721,7 +693,6 @@ func (r *Repo) String() string {
   Counter: %d,
   FullName: %s,
   ID: %d,
-  LastUpdate: %d,
   Link: %s,
   Name: %s,
   Org: %s,
@@ -745,7 +716,6 @@ func (r *Repo) String() string {
 		r.GetCounter(),
 		r.GetFullName(),
 		r.GetID(),
-		r.GetLastUpdate(),
 		r.GetLink(),
 		r.GetName(),
 		r.GetOrg(),

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -31,7 +31,6 @@ func TestLibrary_Repo_Environment(t *testing.T) {
 		"VELA_REPO_TRUSTED":        "false",
 		"VELA_REPO_VISIBILITY":     "public",
 		"VELA_REPO_PIPELINE_TYPE":  "",
-		"VELA_REPO_LAST_UPDATE":    "1563474076",
 		"REPOSITORY_ACTIVE":        "true",
 		"REPOSITORY_ALLOW_COMMENT": "false",
 		"REPOSITORY_ALLOW_DEPLOY":  "false",
@@ -163,10 +162,6 @@ func TestLibrary_Repo_Getters(t *testing.T) {
 		if !reflect.DeepEqual(test.repo.GetPreviousName(), test.want.GetPreviousName()) {
 			t.Errorf("GetPreviousName is %v, want %v", test.repo.GetPreviousName(), test.want.GetPreviousName())
 		}
-
-		if test.repo.GetLastUpdate() != test.want.GetLastUpdate() {
-			t.Errorf("GetLastUpdate is %v, want %v", test.repo.GetLastUpdate(), test.want.GetLastUpdate())
-		}
 	}
 }
 
@@ -214,7 +209,6 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 		test.repo.SetAllowComment(test.want.GetAllowComment())
 		test.repo.SetPipelineType(test.want.GetPipelineType())
 		test.repo.SetPreviousName(test.want.GetPreviousName())
-		test.repo.SetLastUpdate(test.want.GetLastUpdate())
 
 		if test.repo.GetID() != test.want.GetID() {
 			t.Errorf("SetID is %v, want %v", test.repo.GetID(), test.want.GetID())
@@ -303,10 +297,6 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 		if !reflect.DeepEqual(test.repo.GetPreviousName(), test.want.GetPreviousName()) {
 			t.Errorf("SetPreviousName is %v, want %v", test.repo.GetPreviousName(), test.want.GetPreviousName())
 		}
-
-		if test.repo.GetLastUpdate() != test.want.GetLastUpdate() {
-			t.Errorf("SetLastUpdate is %v, want %v", test.repo.GetLastUpdate(), test.want.GetLastUpdate())
-		}
 	}
 }
 
@@ -327,7 +317,6 @@ func TestLibrary_Repo_String(t *testing.T) {
   Counter: %d,
   FullName: %s,
   ID: %d,
-  LastUpdate: %d,
   Link: %s,
   Name: %s,
   Org: %s,
@@ -351,7 +340,6 @@ func TestLibrary_Repo_String(t *testing.T) {
 		r.GetCounter(),
 		r.GetFullName(),
 		r.GetID(),
-		r.GetLastUpdate(),
 		r.GetLink(),
 		r.GetName(),
 		r.GetOrg(),
@@ -398,7 +386,6 @@ func testRepo() *Repo {
 	r.SetAllowComment(false)
 	r.SetPipelineType("")
 	r.SetPreviousName("")
-	r.SetLastUpdate(1563474076)
 
 	return r
 }


### PR DESCRIPTION
As noted [here](https://github.com/go-vela/server/pull/607#pullrequestreview-906303616), the done criteria for https://github.com/go-vela/community/issues/343 can be accomplished using a different query rather than adding a column to the database. 