### PR TITLE
chore(io/os): change ioutil to io or os pkg due to deprecation

### DIFF
--- a/database/compression.go
+++ b/database/compression.go
@@ -7,7 +7,7 @@ package database
 import (
 	"bytes"
 	"compress/zlib"
-	"io/ioutil"
+	"io"
 )
 
 // compress is a helper function to compress values. First, an
@@ -64,7 +64,7 @@ func decompress(value []byte) ([]byte, error) {
 	defer r.Close()
 
 	// capture decompressed data from the compressed data in the buffer
-	data, err := ioutil.ReadAll(r)
+	data, err := io.ReadAll(r)
 	if err != nil {
 		return value, err
 	}

--- a/raw/map_test.go
+++ b/raw/map_test.go
@@ -6,7 +6,7 @@ package raw
 
 import (
 	"database/sql/driver"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -62,7 +62,7 @@ func TestRaw_StringSliceMap_UnmarshalJSON(t *testing.T) {
 		)
 
 		if len(test.file) > 0 {
-			b, err = ioutil.ReadFile(test.file)
+			b, err = os.ReadFile(test.file)
 			if err != nil {
 				t.Errorf("unable to read %s file: %v", test.file, err)
 			}
@@ -126,7 +126,7 @@ func TestRaw_StringSliceMap_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(StringSliceMap)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read %s file: %v", test.file, err)
 		}

--- a/raw/slice_test.go
+++ b/raw/slice_test.go
@@ -5,7 +5,7 @@
 package raw
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -51,7 +51,7 @@ func TestRaw_StringSlice_UnmarshalJSON(t *testing.T) {
 		)
 
 		if len(test.file) > 0 {
-			b, err = ioutil.ReadFile(test.file)
+			b, err = os.ReadFile(test.file)
 			if err != nil {
 				t.Errorf("unable to read %s file: %v", test.file, err)
 			}
@@ -105,7 +105,7 @@ func TestRaw_StringSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(StringSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read %s file: %v", test.file, err)
 		}

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -75,7 +75,7 @@ func TestYaml_Build_ToLibrary(t *testing.T) {
 	for _, test := range tests {
 		b := new(Build)
 
-		data, err := ioutil.ReadFile(test.file)
+		data, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file %s for %s: %v", test.file, test.name, err)
 		}
@@ -594,7 +594,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(Build)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("Reading file for UnmarshalYAML returned err: %v", err)
 		}

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -142,7 +142,7 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(Ruleset)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}
@@ -238,7 +238,7 @@ func TestYaml_Rules_UnmarshalYAML(t *testing.T) {
 		got := new(Rules)
 
 		if len(test.file) > 0 {
-			b, err = ioutil.ReadFile(test.file)
+			b, err = os.ReadFile(test.file)
 			if err != nil {
 				t.Errorf("unable to read file: %v", err)
 			}

--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -310,7 +310,7 @@ func TestYaml_SecretSlice_UnmarshalYAML(t *testing.T) {
 		got := new(SecretSlice)
 
 		// run test
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}
@@ -424,7 +424,7 @@ func TestYaml_StepSecretSlice_UnmarshalYAML(t *testing.T) {
 		got := new(StepSecretSlice)
 
 		// run test
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}

--- a/yaml/service_test.go
+++ b/yaml/service_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -102,7 +102,7 @@ func TestYaml_ServiceSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(ServiceSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -264,7 +264,7 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 		got := new(StageSlice)
 
 		if len(test.file) > 0 {
-			b, err = ioutil.ReadFile(test.file)
+			b, err = os.ReadFile(test.file)
 			if err != nil {
 				t.Errorf("unable to read file: %v", err)
 			}
@@ -377,7 +377,7 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 		got2 := new(StageSlice)
 
 		if len(test.file) > 0 {
-			b, err = ioutil.ReadFile(test.file)
+			b, err = os.ReadFile(test.file)
 			if err != nil {
 				t.Errorf("unable to read file: %v", err)
 			}

--- a/yaml/step_test.go
+++ b/yaml/step_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -233,7 +233,7 @@ func TestYaml_StepSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(StepSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}

--- a/yaml/template_test.go
+++ b/yaml/template_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -54,7 +54,7 @@ func TestBuild_TemplateSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(TemplateSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}

--- a/yaml/ulimit_test.go
+++ b/yaml/ulimit_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -122,7 +122,7 @@ func TestYaml_UlimitSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(UlimitSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}

--- a/yaml/volume_test.go
+++ b/yaml/volume_test.go
@@ -5,7 +5,7 @@
 package yaml
 
 import (
-	"io/ioutil"
+	"os"
 	"reflect"
 	"testing"
 
@@ -112,7 +112,7 @@ func TestYaml_VolumeSlice_UnmarshalYAML(t *testing.T) {
 	for _, test := range tests {
 		got := new(VolumeSlice)
 
-		b, err := ioutil.ReadFile(test.file)
+		b, err := os.ReadFile(test.file)
 		if err != nil {
 			t.Errorf("unable to read file: %v", err)
 		}


### PR DESCRIPTION
I noticed that the `io/ioutil` package has been deprecated since Go 1.16 (see [here](https://pkg.go.dev/io/ioutil) for details). Luckily it seems the functions we were using have 1-to-1 connections to supported functions in the `io` and `os` packages.