### PR TITLE
feat(rulesets): add event action field

### DIFF
--- a/constants/action.go
+++ b/constants/action.go
@@ -9,7 +9,10 @@ const (
 	// ActionOpened defines the action for opening pull requests.
 	ActionOpened = "opened"
 
-	// ActionEdited defines the action for the editing of pull requests.
+	// ActionCreated defines the action for creating issue comments.
+	ActionCreated = "created"
+
+	// ActionEdited defines the action for the editing of pull requests or issue comments.
 	ActionEdited = "edited"
 
 	// ActionSynchronized defines the action for the synchronizing of pull requests.

--- a/database/build.go
+++ b/database/build.go
@@ -39,6 +39,7 @@ type Build struct {
 	Number        sql.NullInt32      `sql:"number"`
 	Parent        sql.NullInt32      `sql:"parent"`
 	Event         sql.NullString     `sql:"event"`
+	EventAction   sql.NullString     `sql:"event_action"`
 	Status        sql.NullString     `sql:"status"`
 	Error         sql.NullString     `sql:"error"`
 	Enqueued      sql.NullInt64      `sql:"enqueued"`
@@ -127,6 +128,11 @@ func (b *Build) Nullify() *Build {
 	// check if the Event field should be false
 	if len(b.Event.String) == 0 {
 		b.Event.Valid = false
+	}
+
+	// check if the EventAction field should be false
+	if len(b.EventAction.String) == 0 {
+		b.EventAction.Valid = false
 	}
 
 	// check if the Status field should be false
@@ -258,6 +264,7 @@ func (b *Build) ToLibrary() *library.Build {
 	build.SetNumber(int(b.Number.Int32))
 	build.SetParent(int(b.Parent.Int32))
 	build.SetEvent(b.Event.String)
+	build.SetEventAction(b.EventAction.String)
 	build.SetStatus(b.Status.String)
 	build.SetError(b.Error.String)
 	build.SetEnqueued(b.Enqueued.Int64)
@@ -303,6 +310,7 @@ func (b *Build) Validate() error {
 	// that can be returned as JSON are sanitized
 	// to avoid unsafe HTML content
 	b.Event = sql.NullString{String: sanitize(b.Event.String), Valid: b.Event.Valid}
+	b.EventAction = sql.NullString{String: sanitize(b.EventAction.String), Valid: b.EventAction.Valid}
 	b.Status = sql.NullString{String: sanitize(b.Status.String), Valid: b.Status.Valid}
 	b.Error = sql.NullString{String: sanitize(b.Error.String), Valid: b.Error.Valid}
 	b.Deploy = sql.NullString{String: sanitize(b.Deploy.String), Valid: b.Deploy.Valid}
@@ -336,6 +344,7 @@ func BuildFromLibrary(b *library.Build) *Build {
 		Number:        sql.NullInt32{Int32: int32(b.GetNumber()), Valid: true},
 		Parent:        sql.NullInt32{Int32: int32(b.GetParent()), Valid: true},
 		Event:         sql.NullString{String: b.GetEvent(), Valid: true},
+		EventAction:   sql.NullString{String: b.GetEventAction(), Valid: true},
 		Status:        sql.NullString{String: b.GetStatus(), Valid: true},
 		Error:         sql.NullString{String: b.GetError(), Valid: true},
 		Enqueued:      sql.NullInt64{Int64: b.GetEnqueued(), Valid: true},

--- a/database/build_test.go
+++ b/database/build_test.go
@@ -49,6 +49,7 @@ func TestDatabase_Build_Nullify(t *testing.T) {
 		Number:        sql.NullInt32{Int32: 0, Valid: false},
 		Parent:        sql.NullInt32{Int32: 0, Valid: false},
 		Event:         sql.NullString{String: "", Valid: false},
+		EventAction:   sql.NullString{String: "", Valid: false},
 		Status:        sql.NullString{String: "", Valid: false},
 		Error:         sql.NullString{String: "", Valid: false},
 		Enqueued:      sql.NullInt64{Int64: 0, Valid: false},
@@ -114,6 +115,7 @@ func TestDatabase_Build_ToLibrary(t *testing.T) {
 	want.SetNumber(1)
 	want.SetParent(1)
 	want.SetEvent("push")
+	want.SetEventAction("push")
 	want.SetStatus("running")
 	want.SetError("")
 	want.SetEnqueued(1563474077)
@@ -202,6 +204,7 @@ func TestDatabase_BuildFromLibrary(t *testing.T) {
 	b.SetNumber(1)
 	b.SetParent(1)
 	b.SetEvent("push")
+	b.SetEventAction("push")
 	b.SetStatus("running")
 	b.SetError("")
 	b.SetEnqueued(1563474077)
@@ -260,6 +263,7 @@ func testBuild() *Build {
 		Number:        sql.NullInt32{Int32: 1, Valid: true},
 		Parent:        sql.NullInt32{Int32: 1, Valid: true},
 		Event:         sql.NullString{String: "push", Valid: true},
+		EventAction:   sql.NullString{String: "push", Valid: true},
 		Status:        sql.NullString{String: "running", Valid: true},
 		Error:         sql.NullString{String: "", Valid: false},
 		Enqueued:      sql.NullInt64{Int64: 1563474077, Valid: true},

--- a/database/build_test.go
+++ b/database/build_test.go
@@ -115,7 +115,7 @@ func TestDatabase_Build_ToLibrary(t *testing.T) {
 	want.SetNumber(1)
 	want.SetParent(1)
 	want.SetEvent("push")
-	want.SetEventAction("push")
+	want.SetEventAction("")
 	want.SetStatus("running")
 	want.SetError("")
 	want.SetEnqueued(1563474077)
@@ -204,7 +204,7 @@ func TestDatabase_BuildFromLibrary(t *testing.T) {
 	b.SetNumber(1)
 	b.SetParent(1)
 	b.SetEvent("push")
-	b.SetEventAction("push")
+	b.SetEventAction("")
 	b.SetStatus("running")
 	b.SetError("")
 	b.SetEnqueued(1563474077)
@@ -263,7 +263,7 @@ func testBuild() *Build {
 		Number:        sql.NullInt32{Int32: 1, Valid: true},
 		Parent:        sql.NullInt32{Int32: 1, Valid: true},
 		Event:         sql.NullString{String: "push", Valid: true},
-		EventAction:   sql.NullString{String: "push", Valid: true},
+		EventAction:   sql.NullString{String: "", Valid: false},
 		Status:        sql.NullString{String: "running", Valid: true},
 		Error:         sql.NullString{String: "", Valid: false},
 		Enqueued:      sql.NullInt64{Int64: 1563474077, Valid: true},

--- a/library/build.go
+++ b/library/build.go
@@ -23,6 +23,7 @@ type Build struct {
 	Number        *int                `json:"number,omitempty"`
 	Parent        *int                `json:"parent,omitempty"`
 	Event         *string             `json:"event,omitempty"`
+	EventAction   *string             `json:"event_action,omitempty"`
 	Status        *string             `json:"status,omitempty"`
 	Error         *string             `json:"error,omitempty"`
 	Enqueued      *int64              `json:"enqueued,omitempty"`
@@ -95,6 +96,7 @@ func (b *Build) Environment(workspace, channel string) map[string]string {
 		"VELA_BUILD_DISTRIBUTION": ToString(b.GetDistribution()),
 		"VELA_BUILD_ENQUEUED":     ToString(b.GetEnqueued()),
 		"VELA_BUILD_EVENT":        ToString(b.GetEvent()),
+		"VELA_BUILD_EVENT_ACTION": ToString(b.GetEventAction()),
 		"VELA_BUILD_HOST":         ToString(b.GetHost()),
 		"VELA_BUILD_LINK":         ToString(b.GetLink()),
 		"VELA_BUILD_MESSAGE":      ToString(b.GetMessage()),
@@ -273,6 +275,19 @@ func (b *Build) GetEvent() string {
 	}
 
 	return *b.Event
+}
+
+// GetEventAction returns the EventAction field.
+//
+// When the provided Build type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (b *Build) GetEventAction() string {
+	// return zero value if Build type or EventAction field is nil
+	if b == nil || b.EventAction == nil {
+		return ""
+	}
+
+	return *b.EventAction
 }
 
 // GetStatus returns the Status field.
@@ -665,6 +680,19 @@ func (b *Build) SetEvent(v string) {
 	b.Event = &v
 }
 
+// SetEventAction sets the EventAction field.
+//
+// When the provided Build type is nil, it
+// will set nothing and immediately return.
+func (b *Build) SetEventAction(v string) {
+	// return if Build type is nil
+	if b == nil {
+		return
+	}
+
+	b.EventAction = &v
+}
+
 // SetStatus sets the Status field.
 //
 // When the provided Build type is nil, it
@@ -994,6 +1022,7 @@ func (b *Build) String() string {
   Enqueued: %d,
   Error: %s,
   Event: %s,
+  EventAction: %s,
   Finished: %d,
   HeadRef: %s,
   Host: %s,
@@ -1025,6 +1054,7 @@ func (b *Build) String() string {
 		b.GetEnqueued(),
 		b.GetError(),
 		b.GetEvent(),
+		b.GetEventAction(),
 		b.GetFinished(),
 		b.GetHeadRef(),
 		b.GetHost(),

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -51,10 +51,12 @@ func TestLibrary_Build_Environment(t *testing.T) {
 	// setup types
 	_comment := testBuild()
 	_comment.SetEvent("comment")
+	_comment.SetEventAction("comment:created")
 	_comment.SetRef("refs/pulls/1/head")
 
 	_deploy := testBuild()
 	_deploy.SetEvent("deployment")
+	_deploy.SetEventAction("deployment")
 	_deploy.SetDeploy("production")
 	_deploy.SetDeployPayload(map[string]string{
 		"foo": "test1",
@@ -64,6 +66,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 	_deployTag := testBuild()
 	_deployTag.SetRef("refs/tags/v0.1.0")
 	_deployTag.SetEvent("deployment")
+	_deployTag.SetEventAction("deployment")
 	_deployTag.SetDeploy("production")
 	_deployTag.SetDeployPayload(map[string]string{
 		"foo": "test1",
@@ -72,10 +75,12 @@ func TestLibrary_Build_Environment(t *testing.T) {
 
 	_pull := testBuild()
 	_pull.SetEvent("pull_request")
+	_pull.SetEventAction("pull_request:opened")
 	_pull.SetRef("refs/pulls/1/head")
 
 	_tag := testBuild()
 	_tag.SetEvent("tag")
+	_tag.SetEventAction("tag")
 	_tag.SetRef("refs/tags/v0.1.0")
 
 	// setup tests
@@ -97,6 +102,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION": "linux",
 				"VELA_BUILD_ENQUEUED":     "1563474077",
 				"VELA_BUILD_EVENT":        "push",
+				"VELA_BUILD_EVENT_ACTION": "push",
 				"VELA_BUILD_HOST":         "example.company.com",
 				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":      "First commit...",
@@ -148,6 +154,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":   "linux",
 				"VELA_BUILD_ENQUEUED":       "1563474077",
 				"VELA_BUILD_EVENT":          "comment",
+				"VELA_BUILD_EVENT_ACTION":   "comment:created",
 				"VELA_BUILD_HOST":           "example.company.com",
 				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":        "First commit...",
@@ -202,6 +209,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":  "linux",
 				"VELA_BUILD_ENQUEUED":      "1563474077",
 				"VELA_BUILD_EVENT":         "deployment",
+				"VELA_BUILD_EVENT_ACTION":  "deployment",
 				"VELA_BUILD_HOST":          "example.company.com",
 				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":       "First commit...",
@@ -258,6 +266,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":  "linux",
 				"VELA_BUILD_ENQUEUED":      "1563474077",
 				"VELA_BUILD_EVENT":         "deployment",
+				"VELA_BUILD_EVENT_ACTION":  "deployment",
 				"VELA_BUILD_HOST":          "example.company.com",
 				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":       "First commit...",
@@ -316,6 +325,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":   "linux",
 				"VELA_BUILD_ENQUEUED":       "1563474077",
 				"VELA_BUILD_EVENT":          "pull_request",
+				"VELA_BUILD_EVENT_ACTION":   "pull_request:opened",
 				"VELA_BUILD_HOST":           "example.company.com",
 				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":        "First commit...",
@@ -372,6 +382,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION": "linux",
 				"VELA_BUILD_ENQUEUED":     "1563474077",
 				"VELA_BUILD_EVENT":        "tag",
+				"VELA_BUILD_EVENT_ACTION": "tag",
 				"VELA_BUILD_HOST":         "example.company.com",
 				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":      "First commit...",
@@ -463,6 +474,10 @@ func TestLibrary_Build_Getters(t *testing.T) {
 
 		if test.build.GetEvent() != test.want.GetEvent() {
 			t.Errorf("GetEvent is %v, want %v", test.build.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.build.GetEventAction() != test.want.GetEventAction() {
+			t.Errorf("GetEventAction is %v, want %v", test.build.GetEventAction(), test.want.GetEventAction())
 		}
 
 		if test.build.GetStatus() != test.want.GetStatus() {
@@ -590,6 +605,7 @@ func TestLibrary_Build_Setters(t *testing.T) {
 		test.build.SetNumber(test.want.GetNumber())
 		test.build.SetParent(test.want.GetParent())
 		test.build.SetEvent(test.want.GetEvent())
+		test.build.SetEventAction(test.want.GetEventAction())
 		test.build.SetStatus(test.want.GetStatus())
 		test.build.SetError(test.want.GetError())
 		test.build.SetEnqueued(test.want.GetEnqueued())
@@ -637,6 +653,10 @@ func TestLibrary_Build_Setters(t *testing.T) {
 
 		if test.build.GetEvent() != test.want.GetEvent() {
 			t.Errorf("SetEvent is %v, want %v", test.build.GetEvent(), test.want.GetEvent())
+		}
+
+		if test.build.GetEventAction() != test.want.GetEventAction() {
+			t.Errorf("SetEventAction is %v, want %v", test.build.GetEventAction(), test.want.GetEventAction())
 		}
 
 		if test.build.GetStatus() != test.want.GetStatus() {
@@ -755,6 +775,7 @@ func TestLibrary_Build_String(t *testing.T) {
   Enqueued: %d,
   Error: %s,
   Event: %s,
+  EventAction: %s,
   Finished: %d,
   HeadRef: %s,
   Host: %s,
@@ -786,6 +807,7 @@ func TestLibrary_Build_String(t *testing.T) {
 		b.GetEnqueued(),
 		b.GetError(),
 		b.GetEvent(),
+		b.GetEventAction(),
 		b.GetFinished(),
 		b.GetHeadRef(),
 		b.GetHost(),
@@ -824,6 +846,7 @@ func testBuild() *Build {
 	b.SetNumber(1)
 	b.SetParent(1)
 	b.SetEvent("push")
+	b.SetEventAction("push")
 	b.SetStatus("running")
 	b.SetError("")
 	b.SetEnqueued(1563474077)

--- a/library/build_test.go
+++ b/library/build_test.go
@@ -51,12 +51,11 @@ func TestLibrary_Build_Environment(t *testing.T) {
 	// setup types
 	_comment := testBuild()
 	_comment.SetEvent("comment")
-	_comment.SetEventAction("comment:created")
+	_comment.SetEventAction("created")
 	_comment.SetRef("refs/pulls/1/head")
 
 	_deploy := testBuild()
 	_deploy.SetEvent("deployment")
-	_deploy.SetEventAction("deployment")
 	_deploy.SetDeploy("production")
 	_deploy.SetDeployPayload(map[string]string{
 		"foo": "test1",
@@ -66,7 +65,6 @@ func TestLibrary_Build_Environment(t *testing.T) {
 	_deployTag := testBuild()
 	_deployTag.SetRef("refs/tags/v0.1.0")
 	_deployTag.SetEvent("deployment")
-	_deployTag.SetEventAction("deployment")
 	_deployTag.SetDeploy("production")
 	_deployTag.SetDeployPayload(map[string]string{
 		"foo": "test1",
@@ -75,12 +73,11 @@ func TestLibrary_Build_Environment(t *testing.T) {
 
 	_pull := testBuild()
 	_pull.SetEvent("pull_request")
-	_pull.SetEventAction("pull_request:opened")
+	_pull.SetEventAction("opened")
 	_pull.SetRef("refs/pulls/1/head")
 
 	_tag := testBuild()
 	_tag.SetEvent("tag")
-	_tag.SetEventAction("tag")
 	_tag.SetRef("refs/tags/v0.1.0")
 
 	// setup tests
@@ -102,7 +99,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION": "linux",
 				"VELA_BUILD_ENQUEUED":     "1563474077",
 				"VELA_BUILD_EVENT":        "push",
-				"VELA_BUILD_EVENT_ACTION": "push",
+				"VELA_BUILD_EVENT_ACTION": "",
 				"VELA_BUILD_HOST":         "example.company.com",
 				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":      "First commit...",
@@ -154,7 +151,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":   "linux",
 				"VELA_BUILD_ENQUEUED":       "1563474077",
 				"VELA_BUILD_EVENT":          "comment",
-				"VELA_BUILD_EVENT_ACTION":   "comment:created",
+				"VELA_BUILD_EVENT_ACTION":   "created",
 				"VELA_BUILD_HOST":           "example.company.com",
 				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":        "First commit...",
@@ -209,7 +206,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":  "linux",
 				"VELA_BUILD_ENQUEUED":      "1563474077",
 				"VELA_BUILD_EVENT":         "deployment",
-				"VELA_BUILD_EVENT_ACTION":  "deployment",
+				"VELA_BUILD_EVENT_ACTION":  "",
 				"VELA_BUILD_HOST":          "example.company.com",
 				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":       "First commit...",
@@ -266,7 +263,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":  "linux",
 				"VELA_BUILD_ENQUEUED":      "1563474077",
 				"VELA_BUILD_EVENT":         "deployment",
-				"VELA_BUILD_EVENT_ACTION":  "deployment",
+				"VELA_BUILD_EVENT_ACTION":  "",
 				"VELA_BUILD_HOST":          "example.company.com",
 				"VELA_BUILD_LINK":          "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":       "First commit...",
@@ -325,7 +322,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION":   "linux",
 				"VELA_BUILD_ENQUEUED":       "1563474077",
 				"VELA_BUILD_EVENT":          "pull_request",
-				"VELA_BUILD_EVENT_ACTION":   "pull_request:opened",
+				"VELA_BUILD_EVENT_ACTION":   "opened",
 				"VELA_BUILD_HOST":           "example.company.com",
 				"VELA_BUILD_LINK":           "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":        "First commit...",
@@ -382,7 +379,7 @@ func TestLibrary_Build_Environment(t *testing.T) {
 				"VELA_BUILD_DISTRIBUTION": "linux",
 				"VELA_BUILD_ENQUEUED":     "1563474077",
 				"VELA_BUILD_EVENT":        "tag",
-				"VELA_BUILD_EVENT_ACTION": "tag",
+				"VELA_BUILD_EVENT_ACTION": "",
 				"VELA_BUILD_HOST":         "example.company.com",
 				"VELA_BUILD_LINK":         "https://example.company.com/github/octocat/1",
 				"VELA_BUILD_MESSAGE":      "First commit...",
@@ -846,7 +843,6 @@ func testBuild() *Build {
 	b.SetNumber(1)
 	b.SetParent(1)
 	b.SetEvent("push")
-	b.SetEventAction("push")
 	b.SetStatus("running")
 	b.SetError("")
 	b.SetEnqueued(1563474077)

--- a/library/secret.go
+++ b/library/secret.go
@@ -70,7 +70,7 @@ func (s *Secret) Match(from *pipeline.Container) bool {
 	}
 
 	// check incoming events
-	switch strings.Split(from.Environment["BUILD_EVENT"], ":")[0] {
+	switch from.Environment["BUILD_EVENT"] {
 	case constants.EventPush:
 		eACL = checkEvent(events, constants.EventPush)
 	case constants.EventPull:
@@ -508,7 +508,7 @@ func (s *Secret) String() string {
 // a list to check the event is a member of the list.
 func checkEvent(events []string, event string) bool {
 	for _, e := range events {
-		if strings.Split(e, ":")[0] == event {
+		if e == event {
 			return true
 		}
 	}

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -149,7 +149,7 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		for _, e := range rules.Event {
 			switch e {
 			// backwards compatibility - pull_request = pull_request:opened + pull_request:synchronized
-			//                           comment = comment:created + comment:edited
+			// comment = comment:created + comment:edited
 			case constants.EventPull:
 				events = append(events,
 					constants.EventPull+":"+constants.ActionOpened,

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -149,10 +149,15 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		for _, e := range rules.Event {
 			switch e {
 			// backwards compatibility - pull_request = pull_request:opened + pull_request:synchronized
+			//                           comment = comment:created + comment:edited
 			case constants.EventPull:
 				events = append(events,
 					constants.EventPull+":"+constants.ActionOpened,
 					constants.EventPull+":"+constants.ActionSynchronized)
+			case constants.EventComment:
+				events = append(events,
+					constants.EventComment+":"+constants.ActionCreated,
+					constants.EventComment+":"+constants.ActionEdited)
 			default:
 				events = append(events, e)
 			}

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -116,7 +116,7 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
 				},
 				Unless: Rules{
-					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronized"},
+					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronized", "comment:created", "comment:edited"},
 					Path:  []string{"foo.txt", "/foo/bar.txt"},
 				},
 				Matcher:  "regexp",

--- a/yaml/testdata/ruleset_advanced.yml
+++ b/yaml/testdata/ruleset_advanced.yml
@@ -7,6 +7,7 @@ unless:
   event:
     - deployment
     - pull_request
+    - comment
   path: [ foo.txt, /foo/bar.txt ]
 matcher: regexp
 operator: or


### PR DESCRIPTION
I was noticing an issue with [my first iteration on this](https://github.com/go-vela/types/pull/236). In order to execute a step, it must pass [the purge process](https://github.com/go-vela/types/blob/abb9e3afc4bd429783c6805c051e85aa58b93652/pipeline/container.go#L60) and [the skip process](https://github.com/go-vela/worker/blob/151849034f86575046422c1407d33fc1aafa13b1/internal/step/skip.go#L18). In order to respect scoped events (`pull_request:opened` for example), I needed to change the `build.Event` value to that [here](https://github.com/go-vela/server/blob/ccfff2af42eea4abeceac8ac3d5b93790b3ef300/scm/github/webhook.go#L208). This is not ideal. Not only does it require splitting logic all over to respect various event gatekeeping, it also changes the environment variable `VELA_BUILD_EVENT`, which is used by many end users. 

To get around this, I decided to add a new field, `EventAction` (open to new name suggestions). This lays the ground work for future event action handling (such as PR review events). It also makes handling comment event scoping seamless, which I've also added to this PR. 

The obvious drawback to this method is two fold:
1) another column in the database
2) that column will be a duplicate of the `event` column for `push`, `deploy`, and `tag` events. 

Another strategy here would be to change `EventAction` to `Action`, and handle the events without actions as `nil`. I chose the more verbose option for now but am more than willing to pursue that route instead if we wanted. 