### PR TITLE
fix(schema): use anyOf for ruleset matching

### DIFF
--- a/cmd/schema/main.go
+++ b/cmd/schema/main.go
@@ -168,7 +168,7 @@ func main() {
 		s.Definitions["Ruleset"].AdditionalProperties = []byte("")
 
 		// at the top level for Ruleset
-		s.Definitions["Ruleset"].OneOf = []*jsonschema.Type{
+		s.Definitions["Ruleset"].AnyOf = []*jsonschema.Type{
 			{
 				Properties:           rulesetProps,
 				Type:                 "object",


### PR DESCRIPTION
fixes an issue when using rulesets that match both the normal and the "flattened" props.

### Steps to Reproduce
provide the schema to [VSCode YAML extension](https://marketplace.visualstudio.com/items?itemName=redhat.vscode-yaml) (or use `Yaml › Schema Store: Enable`) and use the following pipeline syntax:
```yaml
version: "1"
steps:
  - name: anything
     image: golang
     ruleset:
       continue: true
     commands:
     - "echo hello"
```

the `continue` tag within `ruleset` will match both objects provided in the `Ruleset` block based on the `oneOf` matcher.

error:
```
Matches multiple schemas when only one must validate.yaml-schema: Vela Pipeline Configuration
```

*Note*: im not sure if the bug exists for the other blocks using `oneOf`, i just see the error in `ruleset` because i apply continues when debugging.