### PR TITLE
fix(log): add = to secret mask

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@
 *.ipr
 *.iws
 *.xml
+
+# VSCode project folder
+.vscode/

--- a/library/log.go
+++ b/library/log.go
@@ -56,7 +56,7 @@ func (l *Log) MaskData(secrets []string) {
 		// create regexp to match secrets in the log data surrounded by regexp metacharacters
 		//
 		// https://pkg.go.dev/regexp#MustCompile
-		re := regexp.MustCompile((`(\s|^|"|:|'|\.|,)` + escaped + `(\s|$|"|:|'|\.|,)`))
+		re := regexp.MustCompile((`(\s|^|=|"|:|'|\.|,)` + escaped + `(\s|$|"|:|'|\.|,)`))
 
 		// create a mask for the secret
 		mask := fmt.Sprintf("$1%s$2", constants.SecretLogMask)


### PR DESCRIPTION
If a user were to run `printenv`, since we add secrets to the environment, and the printing of the environment is of the style `key=value` with no space, secrets can be printed using that. Further, not including `=` in the pre-secret mask seems like a pretty large oversight.