### PR TITLE
feat: Make Init a first-class-citizen (database, library, pipeline)

### DIFF
--- a/database/log.go
+++ b/database/log.go
@@ -20,9 +20,9 @@ var (
 	// Log type has an empty RepoID field provided.
 	ErrEmptyLogRepoID = errors.New("empty log repo_id provided")
 
-	// ErrEmptyLogStepOrServiceID defines the error type when a
+	// ErrEmptyLogStepOrServiceOrInitID defines the error type when a
 	// Log type has an empty StepID or ServiceID field provided.
-	ErrEmptyLogStepOrServiceID = errors.New("empty log step_id or service_id not provided")
+	ErrEmptyLogStepOrServiceOrInitID = errors.New("empty log step_id or service_id or init_id provided")
 )
 
 // Log is the database representation of a log for a step in a build.
@@ -32,6 +32,7 @@ type Log struct {
 	RepoID    sql.NullInt64 `sql:"repo_id"`
 	ServiceID sql.NullInt64 `sql:"service_id"`
 	StepID    sql.NullInt64 `sql:"step_id"`
+	InitID    sql.NullInt64 `sql:"init_id"`
 	Data      []byte        `sql:"data"`
 }
 
@@ -105,6 +106,11 @@ func (l *Log) Nullify() *Log {
 		l.StepID.Valid = false
 	}
 
+	// check if the InitID field should be false
+	if l.InitID.Int64 == 0 {
+		l.InitID.Valid = false
+	}
+
 	return l
 }
 
@@ -118,6 +124,7 @@ func (l *Log) ToLibrary() *library.Log {
 	log.SetRepoID(l.RepoID.Int64)
 	log.SetServiceID(l.ServiceID.Int64)
 	log.SetStepID(l.StepID.Int64)
+	log.SetInitID(l.InitID.Int64)
 	log.SetData(l.Data)
 
 	return log
@@ -126,9 +133,9 @@ func (l *Log) ToLibrary() *library.Log {
 // Validate verifies the necessary fields for
 // the Log type are populated correctly.
 func (l *Log) Validate() error {
-	// verify the has StepID or ServiceID field populated
-	if l.StepID.Int64 <= 0 && l.ServiceID.Int64 <= 0 {
-		return ErrEmptyLogStepOrServiceID
+	// verify the has StepID or ServiceID or InitID field populated
+	if l.StepID.Int64 <= 0 && l.ServiceID.Int64 <= 0 && l.InitID.Int64 <= 0 {
+		return ErrEmptyLogStepOrServiceOrInitID
 	}
 
 	// verify the BuildID field is populated
@@ -153,6 +160,7 @@ func LogFromLibrary(l *library.Log) *Log {
 		RepoID:    sql.NullInt64{Int64: l.GetRepoID(), Valid: true},
 		ServiceID: sql.NullInt64{Int64: l.GetServiceID(), Valid: true},
 		StepID:    sql.NullInt64{Int64: l.GetStepID(), Valid: true},
+		InitID:    sql.NullInt64{Int64: l.GetInitID(), Valid: true},
 		Data:      l.GetData(),
 	}
 

--- a/database/log_test.go
+++ b/database/log_test.go
@@ -235,6 +235,7 @@ func TestDatabase_Log_Nullify(t *testing.T) {
 		RepoID:    sql.NullInt64{Int64: 0, Valid: false},
 		ServiceID: sql.NullInt64{Int64: 0, Valid: false},
 		StepID:    sql.NullInt64{Int64: 0, Valid: false},
+		InitID:    sql.NullInt64{Int64: 0, Valid: false},
 	}
 
 	// setup tests
@@ -273,6 +274,7 @@ func TestDatabase_Log_ToLibrary(t *testing.T) {
 	want.SetID(1)
 	want.SetServiceID(1)
 	want.SetStepID(1)
+	want.SetInitID(1)
 	want.SetBuildID(1)
 	want.SetRepoID(1)
 	want.SetData([]byte("foo"))
@@ -295,12 +297,39 @@ func TestDatabase_Log_Validate(t *testing.T) {
 			failure: false,
 			log:     testLog(),
 		},
-		{ // no service_id or step_id set for log
+		{ // no service_id or step_id or init_id set for log
 			failure: true,
 			log: &Log{
 				ID:      sql.NullInt64{Int64: 1, Valid: true},
 				BuildID: sql.NullInt64{Int64: 1, Valid: true},
 				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+			},
+		},
+		{ // only step_id set for log
+			failure: false,
+			log: &Log{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				StepID:  sql.NullInt64{Int64: 1, Valid: true},
+			},
+		},
+		{ // only service_id set for log
+			failure: false,
+			log: &Log{
+				ID:        sql.NullInt64{Int64: 1, Valid: true},
+				BuildID:   sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:    sql.NullInt64{Int64: 1, Valid: true},
+				ServiceID: sql.NullInt64{Int64: 1, Valid: true},
+			},
+		},
+		{ // only init_id set for log
+			failure: false,
+			log: &Log{
+				ID:      sql.NullInt64{Int64: 1, Valid: true},
+				BuildID: sql.NullInt64{Int64: 1, Valid: true},
+				RepoID:  sql.NullInt64{Int64: 1, Valid: true},
+				InitID:  sql.NullInt64{Int64: 1, Valid: true},
 			},
 		},
 		{ // no build_id set for log
@@ -348,6 +377,7 @@ func TestDatabase_LogFromLibrary(t *testing.T) {
 	l.SetID(1)
 	l.SetServiceID(1)
 	l.SetStepID(1)
+	l.SetInitID(1)
 	l.SetBuildID(1)
 	l.SetRepoID(1)
 	l.SetData([]byte("foo"))
@@ -371,6 +401,7 @@ func testLog() *Log {
 		RepoID:    sql.NullInt64{Int64: 1, Valid: true},
 		ServiceID: sql.NullInt64{Int64: 1, Valid: true},
 		StepID:    sql.NullInt64{Int64: 1, Valid: true},
+		InitID:    sql.NullInt64{Int64: 1, Valid: true},
 		Data:      []byte("foo"),
 	}
 }

--- a/library/init.go
+++ b/library/init.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import (
+	"fmt"
+	"github.com/go-vela/types/pipeline"
+)
+
+// Init is the library representation of an init report in a build.
+//
+// swagger:model Init
+type Init struct {
+	ID       *int64  `json:"id,omitempty"`
+	BuildID  *int64  `json:"build_id,omitempty"`
+	RepoID   *int64  `json:"repo_id,omitempty"`
+	Number   *int    `json:"number,omitempty"`
+	Name     *string `json:"name,omitempty"`
+	Mimetype *string `json:"mimetype,omitempty"`
+	Reporter *string `json:"reporter,omitempty"` // which layer created this: compile, runtime, ...
+}
+
+// GetID returns the ID field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetID() int64 {
+	// return zero value if Init type or ID field is nil
+	if i == nil || i.ID == nil {
+		return 0
+	}
+
+	return *i.ID
+}
+
+// GetBuildID returns the BuildID field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetBuildID() int64 {
+	// return zero value if Init type or BuildID field is nil
+	if i == nil || i.BuildID == nil {
+		return 0
+	}
+
+	return *i.BuildID
+}
+
+// GetRepoID returns the RepoID field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetRepoID() int64 {
+	// return zero value if Init type or RepoID field is nil
+	if i == nil || i.RepoID == nil {
+		return 0
+	}
+
+	return *i.RepoID
+}
+
+// GetNumber returns the Number field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetNumber() int {
+	// return zero value if Init type or Number field is nil
+	if i == nil || i.Number == nil {
+		return 0
+	}
+
+	return *i.Number
+}
+
+// GetName returns the Name field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetName() string {
+	// return zero value if Init type or Name field is nil
+	if i == nil || i.Name == nil {
+		return ""
+	}
+
+	return *i.Name
+}
+
+// GetMimetype returns the Mimetype field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetMimetype() string {
+	// return zero value if Init type of Image field is nil
+	if i == nil || i.Mimetype == nil {
+		return ""
+	}
+
+	return *i.Mimetype
+}
+
+// GetReporter returns the Reporter field.
+//
+// When the provided Init type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (i *Init) GetReporter() string {
+	// return zero value if Init type or Stage field is nil
+	if i == nil || i.Reporter == nil {
+		return ""
+	}
+
+	return *i.Reporter
+}
+
+// SetID sets the ID field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetID(v int64) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.ID = &v
+}
+
+// SetBuildID sets the BuildID field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetBuildID(v int64) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.BuildID = &v
+}
+
+// SetRepoID sets the RepoID field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetRepoID(v int64) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.RepoID = &v
+}
+
+// SetNumber sets the Number field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetNumber(v int) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.Number = &v
+}
+
+// SetName sets the Name field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetName(v string) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.Name = &v
+}
+
+// SetMimetype sets the Mimetype field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetMimetype(v string) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.Mimetype = &v
+}
+
+// SetReporter sets the Reporter field.
+//
+// When the provided Init type is nil, it
+// will set nothing and immediately return.
+func (i *Init) SetReporter(v string) {
+	// return if Init type is nil
+	if i == nil {
+		return
+	}
+
+	i.Reporter = &v
+}
+
+// String implements the Stringer interface for the Init type.
+func (i *Init) String() string {
+	return fmt.Sprintf(`{
+  BuildID: %d,
+  ID: %d,
+  Mimetype: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  Reporter: %s,
+}`,
+		i.GetBuildID(),
+		i.GetID(),
+		i.GetMimetype(),
+		i.GetName(),
+		i.GetNumber(),
+		i.GetRepoID(),
+		i.GetReporter(),
+	)
+}
+
+// InitFromBuildInit creates a new Init based on a Build and pipeline Init.
+func InitFromBuildInit(init *pipeline.Init) *Init {
+	// create new step type we want to return
+	i := new(Init)
+
+	// copy fields from init
+	if init != nil && init.Name != "" {
+		// set values from the init
+		i.SetName(init.Name)
+		i.SetNumber(init.Number)
+		i.SetMimetype(init.Mimetype)
+		i.SetReporter(init.Reporter)
+	}
+
+	return i
+}

--- a/library/init_test.go
+++ b/library/init_test.go
@@ -1,0 +1,212 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package library
+
+import (
+	"fmt"
+	"github.com/go-vela/types/pipeline"
+	"reflect"
+	"testing"
+)
+
+func TestLibrary_Init_Getters(t *testing.T) {
+	// setup tests
+	tests := []struct {
+		step *Init
+		want *Init
+	}{
+		{
+			step: testInit(),
+			want: testInit(),
+		},
+		{
+			step: new(Init),
+			want: new(Init),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("GetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
+
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("GetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("GetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("GetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("GetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetMimetype() != test.want.GetMimetype() {
+			t.Errorf("GetMimetype is %v, want %v", test.step.GetMimetype(), test.want.GetMimetype())
+		}
+
+		if test.step.GetReporter() != test.want.GetReporter() {
+			t.Errorf("GetReporter is %v, want %v", test.step.GetReporter(), test.want.GetReporter())
+		}
+	}
+}
+
+func TestLibrary_Init_Setters(t *testing.T) {
+	// setup types
+	var s *Init
+
+	// setup tests
+	tests := []struct {
+		step *Init
+		want *Init
+	}{
+		{
+			step: testInit(),
+			want: testInit(),
+		},
+		{
+			step: s,
+			want: new(Init),
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		test.step.SetID(test.want.GetID())
+		test.step.SetBuildID(test.want.GetBuildID())
+		test.step.SetRepoID(test.want.GetRepoID())
+		test.step.SetNumber(test.want.GetNumber())
+		test.step.SetName(test.want.GetName())
+		test.step.SetMimetype(test.want.GetMimetype())
+		test.step.SetReporter(test.want.GetReporter())
+
+		if test.step.GetID() != test.want.GetID() {
+			t.Errorf("SetID is %v, want %v", test.step.GetID(), test.want.GetID())
+		}
+
+		if test.step.GetBuildID() != test.want.GetBuildID() {
+			t.Errorf("SetBuildID is %v, want %v", test.step.GetBuildID(), test.want.GetBuildID())
+		}
+
+		if test.step.GetRepoID() != test.want.GetRepoID() {
+			t.Errorf("SetRepoID is %v, want %v", test.step.GetRepoID(), test.want.GetRepoID())
+		}
+
+		if test.step.GetNumber() != test.want.GetNumber() {
+			t.Errorf("SetNumber is %v, want %v", test.step.GetNumber(), test.want.GetNumber())
+		}
+
+		if test.step.GetName() != test.want.GetName() {
+			t.Errorf("SetName is %v, want %v", test.step.GetName(), test.want.GetName())
+		}
+
+		if test.step.GetMimetype() != test.want.GetMimetype() {
+			t.Errorf("SetMimetype is %v, want %v", test.step.GetMimetype(), test.want.GetMimetype())
+		}
+
+		if test.step.GetReporter() != test.want.GetReporter() {
+			t.Errorf("SetReporter is %v, want %v", test.step.GetReporter(), test.want.GetReporter())
+		}
+	}
+}
+
+func TestLibrary_Init_String(t *testing.T) {
+	// setup types
+	i := testInit()
+
+	want := fmt.Sprintf(`{
+  BuildID: %d,
+  ID: %d,
+  Mimetype: %s,
+  Name: %s,
+  Number: %d,
+  RepoID: %d,
+  Reporter: %s,
+}`,
+		i.GetBuildID(),
+		i.GetID(),
+		i.GetMimetype(),
+		i.GetName(),
+		i.GetNumber(),
+		i.GetRepoID(),
+		i.GetReporter(),
+	)
+
+	// run test
+	got := i.String()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("String is %v, want %v", got, want)
+	}
+}
+
+func TestLibrary_InitFromBuildInit(t *testing.T) {
+	// setup types
+	s := testInit()
+	s.SetReporter("clone")
+
+	// modify fields that aren't set
+	s.ID = nil
+	s.BuildID = nil
+	s.RepoID = nil
+
+	tests := []struct {
+		name string
+		init *pipeline.Init
+		want *Init
+	}{
+		{
+			name: "nil init",
+			init: nil,
+			want: &Init{},
+		},
+		{
+			name: "empty init",
+			init: new(pipeline.Init),
+			want: &Init{},
+		},
+		{
+			name: "populated init",
+			init: &pipeline.Init{
+				Name:     s.GetName(),
+				Number:   s.GetNumber(),
+				Mimetype: s.GetMimetype(),
+				Reporter: s.GetReporter(),
+			},
+			want: s,
+		},
+	}
+
+	// run tests
+	for _, test := range tests {
+		got := InitFromBuildInit(test.init)
+
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf("InitFromBuildInit for %s is %v, want %v", test.name, got, test.want)
+		}
+	}
+}
+
+// testInit is a test helper function to create a Init
+// type with all fields set to a fake value.
+func testInit() *Init {
+	s := new(Init)
+
+	s.SetID(1)
+	s.SetBuildID(1)
+	s.SetRepoID(1)
+	s.SetNumber(1)
+	s.SetName("clone")
+	s.SetMimetype("text/plain")
+	s.SetReporter("Kubernetes Runtime")
+
+	return s
+}

--- a/library/log.go
+++ b/library/log.go
@@ -20,6 +20,7 @@ type Log struct {
 	RepoID    *int64 `json:"repo_id,omitempty"`
 	ServiceID *int64 `json:"service_id,omitempty"`
 	StepID    *int64 `json:"step_id,omitempty"`
+	InitID    *int64 `json:"init_id,omitempty"`
 	// swagger:strfmt base64
 	Data *[]byte `json:"data,omitempty"`
 }
@@ -136,6 +137,19 @@ func (l *Log) GetStepID() int64 {
 	return *l.StepID
 }
 
+// GetInitID returns the InitID field.
+//
+// When the provided Log type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (l *Log) GetInitID() int64 {
+	// return zero value if Log type or InitID field is nil
+	if l == nil || l.InitID == nil {
+		return 0
+	}
+
+	return *l.InitID
+}
+
 // GetData returns the Data field.
 //
 // When the provided Log type is nil, or the field within
@@ -214,6 +228,19 @@ func (l *Log) SetStepID(v int64) {
 	l.StepID = &v
 }
 
+// SetInitID sets the InitID field.
+//
+// When the provided Log type is nil, it
+// will set nothing and immediately return.
+func (l *Log) SetInitID(v int64) {
+	// return if Log type is nil
+	if l == nil {
+		return
+	}
+
+	l.InitID = &v
+}
+
 // SetData sets the Data field.
 //
 // When the provided Log type is nil, it
@@ -236,6 +263,7 @@ func (l *Log) String() string {
   RepoID: %d,
   ServiceID: %d,
   StepID: %d,
+  InitID: %d,
 }`,
 		l.GetBuildID(),
 		l.GetData(),
@@ -243,5 +271,6 @@ func (l *Log) String() string {
 		l.GetRepoID(),
 		l.GetServiceID(),
 		l.GetStepID(),
+		l.GetInitID(),
 	)
 }

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -129,6 +129,10 @@ func TestLibrary_Log_Getters(t *testing.T) {
 			t.Errorf("GetStepID is %v, want %v", test.log.GetStepID(), test.want.GetStepID())
 		}
 
+		if test.log.GetInitID() != test.want.GetInitID() {
+			t.Errorf("GetInitID is %v, want %v", test.log.GetInitID(), test.want.GetInitID())
+		}
+
 		if test.log.GetBuildID() != test.want.GetBuildID() {
 			t.Errorf("GetBuildID is %v, want %v", test.log.GetBuildID(), test.want.GetBuildID())
 		}
@@ -167,6 +171,7 @@ func TestLibrary_Log_Setters(t *testing.T) {
 		test.log.SetID(test.want.GetID())
 		test.log.SetServiceID(test.want.GetServiceID())
 		test.log.SetStepID(test.want.GetStepID())
+		test.log.SetInitID(test.want.GetInitID())
 		test.log.SetBuildID(test.want.GetBuildID())
 		test.log.SetRepoID(test.want.GetRepoID())
 		test.log.SetData(test.want.GetData())
@@ -181,6 +186,10 @@ func TestLibrary_Log_Setters(t *testing.T) {
 
 		if test.log.GetStepID() != test.want.GetStepID() {
 			t.Errorf("SetStepID is %v, want %v", test.log.GetStepID(), test.want.GetStepID())
+		}
+
+		if test.log.GetInitID() != test.want.GetInitID() {
+			t.Errorf("SetInitID is %v, want %v", test.log.GetInitID(), test.want.GetInitID())
 		}
 
 		if test.log.GetBuildID() != test.want.GetBuildID() {
@@ -208,6 +217,7 @@ func TestLibrary_Log_String(t *testing.T) {
   RepoID: %d,
   ServiceID: %d,
   StepID: %d,
+  InitID: %d,
 }`,
 		l.GetBuildID(),
 		l.GetData(),
@@ -215,6 +225,7 @@ func TestLibrary_Log_String(t *testing.T) {
 		l.GetRepoID(),
 		l.GetServiceID(),
 		l.GetStepID(),
+		l.GetInitID(),
 	)
 
 	// run test

--- a/pipeline/build.go
+++ b/pipeline/build.go
@@ -26,6 +26,7 @@ type Build struct {
 	Services    ContainerSlice     `json:"services,omitempty" yaml:"services,omitempty"`
 	Stages      StageSlice         `json:"stages,omitempty"   yaml:"stages,omitempty"`
 	Steps       ContainerSlice     `json:"steps,omitempty"    yaml:"steps,omitempty"`
+	Inits       InitSlice          `json:"init,omitempty"     yaml:"init,omitempty"`
 }
 
 // Purge removes the steps, in every stage, that contain a ruleset

--- a/pipeline/init.go
+++ b/pipeline/init.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+//
+// Use of this source code is governed by the LICENSE file in this repository.
+
+package pipeline
+
+type (
+	// InitSlice is the pipeline representation
+	// of the Inits block for a pipeline.
+	//
+	// swagger:model PipelineInitSlice
+	//
+	// swagger:model PipelineInitSlice
+	InitSlice []*Init
+
+	// Init is the pipeline representation of an Init entry in a pipeline.
+	//
+	// An Init allows logs to be associated with something other than a container.
+	//
+	// swagger:model PipelineInit
+	Init struct {
+		ID       string `json:"id,omitempty"         yaml:"id,omitempty"`
+		Name     string `json:"name,omitempty"       yaml:"name,omitempty"`
+		Number   int    `json:"number,omitempty"     yaml:"number,omitempty"`
+		Reporter string `json:"reporter,omitempty"   yaml:"reporter,omitempty"`
+		Mimetype string `json:"mimetype,omitempty"   yaml:"mimetype,omitempty"`
+	}
+)

--- a/yaml/build.go
+++ b/yaml/build.go
@@ -20,6 +20,7 @@ type Build struct {
 	Stages      StageSlice         `yaml:"stages,omitempty"    json:"stages,omitempty" jsonschema:"oneof_required=stages,description=Provide parallel execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/stages/"`
 	Steps       StepSlice          `yaml:"steps,omitempty"     json:"steps,omitempty" jsonschema:"oneof_required=steps,description=Provide sequential execution instructions.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/"`
 	Templates   TemplateSlice      `yaml:"templates,omitempty" json:"templates,omitempty" jsonschema:"description=Provide the name of templates to expand.\nReference: https://go-vela.github.io/docs/reference/yaml/templates/"`
+	// The init section is internal and should not be exposed in yaml.
 }
 
 // ToPipelineLibrary converts the Build type to a library Pipeline type.

--- a/yaml/stage.go
+++ b/yaml/stage.go
@@ -82,7 +82,7 @@ func (s *StageSlice) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		}
 
 		// implicitly set the stage `needs`
-		if stage.Name != "clone" && stage.Name != "init" {
+		if stage.Name != "clone" && stage.Name != "init" { // TODO: drop the "init" check
 			// add clone if not present
 			stage.Needs = func(needs []string) []string {
 				for _, s := range needs {


### PR DESCRIPTION
Currently, we're abusing the `Step` and `Container` models to allow reporting on build setup (eg when Docker initializes the Network and Volumes). This means that we have to check for the special "init" stage/step/container in many places. This makes "Init" reporting a first-class-citizen, instead of shoe-horning it into steps and containers (which was admittedly an excellent MVP).

An `Init` is a report by a "reporter" about a discrete part of the build setup. The "reporter" would be a logical part of the stack, for example "Pipeline Compiler", "Docker Runtime", "Kubernetes Runtime", ... For example, we could have these reporters be discrete inits:
- Pipeline Compiler: report info/debug logs
- Docker Runtime: report network setup
- Docker Runtime: report volume setup
- Kubernetes Runtime: Pod YAML

Similar to a `Step`, where the log data is stored in a separate `Log` struct/table, the `Init` is also associated with a `Log` that stores the actual log/report. The `Init` however can also specify a mimetype for the output, which is meant for eventual consumption by the UI to do syntax highlighting if relevant.

So, this adds these structs:

- `pipeline.Init`: a new struct meant to be used in communication between worker <=> server to report about "init".
- `library.Init`: represents a discrete "init" report (actually, just the metadata for it - the report is stored in a `Log`)
- `database.Init`: to persist the `library.Init`

We explicitly do NOT want to add a `yaml.Init` struct, as this is only for server/worker to report on build init. It shouldn't be exposed in the user's pipeline.

We also add these fields:

- `pipeline.Build.Inits`: an `InitSlice` / a slice of `pipeline.Init` structs
- `library.Log.InitID`: to associate a `library.Log` with a `library.Init` instead of a step or a service.
- `database.Log.InitID`: to associate a `database.Log` with a `database.Init` instead of a step or a service.