### PR TITLE
fix(actions): make sure to use latest Go version

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -20,6 +20,7 @@ jobs:
         # use version from go.mod file
         go-version-file: 'go.mod'
         cache: true
+        check-latest: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2
@@ -43,6 +44,7 @@ jobs:
         # use version from go.mod file
         go-version-file: 'go.mod'
         cache: true
+        check-latest: true
 
     - name: golangci-lint
       uses: reviewdog/action-golangci-lint@v2

--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -21,6 +21,7 @@ jobs:
         # use version from go.mod file
         go-version-file: 'go.mod'
         cache: true
+        check-latest: true
 
     - name: build
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,6 +22,7 @@ jobs:
         # use version from go.mod file
         go-version-file: 'go.mod'
         cache: true
+        check-latest: true
 
     - name: test
       run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -22,6 +22,7 @@ jobs:
         # use version from go.mod file
         go-version-file: 'go.mod'
         cache: true
+        check-latest: true
 
     - name: validate
       run: |


### PR DESCRIPTION
waiting for https://github.com/actions/go-versions/pull/60 to get merged to pull in 1.19.2 instead of 1.19.1 because that's what check_latest looks at to get the newest version.

I validated that this is need by rerunning https://github.com/go-vela/types/actions/runs/3171645351/jobs/5232434827 after the fix above was merged. It still pulled in the cached 1.19.1 version of Go.

We will want to apply this to all repos :octocat: (EDIT: ✅ PRs have been created)