### PR TITLE
fix(schema): synchronized to synchronize in order to mirror GH

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -98,7 +98,7 @@ func main() {
 			"pull_request",
 			"pull_request:edited",
 			"pull_request:opened",
-			"pull_request:synchronized",
+			"pull_request:synchronize",
 			"push",
 			"tag",
 		},


### PR DESCRIPTION
One letter change. `Synchronize` is the action specified in the GH webhook payload, so we decided to mirror that in the code.