### PR TITLE
fix(hook): clean up old repo rename code by adding action field to hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 *.ipr
 *.iws
 *.xml
+
+# VSCode project folder
+.vscode/

--- a/constants/action.go
+++ b/constants/action.go
@@ -15,6 +15,9 @@ const (
 	// ActionEdited defines the action for the editing of pull requests or issue comments.
 	ActionEdited = "edited"
 
+	// ActionRenamed defines the action for renaming a repository.
+	ActionRenamed = "renamed"
+
 	// ActionSynchronized defines the action for the synchronizing of pull requests.
 	ActionSynchronized = "synchronized"
 )

--- a/constants/event.go
+++ b/constants/event.go
@@ -21,9 +21,6 @@ const (
 	// EventComment defines the event type for comments added to a pull request.
 	EventComment = "comment"
 
-	// EventRepositoryRename defines the event type for a repo being renamed.
-	EventRepositoryRename = "repositoryRename"
-
 	// EventRepository defines the general event type for repo management.
 	EventRepository = "repository"
 )

--- a/database/hook.go
+++ b/database/hook.go
@@ -31,19 +31,20 @@ var (
 
 // Hook is the database representation of a webhook for a repo.
 type Hook struct {
-	ID        sql.NullInt64  `sql:"id"`
-	RepoID    sql.NullInt64  `sql:"repo_id"`
-	BuildID   sql.NullInt64  `sql:"build_id"`
-	Number    sql.NullInt32  `sql:"number"`
-	SourceID  sql.NullString `sql:"source_id"`
-	Created   sql.NullInt64  `sql:"created"`
-	Host      sql.NullString `sql:"host"`
-	Event     sql.NullString `sql:"event"`
-	Branch    sql.NullString `sql:"branch"`
-	Error     sql.NullString `sql:"error"`
-	Status    sql.NullString `sql:"status"`
-	Link      sql.NullString `sql:"link"`
-	WebhookID sql.NullInt64  `sql:"webhook_id"`
+	ID          sql.NullInt64  `sql:"id"`
+	RepoID      sql.NullInt64  `sql:"repo_id"`
+	BuildID     sql.NullInt64  `sql:"build_id"`
+	Number      sql.NullInt32  `sql:"number"`
+	SourceID    sql.NullString `sql:"source_id"`
+	Created     sql.NullInt64  `sql:"created"`
+	Host        sql.NullString `sql:"host"`
+	Event       sql.NullString `sql:"event"`
+	EventAction sql.NullString `sql:"event_action"`
+	Branch      sql.NullString `sql:"branch"`
+	Error       sql.NullString `sql:"error"`
+	Status      sql.NullString `sql:"status"`
+	Link        sql.NullString `sql:"link"`
+	WebhookID   sql.NullInt64  `sql:"webhook_id"`
 }
 
 // Nullify ensures the valid flag for
@@ -97,6 +98,11 @@ func (h *Hook) Nullify() *Hook {
 		h.Event.Valid = false
 	}
 
+	// check if the EventAction field should be false
+	if len(h.EventAction.String) == 0 {
+		h.EventAction.Valid = false
+	}
+
 	// check if the Branch field should be false
 	if len(h.Branch.String) == 0 {
 		h.Branch.Valid = false
@@ -138,6 +144,7 @@ func (h *Hook) ToLibrary() *library.Hook {
 	hook.SetCreated(h.Created.Int64)
 	hook.SetHost(h.Host.String)
 	hook.SetEvent(h.Event.String)
+	hook.SetEventAction(h.EventAction.String)
 	hook.SetBranch(h.Branch.String)
 	hook.SetError(h.Error.String)
 	hook.SetStatus(h.Status.String)
@@ -176,6 +183,7 @@ func (h *Hook) Validate() error {
 	h.SourceID = sql.NullString{String: sanitize(h.SourceID.String), Valid: h.SourceID.Valid}
 	h.Host = sql.NullString{String: sanitize(h.Host.String), Valid: h.Host.Valid}
 	h.Event = sql.NullString{String: sanitize(h.Event.String), Valid: h.Event.Valid}
+	h.EventAction = sql.NullString{String: sanitize(h.EventAction.String), Valid: h.EventAction.Valid}
 	h.Branch = sql.NullString{String: sanitize(h.Branch.String), Valid: h.Branch.Valid}
 	h.Error = sql.NullString{String: sanitize(h.Error.String), Valid: h.Error.Valid}
 	h.Status = sql.NullString{String: sanitize(h.Status.String), Valid: h.Status.Valid}
@@ -188,19 +196,20 @@ func (h *Hook) Validate() error {
 // to a library Hook type.
 func HookFromLibrary(h *library.Hook) *Hook {
 	hook := &Hook{
-		ID:        sql.NullInt64{Int64: h.GetID(), Valid: true},
-		RepoID:    sql.NullInt64{Int64: h.GetRepoID(), Valid: true},
-		BuildID:   sql.NullInt64{Int64: h.GetBuildID(), Valid: true},
-		Number:    sql.NullInt32{Int32: int32(h.GetNumber()), Valid: true},
-		SourceID:  sql.NullString{String: h.GetSourceID(), Valid: true},
-		Created:   sql.NullInt64{Int64: h.GetCreated(), Valid: true},
-		Host:      sql.NullString{String: h.GetHost(), Valid: true},
-		Event:     sql.NullString{String: h.GetEvent(), Valid: true},
-		Branch:    sql.NullString{String: h.GetBranch(), Valid: true},
-		Error:     sql.NullString{String: h.GetError(), Valid: true},
-		Status:    sql.NullString{String: h.GetStatus(), Valid: true},
-		Link:      sql.NullString{String: h.GetLink(), Valid: true},
-		WebhookID: sql.NullInt64{Int64: h.GetWebhookID(), Valid: true},
+		ID:          sql.NullInt64{Int64: h.GetID(), Valid: true},
+		RepoID:      sql.NullInt64{Int64: h.GetRepoID(), Valid: true},
+		BuildID:     sql.NullInt64{Int64: h.GetBuildID(), Valid: true},
+		Number:      sql.NullInt32{Int32: int32(h.GetNumber()), Valid: true},
+		SourceID:    sql.NullString{String: h.GetSourceID(), Valid: true},
+		Created:     sql.NullInt64{Int64: h.GetCreated(), Valid: true},
+		Host:        sql.NullString{String: h.GetHost(), Valid: true},
+		Event:       sql.NullString{String: h.GetEvent(), Valid: true},
+		EventAction: sql.NullString{String: h.GetEventAction(), Valid: true},
+		Branch:      sql.NullString{String: h.GetBranch(), Valid: true},
+		Error:       sql.NullString{String: h.GetError(), Valid: true},
+		Status:      sql.NullString{String: h.GetStatus(), Valid: true},
+		Link:        sql.NullString{String: h.GetLink(), Valid: true},
+		WebhookID:   sql.NullInt64{Int64: h.GetWebhookID(), Valid: true},
 	}
 
 	return hook.Nullify()

--- a/database/hook_test.go
+++ b/database/hook_test.go
@@ -18,19 +18,20 @@ func TestDatabase_Hook_Nullify(t *testing.T) {
 	var h *Hook
 
 	want := &Hook{
-		ID:        sql.NullInt64{Int64: 0, Valid: false},
-		RepoID:    sql.NullInt64{Int64: 0, Valid: false},
-		BuildID:   sql.NullInt64{Int64: 0, Valid: false},
-		Number:    sql.NullInt32{Int32: 0, Valid: false},
-		SourceID:  sql.NullString{String: "", Valid: false},
-		Created:   sql.NullInt64{Int64: 0, Valid: false},
-		Host:      sql.NullString{String: "", Valid: false},
-		Event:     sql.NullString{String: "", Valid: false},
-		Branch:    sql.NullString{String: "", Valid: false},
-		Error:     sql.NullString{String: "", Valid: false},
-		Status:    sql.NullString{String: "", Valid: false},
-		Link:      sql.NullString{String: "", Valid: false},
-		WebhookID: sql.NullInt64{Int64: 0, Valid: false},
+		ID:          sql.NullInt64{Int64: 0, Valid: false},
+		RepoID:      sql.NullInt64{Int64: 0, Valid: false},
+		BuildID:     sql.NullInt64{Int64: 0, Valid: false},
+		Number:      sql.NullInt32{Int32: 0, Valid: false},
+		SourceID:    sql.NullString{String: "", Valid: false},
+		Created:     sql.NullInt64{Int64: 0, Valid: false},
+		Host:        sql.NullString{String: "", Valid: false},
+		Event:       sql.NullString{String: "", Valid: false},
+		EventAction: sql.NullString{String: "", Valid: false},
+		Branch:      sql.NullString{String: "", Valid: false},
+		Error:       sql.NullString{String: "", Valid: false},
+		Status:      sql.NullString{String: "", Valid: false},
+		Link:        sql.NullString{String: "", Valid: false},
+		WebhookID:   sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -73,6 +74,7 @@ func TestDatabase_Hook_ToLibrary(t *testing.T) {
 	want.SetCreated(time.Now().UTC().Unix())
 	want.SetHost("github.com")
 	want.SetEvent("push")
+	want.SetEventAction("")
 	want.SetBranch("master")
 	want.SetError("")
 	want.SetStatus("success")
@@ -80,19 +82,20 @@ func TestDatabase_Hook_ToLibrary(t *testing.T) {
 	want.SetWebhookID(123456)
 
 	h := &Hook{
-		ID:        sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
-		Number:    sql.NullInt32{Int32: 1, Valid: true},
-		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:      sql.NullString{String: "github.com", Valid: true},
-		Event:     sql.NullString{String: "push", Valid: true},
-		Branch:    sql.NullString{String: "master", Valid: true},
-		Error:     sql.NullString{String: "", Valid: true},
-		Status:    sql.NullString{String: "success", Valid: true},
-		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
+		ID:          sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:      sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:     sql.NullInt64{Int64: 1, Valid: true},
+		Number:      sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:    sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:     sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:        sql.NullString{String: "github.com", Valid: true},
+		Event:       sql.NullString{String: "push", Valid: true},
+		EventAction: sql.NullString{String: "", Valid: true},
+		Branch:      sql.NullString{String: "master", Valid: true},
+		Error:       sql.NullString{String: "", Valid: true},
+		Status:      sql.NullString{String: "success", Valid: true},
+		Link:        sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID:   sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	// run test
@@ -172,19 +175,20 @@ func TestDatabase_Hook_Validate(t *testing.T) {
 func TestDatabase_HookFromLibrary(t *testing.T) {
 	// setup types
 	want := &Hook{
-		ID:        sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
-		Number:    sql.NullInt32{Int32: 1, Valid: true},
-		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:      sql.NullString{String: "github.com", Valid: true},
-		Event:     sql.NullString{String: "push", Valid: true},
-		Branch:    sql.NullString{String: "master", Valid: true},
-		Error:     sql.NullString{String: "", Valid: false},
-		Status:    sql.NullString{String: "success", Valid: true},
-		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
+		ID:          sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:      sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:     sql.NullInt64{Int64: 1, Valid: true},
+		Number:      sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:    sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:     sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:        sql.NullString{String: "github.com", Valid: true},
+		Event:       sql.NullString{String: "pull_request", Valid: true},
+		EventAction: sql.NullString{String: "opened", Valid: true},
+		Branch:      sql.NullString{String: "master", Valid: true},
+		Error:       sql.NullString{String: "", Valid: false},
+		Status:      sql.NullString{String: "success", Valid: true},
+		Link:        sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID:   sql.NullInt64{Int64: 123456, Valid: true},
 	}
 
 	h := new(library.Hook)
@@ -195,7 +199,8 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 	h.SetSourceID("c8da1302-07d6-11ea-882f-4893bca275b8")
 	h.SetCreated(time.Now().UTC().Unix())
 	h.SetHost("github.com")
-	h.SetEvent("push")
+	h.SetEvent("pull_request")
+	h.SetEventAction("opened")
 	h.SetBranch("master")
 	h.SetError("")
 	h.SetStatus("success")
@@ -214,18 +219,19 @@ func TestDatabase_HookFromLibrary(t *testing.T) {
 // type with all fields set to a fake value.
 func testHook() *Hook {
 	return &Hook{
-		ID:        sql.NullInt64{Int64: 1, Valid: true},
-		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
-		BuildID:   sql.NullInt64{Int64: 1, Valid: true},
-		Number:    sql.NullInt32{Int32: 1, Valid: true},
-		SourceID:  sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
-		Created:   sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
-		Host:      sql.NullString{String: "github.com", Valid: true},
-		Event:     sql.NullString{String: "push", Valid: true},
-		Branch:    sql.NullString{String: "master", Valid: true},
-		Error:     sql.NullString{String: "", Valid: false},
-		Status:    sql.NullString{String: "success", Valid: true},
-		Link:      sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
-		WebhookID: sql.NullInt64{Int64: 123456, Valid: true},
+		ID:          sql.NullInt64{Int64: 1, Valid: true},
+		RepoID:      sql.NullInt64{Int64: 1, Valid: true},
+		BuildID:     sql.NullInt64{Int64: 1, Valid: true},
+		Number:      sql.NullInt32{Int32: 1, Valid: true},
+		SourceID:    sql.NullString{String: "c8da1302-07d6-11ea-882f-4893bca275b8", Valid: true},
+		Created:     sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
+		Host:        sql.NullString{String: "github.com", Valid: true},
+		Event:       sql.NullString{String: "push", Valid: true},
+		EventAction: sql.NullString{String: "", Valid: true},
+		Branch:      sql.NullString{String: "master", Valid: true},
+		Error:       sql.NullString{String: "", Valid: false},
+		Status:      sql.NullString{String: "success", Valid: true},
+		Link:        sql.NullString{String: "https://github.com/github/octocat/settings/hooks/1", Valid: true},
+		WebhookID:   sql.NullInt64{Int64: 123456, Valid: true},
 	}
 }

--- a/database/hook_test.go
+++ b/database/hook_test.go
@@ -227,7 +227,7 @@ func testHook() *Hook {
 		Created:     sql.NullInt64{Int64: time.Now().UTC().Unix(), Valid: true},
 		Host:        sql.NullString{String: "github.com", Valid: true},
 		Event:       sql.NullString{String: "push", Valid: true},
-		EventAction: sql.NullString{String: "", Valid: true},
+		EventAction: sql.NullString{String: "", Valid: false},
 		Branch:      sql.NullString{String: "master", Valid: true},
 		Error:       sql.NullString{String: "", Valid: false},
 		Status:      sql.NullString{String: "success", Valid: true},

--- a/library/hook.go
+++ b/library/hook.go
@@ -12,19 +12,20 @@ import (
 //
 // swagger:model Webhook
 type Hook struct {
-	ID        *int64  `json:"id,omitempty"`
-	RepoID    *int64  `json:"repo_id,omitempty"`
-	BuildID   *int64  `json:"build_id,omitempty"`
-	Number    *int    `json:"number,omitempty"`
-	SourceID  *string `json:"source_id,omitempty"`
-	Created   *int64  `json:"created,omitempty"`
-	Host      *string `json:"host,omitempty"`
-	Event     *string `json:"event,omitempty"`
-	Branch    *string `json:"branch,omitempty"`
-	Error     *string `json:"error,omitempty"`
-	Status    *string `json:"status,omitempty"`
-	Link      *string `json:"link,omitempty"`
-	WebhookID *int64  `json:"webhook_id,omitempty"`
+	ID          *int64  `json:"id,omitempty"`
+	RepoID      *int64  `json:"repo_id,omitempty"`
+	BuildID     *int64  `json:"build_id,omitempty"`
+	Number      *int    `json:"number,omitempty"`
+	SourceID    *string `json:"source_id,omitempty"`
+	Created     *int64  `json:"created,omitempty"`
+	Host        *string `json:"host,omitempty"`
+	Event       *string `json:"event,omitempty"`
+	EventAction *string `json:"event_action,omitempty"`
+	Branch      *string `json:"branch,omitempty"`
+	Error       *string `json:"error,omitempty"`
+	Status      *string `json:"status,omitempty"`
+	Link        *string `json:"link,omitempty"`
+	WebhookID   *int64  `json:"webhook_id,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -129,6 +130,19 @@ func (h *Hook) GetEvent() string {
 	}
 
 	return *h.Event
+}
+
+// GetEventAction returns the EventAction field.
+//
+// When the provided Hook type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (h *Hook) GetEventAction() string {
+	// return zero value if Hook type or EventAction field is nil
+	if h == nil || h.EventAction == nil {
+		return ""
+	}
+
+	return *h.EventAction
 }
 
 // GetBranch returns the Branch field.
@@ -300,6 +314,19 @@ func (h *Hook) SetEvent(v string) {
 	h.Event = &v
 }
 
+// SetEventAction sets the EventAction field.
+//
+// When the provided Hook type is nil, it
+// will set nothing and immediately return.
+func (h *Hook) SetEventAction(v string) {
+	// return if Hook type is nil
+	if h == nil {
+		return
+	}
+
+	h.EventAction = &v
+}
+
 // SetBranch sets the Branch field.
 //
 // When the provided Hook type is nil, it
@@ -373,6 +400,7 @@ func (h *Hook) String() string {
   Created: %d,
   Error: %s,
   Event: %s,
+  EventAction: %s,
   Host: %s,
   ID: %d,
   Link: %s,
@@ -387,6 +415,7 @@ func (h *Hook) String() string {
 		h.GetCreated(),
 		h.GetError(),
 		h.GetEvent(),
+		h.GetEventAction(),
 		h.GetHost(),
 		h.GetID(),
 		h.GetLink(),

--- a/library/hook_test.go
+++ b/library/hook_test.go
@@ -61,6 +61,10 @@ func TestLibrary_Hook_Getters(t *testing.T) {
 			t.Errorf("GetEvent is %v, want %v", test.hook.GetEvent(), test.want.GetEvent())
 		}
 
+		if test.hook.GetEventAction() != test.want.GetEventAction() {
+			t.Errorf("GetEventAction is %v, want %v", test.hook.GetEventAction(), test.want.GetEventAction())
+		}
+
 		if test.hook.GetBranch() != test.want.GetBranch() {
 			t.Errorf("GetBranch is %v, want %v", test.hook.GetBranch(), test.want.GetBranch())
 		}
@@ -112,6 +116,7 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 		test.hook.SetCreated(test.want.GetCreated())
 		test.hook.SetHost(test.want.GetHost())
 		test.hook.SetEvent(test.want.GetEvent())
+		test.hook.SetEventAction(test.want.GetEventAction())
 		test.hook.SetBranch(test.want.GetBranch())
 		test.hook.SetError(test.want.GetError())
 		test.hook.SetStatus(test.want.GetStatus())
@@ -150,6 +155,10 @@ func TestLibrary_Hook_Setters(t *testing.T) {
 			t.Errorf("SetEvent is %v, want %v", test.hook.GetEvent(), test.want.GetEvent())
 		}
 
+		if test.hook.GetEventAction() != test.want.GetEventAction() {
+			t.Errorf("SetEventAction is %v, want %v", test.hook.GetEventAction(), test.want.GetEventAction())
+		}
+
 		if test.hook.GetBranch() != test.want.GetBranch() {
 			t.Errorf("SetBranch is %v, want %v", test.hook.GetBranch(), test.want.GetBranch())
 		}
@@ -182,6 +191,7 @@ func TestLibrary_Hook_String(t *testing.T) {
   Created: %d,
   Error: %s,
   Event: %s,
+  EventAction: %s,
   Host: %s,
   ID: %d,
   Link: %s,
@@ -196,6 +206,7 @@ func TestLibrary_Hook_String(t *testing.T) {
 		h.GetCreated(),
 		h.GetError(),
 		h.GetEvent(),
+		h.GetEventAction(),
 		h.GetHost(),
 		h.GetID(),
 		h.GetLink(),
@@ -227,6 +238,7 @@ func testHook() *Hook {
 	h.SetCreated(time.Now().UTC().Unix())
 	h.SetHost("github.com")
 	h.SetEvent("push")
+	h.SetEventAction("")
 	h.SetBranch("master")
 	h.SetError("")
 	h.SetStatus("success")


### PR DESCRIPTION
Context: there have been some errors related to repository events not being processed correctly by the webhook endpoint. This led me to look over the [renaming a repository code](https://github.com/go-vela/server/pull/556). The fix for the errors can be handled in the server code, but what caught my eye was the fact that I chose to override the `hook.Event` field to be a custom `renameRepository` hard-coded string. With the [new scoped ruleset support](https://github.com/go-vela/server/pull/630), I think it would be consistent to mirror `build.Event` and `build.EventAction` with `hook.Event` and `hook.EventAction`. 

Also random, but VSCode tried to include a project folder in the commit, so I added that to the `.gitignore`.