### PR TITLE
chore(lint): ran gofmt -s on all files

### DIFF
--- a/constants/doc.go
+++ b/constants/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/constants"
+//	import "github.com/go-vela/types/constants"
 package constants

--- a/database/doc.go
+++ b/database/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/database"
+//	import "github.com/go-vela/types/database"
 package database

--- a/library/doc.go
+++ b/library/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/library"
+//	import "github.com/go-vela/types/library"
 package library

--- a/library/repo.go
+++ b/library/repo.go
@@ -369,7 +369,7 @@ func (r *Repo) GetPipelineType() string {
 // GetPreviousName returns the PreviousName field.
 //
 // When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
+//  the type is nil, it returns the zero value for the field.
 func (r *Repo) GetPreviousName() string {
 	// return zero value if Repo type or PreviousName field is nil
 	if r == nil || r.PreviousName == nil {

--- a/pipeline/build.go
+++ b/pipeline/build.go
@@ -70,8 +70,8 @@ func (b *Build) Purge(r *RuleData) *Build {
 // of the provided runtime driver which is setup on every worker.
 // Currently, this function supports the following runtimes:
 //
-//   * Docker
-//   * Kubernetes
+//   - Docker
+//   - Kubernetes
 func (b *Build) Sanitize(driver string) *Build {
 	// return an empty pipeline if both stages and steps are provided
 	if len(b.Stages) > 0 && len(b.Steps) > 0 {

--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -85,8 +85,8 @@ func (c *ContainerSlice) Purge(r *RuleData) *ContainerSlice {
 // based off of the provided runtime driver which is setup on every
 // worker. Currently, this function supports the following runtimes:
 //
-//   * Docker
-//   * Kubernetes
+//   - Docker
+//   - Kubernetes
 func (c *ContainerSlice) Sanitize(driver string) *ContainerSlice {
 	containers := new(ContainerSlice)
 
@@ -250,8 +250,8 @@ func (c *Container) MergeEnv(environment map[string]string) error {
 // based off of the provided runtime driver which is setup on every
 // worker. Currently, this function supports the following runtimes:
 //
-//   * Docker
-//   * Kubernetes
+//   - Docker
+//   - Kubernetes
 func (c *Container) Sanitize(driver string) *Container {
 	container := c
 

--- a/pipeline/doc.go
+++ b/pipeline/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/pipeline"
+//	import "github.com/go-vela/types/pipeline"
 package pipeline

--- a/pipeline/stage.go
+++ b/pipeline/stage.go
@@ -78,8 +78,8 @@ func (s *StageSlice) Purge(r *RuleData) *StageSlice {
 // based off of the provided runtime driver which is setup on every
 // worker. Currently, this function supports the following runtimes:
 //
-//   * Docker
-//   * Kubernetes
+//   - Docker
+//   - Kubernetes
 func (s *StageSlice) Sanitize(driver string) *StageSlice {
 	stages := new(StageSlice)
 

--- a/raw/doc.go
+++ b/raw/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/raw"
+//	import "github.com/go-vela/types/raw"
 package raw

--- a/version/doc.go
+++ b/version/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/version"
+//	import "github.com/go-vela/types/version"
 package version

--- a/yaml/doc.go
+++ b/yaml/doc.go
@@ -6,5 +6,5 @@
 //
 // Usage:
 //
-// 	import "github.com/go-vela/types/yaml"
+//	import "github.com/go-vela/types/yaml"
 package yaml


### PR DESCRIPTION
Linter was complaining about several files not having `gofmt -s` run against them. Seems like it changed some bullets and spacing.