### PR TITLE
fix(yaml/ruleset): fix unmarshal PR event to use synchronize, not synchronized

### DIFF
--- a/constants/action.go
+++ b/constants/action.go
@@ -18,6 +18,6 @@ const (
 	// ActionRenamed defines the action for renaming a repository.
 	ActionRenamed = "renamed"
 
-	// ActionSynchronized defines the action for the synchronizing of pull requests.
-	ActionSynchronized = "synchronize"
+	// ActionSynchronize defines the action for the synchronizing of pull requests.
+	ActionSynchronize = "synchronize"
 )

--- a/constants/action.go
+++ b/constants/action.go
@@ -19,5 +19,5 @@ const (
 	ActionRenamed = "renamed"
 
 	// ActionSynchronized defines the action for the synchronizing of pull requests.
-	ActionSynchronized = "synchronized"
+	ActionSynchronized = "synchronize"
 )

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -137,7 +137,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Name:  "install",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized", "pull_request:edited"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:edited"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -166,7 +166,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -195,7 +195,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -225,7 +225,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "plugins/docker:18.09",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -346,7 +346,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Name:  "install",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -381,7 +381,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Image: "openjdk:latest",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -416,7 +416,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Image: "openjdk:latest",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -460,7 +460,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Name:  "install",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -489,7 +489,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -518,7 +518,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -566,7 +566,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Name:  "install",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronized"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -153,7 +153,7 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			case constants.EventPull:
 				events = append(events,
 					constants.EventPull+":"+constants.ActionOpened,
-					constants.EventPull+":"+constants.ActionSynchronized)
+					constants.EventPull+":"+constants.ActionSynchronize)
 			case constants.EventComment:
 				events = append(events,
 					constants.EventComment+":"+constants.ActionCreated,

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -148,7 +148,7 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 		for _, e := range rules.Event {
 			switch e {
-			// backwards compatibility - pull_request = pull_request:opened + pull_request:synchronized
+			// backwards compatibility - pull_request = pull_request:opened + pull_request:synchronize
 			// comment = comment:created + comment:edited
 			case constants.EventPull:
 				events = append(events,

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -116,7 +116,7 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
 				},
 				Unless: Rules{
-					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronized", "comment:created", "comment:edited"},
+					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronize", "comment:created", "comment:edited"},
 					Path:  []string{"foo.txt", "/foo/bar.txt"},
 				},
 				Matcher:  "regexp",

--- a/yaml/testdata/build.yml
+++ b/yaml/testdata/build.yml
@@ -31,7 +31,7 @@ steps:
     image: openjdk:latest
     pull: true
     ruleset:
-      event: [ push, pull_request:opened, pull_request:synchronized, pull_request:edited ]
+      event: [ push, pull_request:opened, pull_request:synchronize, pull_request:edited ]
     volumes: [ /foo:/bar:ro ]
     ulimits: [ foo=1024:2048 ]
 


### PR DESCRIPTION
Since we decided to model off of what GH tells us is the action, I forgot to change this one instance of unmarshaling where I used `synchronized` instead of `synchronize`. 