### PR TITLE
feat(worker): add last repo and last build fields

### DIFF
--- a/database/worker.go
+++ b/database/worker.go
@@ -31,6 +31,8 @@ type Worker struct {
 	Active        sql.NullBool   `sql:"active"`
 	LastCheckedIn sql.NullInt64  `sql:"last_checked_in"`
 	BuildLimit    sql.NullInt64  `sql:"build_limit"`
+	LastRepo      sql.NullString `sql:"last_repo"`
+	LastBuildID   sql.NullInt64  `sql:"last_build_id"`
 }
 
 // Nullify ensures the valid flag for
@@ -64,8 +66,19 @@ func (w *Worker) Nullify() *Worker {
 		w.LastCheckedIn.Valid = false
 	}
 
+	// check if the BuildLimit field should be false
 	if w.BuildLimit.Int64 == 0 {
 		w.BuildLimit.Valid = false
+	}
+
+	// check if the LastRepo field should be false
+	if len(w.LastRepo.String) == 0 {
+		w.LastRepo.Valid = false
+	}
+
+	// check if the LastBuildID field should be false
+	if w.LastBuildID.Int64 == 0 {
+		w.LastBuildID.Valid = false
 	}
 
 	return w
@@ -83,6 +96,8 @@ func (w *Worker) ToLibrary() *library.Worker {
 	worker.SetActive(w.Active.Bool)
 	worker.SetLastCheckedIn(w.LastCheckedIn.Int64)
 	worker.SetBuildLimit(w.BuildLimit.Int64)
+	worker.SetLastRepo(w.LastRepo.String)
+	worker.SetLastBuildID(w.LastBuildID.Int64)
 
 	return worker
 }
@@ -126,6 +141,8 @@ func WorkerFromLibrary(w *library.Worker) *Worker {
 		Active:        sql.NullBool{Bool: w.GetActive(), Valid: true},
 		LastCheckedIn: sql.NullInt64{Int64: w.GetLastCheckedIn(), Valid: true},
 		BuildLimit:    sql.NullInt64{Int64: w.GetBuildLimit(), Valid: true},
+		LastRepo:      sql.NullString{String: w.GetLastRepo(), Valid: true},
+		LastBuildID:   sql.NullInt64{Int64: w.GetLastBuildID(), Valid: true},
 	}
 
 	return worker.Nullify()

--- a/database/worker_test.go
+++ b/database/worker_test.go
@@ -23,6 +23,8 @@ func TestDatabase_Worker_Nullify(t *testing.T) {
 		Active:        sql.NullBool{Bool: false, Valid: false},
 		LastCheckedIn: sql.NullInt64{Int64: 0, Valid: false},
 		BuildLimit:    sql.NullInt64{Int64: 0, Valid: false},
+		LastRepo:      sql.NullString{String: "", Valid: false},
+		LastBuildID:   sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -65,6 +67,8 @@ func TestDatabase_Worker_ToLibrary(t *testing.T) {
 	want.SetActive(true)
 	want.SetLastCheckedIn(1563474077)
 	want.SetBuildLimit(2)
+	want.SetLastRepo("org/repo")
+	want.SetLastBuildID(1)
 
 	// run test
 	got := testWorker().ToLibrary()
@@ -133,6 +137,8 @@ func TestDatabase_WorkerFromLibrary(t *testing.T) {
 	w.SetActive(true)
 	w.SetLastCheckedIn(1563474077)
 	w.SetBuildLimit(2)
+	w.SetLastRepo("org/repo")
+	w.SetLastBuildID(1)
 
 	want := testWorker()
 
@@ -155,5 +161,7 @@ func testWorker() *Worker {
 		Active:        sql.NullBool{Bool: true, Valid: true},
 		LastCheckedIn: sql.NullInt64{Int64: 1563474077, Valid: true},
 		BuildLimit:    sql.NullInt64{Int64: 2, Valid: true},
+		LastRepo:      sql.NullString{String: "org/repo", Valid: true},
+		LastBuildID:   sql.NullInt64{Int64: 1, Valid: true},
 	}
 }

--- a/library/worker.go
+++ b/library/worker.go
@@ -19,6 +19,8 @@ type Worker struct {
 	Active        *bool     `json:"active,omitempty"`
 	LastCheckedIn *int64    `json:"last_checked_in,omitempty"`
 	BuildLimit    *int64    `json:"build_limit,omitempty"`
+	LastRepo      *string   `json:"last_repo,omitempty"`
+	LastBuildID   *int64    `json:"last_build_id,omitempty"`
 }
 
 // GetID returns the ID field.
@@ -112,6 +114,32 @@ func (w *Worker) GetBuildLimit() int64 {
 	return *w.BuildLimit
 }
 
+// GetLastRepo returns the LastRepo field.
+//
+// When the provided Worker type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (w *Worker) GetLastRepo() string {
+	// return zero value if Worker type or LastRepo field is nil
+	if w == nil || w.LastBuildID == nil {
+		return ""
+	}
+
+	return *w.LastRepo
+}
+
+// GetLastBuildID returns the LastBuildID field.
+//
+// When the provided Worker type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (w *Worker) GetLastBuildID() int64 {
+	// return zero value if Worker type or BuildLimit field is nil
+	if w == nil || w.LastBuildID == nil {
+		return 0
+	}
+
+	return *w.LastBuildID
+}
+
 // SetID sets the ID field.
 //
 // When the provided Worker type is nil, it
@@ -190,7 +218,7 @@ func (w *Worker) SetLastCheckedIn(v int64) {
 	w.LastCheckedIn = &v
 }
 
-// SetBuildLimit sets the LastBuildLimit field.
+// SetBuildLimit sets the BuildLimit field.
 //
 // When the provided Worker type is nil, it
 // will set nothing and immediately return.
@@ -203,6 +231,32 @@ func (w *Worker) SetBuildLimit(v int64) {
 	w.BuildLimit = &v
 }
 
+// SetLastRepo sets the LastRepo field.
+//
+// When the provided Worker type is nil, it
+// will set nothing and immediately return.
+func (w *Worker) SetLastRepo(v string) {
+	// return if Worker type is nil
+	if w == nil {
+		return
+	}
+
+	w.LastRepo = &v
+}
+
+// SetLastBuildID sets the LastBuildID field.
+//
+// When the provided Worker type is nil, it
+// will set nothing and immediately return.
+func (w *Worker) SetLastBuildID(v int64) {
+	// return if Worker type is nil
+	if w == nil {
+		return
+	}
+
+	w.LastBuildID = &v
+}
+
 // String implements the Stringer interface for the Worker type.
 func (w *Worker) String() string {
 	return fmt.Sprintf(`{
@@ -213,6 +267,8 @@ func (w *Worker) String() string {
   Active: %t,
   LastCheckedIn: %v,
   BuildLimit: %v,
+  LastRepo: %s,
+  LastBuildID: %v,
 }`,
 		w.GetID(),
 		w.GetHostname(),
@@ -221,5 +277,7 @@ func (w *Worker) String() string {
 		w.GetActive(),
 		w.GetLastCheckedIn(),
 		w.GetBuildLimit(),
+		w.GetLastRepo(),
+		w.GetLastBuildID(),
 	)
 }

--- a/library/worker_test.go
+++ b/library/worker_test.go
@@ -56,6 +56,14 @@ func TestLibrary_Worker_Getters(t *testing.T) {
 		if test.worker.GetBuildLimit() != test.want.GetBuildLimit() {
 			t.Errorf("GetBuildLimit is %v, want %v", test.worker.GetBuildLimit(), test.want.GetBuildLimit())
 		}
+
+		if test.worker.GetLastRepo() != test.want.GetLastRepo() {
+			t.Errorf("GetLastRepo is %v, want %v", test.worker.GetLastRepo(), test.want.GetLastRepo())
+		}
+
+		if test.worker.GetLastBuildID() != test.want.GetLastBuildID() {
+			t.Errorf("GetLastBuildID is %v, want %v", test.worker.GetLastBuildID(), test.want.GetLastBuildID())
+		}
 	}
 }
 
@@ -114,6 +122,14 @@ func TestLibrary_Worker_Setters(t *testing.T) {
 		if test.worker.GetBuildLimit() != test.want.GetBuildLimit() {
 			t.Errorf("SetBuildLimit is %v, want %v", test.worker.GetBuildLimit(), test.want.GetBuildLimit())
 		}
+
+		if test.worker.GetLastRepo() != test.want.GetLastRepo() {
+			t.Errorf("GetLastRepo is %v, want %v", test.worker.GetLastRepo(), test.want.GetLastRepo())
+		}
+
+		if test.worker.GetLastBuildID() != test.want.GetLastBuildID() {
+			t.Errorf("GetLastBuildID is %v, want %v", test.worker.GetLastBuildID(), test.want.GetLastBuildID())
+		}
 	}
 }
 
@@ -129,6 +145,8 @@ func TestLibrary_Worker_String(t *testing.T) {
   Active: %t,
   LastCheckedIn: %v,
   BuildLimit: %v,
+  LastRepo: %s,
+  LastBuildID: %v,
 }`,
 		w.GetID(),
 		w.GetHostname(),
@@ -137,6 +155,8 @@ func TestLibrary_Worker_String(t *testing.T) {
 		w.GetActive(),
 		w.GetLastCheckedIn(),
 		w.GetBuildLimit(),
+		w.GetLastRepo(),
+		w.GetLastBuildID(),
 	)
 
 	// run test
@@ -159,6 +179,8 @@ func testWorker() *Worker {
 	w.SetActive(true)
 	w.SetLastCheckedIn(time.Time{}.UTC().Unix())
 	w.SetBuildLimit(2)
+	w.SetLastRepo("org/repo")
+	w.SetLastBuildID(1)
 
 	return w
 }


### PR DESCRIPTION
Part of the effort for the admin page.

I wanted to create a favorable situation for our UI to bring in helpful information to the admin page. Instead of trying to search through our builds table to find out the latest build on a given worker, it's much easier to keep the much smaller worker table up-to-date. 

Further, with [this PR in review](https://github.com/go-vela/server/pull/646), I chose to represent the build in a lightweight fashion: by its ID.

Would love any feedback on this! Issue for context: https://github.com/go-vela/community/issues/610