### PR TITLE
fix(k8s/build/sanitize): implement similar line length and lowercase logic as containers for build

### DIFF
--- a/pipeline/build_test.go
+++ b/pipeline/build_test.go
@@ -91,7 +91,7 @@ func TestPipeline_Build_Purge(t *testing.T) {
 func TestPipeline_Build_Sanitize(t *testing.T) {
 	// setup types
 	stages := testBuildStages()
-	stages.ID = "github-octocat._1"
+	stages.ID = "github-Octocat._1"
 	stages.Services[0].ID = "service_github-octocat._1_postgres"
 	stages.Stages[0].Steps[0].ID = "github-octocat._1_init_init"
 	stages.Stages[1].Steps[0].ID = "github-octocat._1_clone_clone"
@@ -206,7 +206,7 @@ func TestPipeline_Build_Sanitize(t *testing.T) {
 func testBuildStages() *Build {
 	return &Build{
 		Version:     "1",
-		ID:          "github octocat._1",
+		ID:          "github Octocat._1",
 		Environment: map[string]string{"HELLO": "Hello, Global Message"},
 		Services: ContainerSlice{
 			{


### PR DESCRIPTION
https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-label-names

Users run into trouble if their org or repo have uppercase letters, or the combination of the two results in a string longer than 63 characters. Fix was already in place for container names, but not pods.