### PR TITLE
enhance(repo)!: add AllowSchedule field

### DIFF
--- a/database/repo.go
+++ b/database/repo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -46,30 +46,31 @@ var (
 
 // Repo is the database representation of a repo.
 type Repo struct {
-	ID           sql.NullInt64  `sql:"id"`
-	UserID       sql.NullInt64  `sql:"user_id"`
-	Hash         sql.NullString `sql:"hash"`
-	Org          sql.NullString `sql:"org"`
-	Name         sql.NullString `sql:"name"`
-	FullName     sql.NullString `sql:"full_name"`
-	Link         sql.NullString `sql:"link"`
-	Clone        sql.NullString `sql:"clone"`
-	Branch       sql.NullString `sql:"branch"`
-	Topics       pq.StringArray `sql:"topics" gorm:"type:varchar(1020)"`
-	BuildLimit   sql.NullInt64  `sql:"build_limit"`
-	Timeout      sql.NullInt64  `sql:"timeout"`
-	Counter      sql.NullInt32  `sql:"counter"`
-	Visibility   sql.NullString `sql:"visibility"`
-	Private      sql.NullBool   `sql:"private"`
-	Trusted      sql.NullBool   `sql:"trusted"`
-	Active       sql.NullBool   `sql:"active"`
-	AllowPull    sql.NullBool   `sql:"allow_pull"`
-	AllowPush    sql.NullBool   `sql:"allow_push"`
-	AllowDeploy  sql.NullBool   `sql:"allow_deploy"`
-	AllowTag     sql.NullBool   `sql:"allow_tag"`
-	AllowComment sql.NullBool   `sql:"allow_comment"`
-	PipelineType sql.NullString `sql:"pipeline_type"`
-	PreviousName sql.NullString `sql:"previous_name"`
+	ID            sql.NullInt64  `sql:"id"`
+	UserID        sql.NullInt64  `sql:"user_id"`
+	Hash          sql.NullString `sql:"hash"`
+	Org           sql.NullString `sql:"org"`
+	Name          sql.NullString `sql:"name"`
+	FullName      sql.NullString `sql:"full_name"`
+	Link          sql.NullString `sql:"link"`
+	Clone         sql.NullString `sql:"clone"`
+	Branch        sql.NullString `sql:"branch"`
+	Topics        pq.StringArray `sql:"topics" gorm:"type:varchar(1020)"`
+	BuildLimit    sql.NullInt64  `sql:"build_limit"`
+	Timeout       sql.NullInt64  `sql:"timeout"`
+	Counter       sql.NullInt32  `sql:"counter"`
+	Visibility    sql.NullString `sql:"visibility"`
+	Private       sql.NullBool   `sql:"private"`
+	Trusted       sql.NullBool   `sql:"trusted"`
+	Active        sql.NullBool   `sql:"active"`
+	AllowPull     sql.NullBool   `sql:"allow_pull"`
+	AllowPush     sql.NullBool   `sql:"allow_push"`
+	AllowDeploy   sql.NullBool   `sql:"allow_deploy"`
+	AllowTag      sql.NullBool   `sql:"allow_tag"`
+	AllowComment  sql.NullBool   `sql:"allow_comment"`
+	AllowSchedule sql.NullBool   `sql:"allow_schedule"`
+	PipelineType  sql.NullString `sql:"pipeline_type"`
+	PreviousName  sql.NullString `sql:"previous_name"`
 }
 
 // Decrypt will manipulate the existing repo hash by
@@ -230,6 +231,7 @@ func (r *Repo) ToLibrary() *library.Repo {
 	repo.SetAllowDeploy(r.AllowDeploy.Bool)
 	repo.SetAllowTag(r.AllowTag.Bool)
 	repo.SetAllowComment(r.AllowComment.Bool)
+	repo.SetAllowSchedule(r.AllowSchedule.Bool)
 	repo.SetPipelineType(r.PipelineType.String)
 	repo.SetPreviousName(r.PreviousName.String)
 
@@ -301,30 +303,31 @@ func (r *Repo) Validate() error {
 // to a database repo type.
 func RepoFromLibrary(r *library.Repo) *Repo {
 	repo := &Repo{
-		ID:           sql.NullInt64{Int64: r.GetID(), Valid: true},
-		UserID:       sql.NullInt64{Int64: r.GetUserID(), Valid: true},
-		Hash:         sql.NullString{String: r.GetHash(), Valid: true},
-		Org:          sql.NullString{String: r.GetOrg(), Valid: true},
-		Name:         sql.NullString{String: r.GetName(), Valid: true},
-		FullName:     sql.NullString{String: r.GetFullName(), Valid: true},
-		Link:         sql.NullString{String: r.GetLink(), Valid: true},
-		Clone:        sql.NullString{String: r.GetClone(), Valid: true},
-		Branch:       sql.NullString{String: r.GetBranch(), Valid: true},
-		Topics:       pq.StringArray(r.GetTopics()),
-		BuildLimit:   sql.NullInt64{Int64: r.GetBuildLimit(), Valid: true},
-		Timeout:      sql.NullInt64{Int64: r.GetTimeout(), Valid: true},
-		Counter:      sql.NullInt32{Int32: int32(r.GetCounter()), Valid: true},
-		Visibility:   sql.NullString{String: r.GetVisibility(), Valid: true},
-		Private:      sql.NullBool{Bool: r.GetPrivate(), Valid: true},
-		Trusted:      sql.NullBool{Bool: r.GetTrusted(), Valid: true},
-		Active:       sql.NullBool{Bool: r.GetActive(), Valid: true},
-		AllowPull:    sql.NullBool{Bool: r.GetAllowPull(), Valid: true},
-		AllowPush:    sql.NullBool{Bool: r.GetAllowPush(), Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: r.GetAllowDeploy(), Valid: true},
-		AllowTag:     sql.NullBool{Bool: r.GetAllowTag(), Valid: true},
-		AllowComment: sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
-		PipelineType: sql.NullString{String: r.GetPipelineType(), Valid: true},
-		PreviousName: sql.NullString{String: r.GetPreviousName(), Valid: true},
+		ID:            sql.NullInt64{Int64: r.GetID(), Valid: true},
+		UserID:        sql.NullInt64{Int64: r.GetUserID(), Valid: true},
+		Hash:          sql.NullString{String: r.GetHash(), Valid: true},
+		Org:           sql.NullString{String: r.GetOrg(), Valid: true},
+		Name:          sql.NullString{String: r.GetName(), Valid: true},
+		FullName:      sql.NullString{String: r.GetFullName(), Valid: true},
+		Link:          sql.NullString{String: r.GetLink(), Valid: true},
+		Clone:         sql.NullString{String: r.GetClone(), Valid: true},
+		Branch:        sql.NullString{String: r.GetBranch(), Valid: true},
+		Topics:        pq.StringArray(r.GetTopics()),
+		BuildLimit:    sql.NullInt64{Int64: r.GetBuildLimit(), Valid: true},
+		Timeout:       sql.NullInt64{Int64: r.GetTimeout(), Valid: true},
+		Counter:       sql.NullInt32{Int32: int32(r.GetCounter()), Valid: true},
+		Visibility:    sql.NullString{String: r.GetVisibility(), Valid: true},
+		Private:       sql.NullBool{Bool: r.GetPrivate(), Valid: true},
+		Trusted:       sql.NullBool{Bool: r.GetTrusted(), Valid: true},
+		Active:        sql.NullBool{Bool: r.GetActive(), Valid: true},
+		AllowPull:     sql.NullBool{Bool: r.GetAllowPull(), Valid: true},
+		AllowPush:     sql.NullBool{Bool: r.GetAllowPush(), Valid: true},
+		AllowDeploy:   sql.NullBool{Bool: r.GetAllowDeploy(), Valid: true},
+		AllowTag:      sql.NullBool{Bool: r.GetAllowTag(), Valid: true},
+		AllowComment:  sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
+		AllowSchedule: sql.NullBool{Bool: r.GetAllowSchedule(), Valid: true},
+		PipelineType:  sql.NullString{String: r.GetPipelineType(), Valid: true},
+		PreviousName:  sql.NullString{String: r.GetPreviousName(), Valid: true},
 	}
 
 	return repo.Nullify()

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -177,6 +177,7 @@ func TestDatabase_Repo_ToLibrary(t *testing.T) {
 	want.SetAllowDeploy(false)
 	want.SetAllowTag(false)
 	want.SetAllowComment(false)
+	want.SetAllowSchedule(false)
 	want.SetPipelineType("yaml")
 	want.SetPreviousName("oldName")
 
@@ -329,6 +330,7 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 	r.SetAllowPush(true)
 	r.SetAllowDeploy(false)
 	r.SetAllowTag(false)
+	r.SetAllowSchedule(false)
 	r.SetAllowComment(false)
 	r.SetPipelineType("yaml")
 	r.SetPreviousName("oldName")
@@ -347,29 +349,30 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 // type with all fields set to a fake value.
 func testRepo() *Repo {
 	return &Repo{
-		ID:           sql.NullInt64{Int64: 1, Valid: true},
-		UserID:       sql.NullInt64{Int64: 1, Valid: true},
-		Hash:         sql.NullString{String: "superSecretHash", Valid: true},
-		Org:          sql.NullString{String: "github", Valid: true},
-		Name:         sql.NullString{String: "octocat", Valid: true},
-		FullName:     sql.NullString{String: "github/octocat", Valid: true},
-		Link:         sql.NullString{String: "https://github.com/github/octocat", Valid: true},
-		Clone:        sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
-		Branch:       sql.NullString{String: "master", Valid: true},
-		Topics:       []string{"cloud", "security"},
-		BuildLimit:   sql.NullInt64{Int64: 10, Valid: true},
-		Timeout:      sql.NullInt64{Int64: 30, Valid: true},
-		Counter:      sql.NullInt32{Int32: 0, Valid: true},
-		Visibility:   sql.NullString{String: "public", Valid: true},
-		Private:      sql.NullBool{Bool: false, Valid: true},
-		Trusted:      sql.NullBool{Bool: false, Valid: true},
-		Active:       sql.NullBool{Bool: true, Valid: true},
-		AllowPull:    sql.NullBool{Bool: false, Valid: true},
-		AllowPush:    sql.NullBool{Bool: true, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
-		AllowTag:     sql.NullBool{Bool: false, Valid: true},
-		AllowComment: sql.NullBool{Bool: false, Valid: true},
-		PipelineType: sql.NullString{String: "yaml", Valid: true},
-		PreviousName: sql.NullString{String: "oldName", Valid: true},
+		ID:            sql.NullInt64{Int64: 1, Valid: true},
+		UserID:        sql.NullInt64{Int64: 1, Valid: true},
+		Hash:          sql.NullString{String: "superSecretHash", Valid: true},
+		Org:           sql.NullString{String: "github", Valid: true},
+		Name:          sql.NullString{String: "octocat", Valid: true},
+		FullName:      sql.NullString{String: "github/octocat", Valid: true},
+		Link:          sql.NullString{String: "https://github.com/github/octocat", Valid: true},
+		Clone:         sql.NullString{String: "https://github.com/github/octocat.git", Valid: true},
+		Branch:        sql.NullString{String: "master", Valid: true},
+		Topics:        []string{"cloud", "security"},
+		BuildLimit:    sql.NullInt64{Int64: 10, Valid: true},
+		Timeout:       sql.NullInt64{Int64: 30, Valid: true},
+		Counter:       sql.NullInt32{Int32: 0, Valid: true},
+		Visibility:    sql.NullString{String: "public", Valid: true},
+		Private:       sql.NullBool{Bool: false, Valid: true},
+		Trusted:       sql.NullBool{Bool: false, Valid: true},
+		Active:        sql.NullBool{Bool: true, Valid: true},
+		AllowPull:     sql.NullBool{Bool: false, Valid: true},
+		AllowPush:     sql.NullBool{Bool: true, Valid: true},
+		AllowDeploy:   sql.NullBool{Bool: false, Valid: true},
+		AllowTag:      sql.NullBool{Bool: false, Valid: true},
+		AllowSchedule: sql.NullBool{Bool: false, Valid: true},
+		AllowComment:  sql.NullBool{Bool: false, Valid: true},
+		PipelineType:  sql.NullString{String: "yaml", Valid: true},
+		PreviousName:  sql.NullString{String: "oldName", Valid: true},
 	}
 }

--- a/library/repo.go
+++ b/library/repo.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -13,55 +13,57 @@ import (
 //
 // swagger:model Repo
 type Repo struct {
-	ID           *int64    `json:"id,omitempty"`
-	UserID       *int64    `json:"user_id,omitempty"`
-	Hash         *string   `json:"-"`
-	Org          *string   `json:"org,omitempty"`
-	Name         *string   `json:"name,omitempty"`
-	FullName     *string   `json:"full_name,omitempty"`
-	Link         *string   `json:"link,omitempty"`
-	Clone        *string   `json:"clone,omitempty"`
-	Branch       *string   `json:"branch,omitempty"`
-	Topics       *[]string `json:"topics,omitempty"`
-	BuildLimit   *int64    `json:"build_limit,omitempty"`
-	Timeout      *int64    `json:"timeout,omitempty"`
-	Counter      *int      `json:"counter,omitempty"`
-	Visibility   *string   `json:"visibility,omitempty"`
-	Private      *bool     `json:"private,omitempty"`
-	Trusted      *bool     `json:"trusted,omitempty"`
-	Active       *bool     `json:"active,omitempty"`
-	AllowPull    *bool     `json:"allow_pull,omitempty"`
-	AllowPush    *bool     `json:"allow_push,omitempty"`
-	AllowDeploy  *bool     `json:"allow_deploy,omitempty"`
-	AllowTag     *bool     `json:"allow_tag,omitempty"`
-	AllowComment *bool     `json:"allow_comment,omitempty"`
-	PipelineType *string   `json:"pipeline_type,omitempty"`
-	PreviousName *string   `json:"previous_name,omitempty"`
+	ID            *int64    `json:"id,omitempty"`
+	UserID        *int64    `json:"user_id,omitempty"`
+	Hash          *string   `json:"-"`
+	Org           *string   `json:"org,omitempty"`
+	Name          *string   `json:"name,omitempty"`
+	FullName      *string   `json:"full_name,omitempty"`
+	Link          *string   `json:"link,omitempty"`
+	Clone         *string   `json:"clone,omitempty"`
+	Branch        *string   `json:"branch,omitempty"`
+	Topics        *[]string `json:"topics,omitempty"`
+	BuildLimit    *int64    `json:"build_limit,omitempty"`
+	Timeout       *int64    `json:"timeout,omitempty"`
+	Counter       *int      `json:"counter,omitempty"`
+	Visibility    *string   `json:"visibility,omitempty"`
+	Private       *bool     `json:"private,omitempty"`
+	Trusted       *bool     `json:"trusted,omitempty"`
+	Active        *bool     `json:"active,omitempty"`
+	AllowPull     *bool     `json:"allow_pull,omitempty"`
+	AllowPush     *bool     `json:"allow_push,omitempty"`
+	AllowDeploy   *bool     `json:"allow_deploy,omitempty"`
+	AllowTag      *bool     `json:"allow_tag,omitempty"`
+	AllowComment  *bool     `json:"allow_comment,omitempty"`
+	AllowSchedule *bool     `json:"allow_schedule,omitempty"`
+	PipelineType  *string   `json:"pipeline_type,omitempty"`
+	PreviousName  *string   `json:"previous_name,omitempty"`
 }
 
 // Environment returns a list of environment variables
 // provided from the fields of the Repo type.
 func (r *Repo) Environment() map[string]string {
 	return map[string]string{
-		"VELA_REPO_ACTIVE":        ToString(r.GetActive()),
-		"VELA_REPO_ALLOW_COMMENT": ToString(r.GetAllowComment()),
-		"VELA_REPO_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
-		"VELA_REPO_ALLOW_PULL":    ToString(r.GetAllowPull()),
-		"VELA_REPO_ALLOW_PUSH":    ToString(r.GetAllowPush()),
-		"VELA_REPO_ALLOW_TAG":     ToString(r.GetAllowTag()),
-		"VELA_REPO_BRANCH":        ToString(r.GetBranch()),
-		"VELA_REPO_TOPICS":        strings.Join(r.GetTopics()[:], ","),
-		"VELA_REPO_BUILD_LIMIT":   ToString(r.GetBuildLimit()),
-		"VELA_REPO_CLONE":         ToString(r.GetClone()),
-		"VELA_REPO_FULL_NAME":     ToString(r.GetFullName()),
-		"VELA_REPO_LINK":          ToString(r.GetLink()),
-		"VELA_REPO_NAME":          ToString(r.GetName()),
-		"VELA_REPO_ORG":           ToString(r.GetOrg()),
-		"VELA_REPO_PRIVATE":       ToString(r.GetPrivate()),
-		"VELA_REPO_TIMEOUT":       ToString(r.GetTimeout()),
-		"VELA_REPO_TRUSTED":       ToString(r.GetTrusted()),
-		"VELA_REPO_VISIBILITY":    ToString(r.GetVisibility()),
-		"VELA_REPO_PIPELINE_TYPE": ToString(r.GetPipelineType()),
+		"VELA_REPO_ACTIVE":         ToString(r.GetActive()),
+		"VELA_REPO_ALLOW_COMMENT":  ToString(r.GetAllowComment()),
+		"VELA_REPO_ALLOW_DEPLOY":   ToString(r.GetAllowDeploy()),
+		"VELA_REPO_ALLOW_PULL":     ToString(r.GetAllowPull()),
+		"VELA_REPO_ALLOW_PUSH":     ToString(r.GetAllowPush()),
+		"VELA_REPO_ALLOW_SCHEDULE": ToString(r.GetAllowSchedule()),
+		"VELA_REPO_ALLOW_TAG":      ToString(r.GetAllowTag()),
+		"VELA_REPO_BRANCH":         ToString(r.GetBranch()),
+		"VELA_REPO_TOPICS":         strings.Join(r.GetTopics()[:], ","),
+		"VELA_REPO_BUILD_LIMIT":    ToString(r.GetBuildLimit()),
+		"VELA_REPO_CLONE":          ToString(r.GetClone()),
+		"VELA_REPO_FULL_NAME":      ToString(r.GetFullName()),
+		"VELA_REPO_LINK":           ToString(r.GetLink()),
+		"VELA_REPO_NAME":           ToString(r.GetName()),
+		"VELA_REPO_ORG":            ToString(r.GetOrg()),
+		"VELA_REPO_PRIVATE":        ToString(r.GetPrivate()),
+		"VELA_REPO_TIMEOUT":        ToString(r.GetTimeout()),
+		"VELA_REPO_TRUSTED":        ToString(r.GetTrusted()),
+		"VELA_REPO_VISIBILITY":     ToString(r.GetVisibility()),
+		"VELA_REPO_PIPELINE_TYPE":  ToString(r.GetPipelineType()),
 
 		// deprecated environment variables
 		"REPOSITORY_ACTIVE":        ToString(r.GetActive()),
@@ -361,12 +363,25 @@ func (r *Repo) GetAllowTag() bool {
 // When the provided Repo type is nil, or the field within
 // the type is nil, it returns the zero value for the field.
 func (r *Repo) GetAllowComment() bool {
-	// return zero value if Repo type or AllowTag field is nil
+	// return zero value if Repo type or AllowComment field is nil
 	if r == nil || r.AllowComment == nil {
 		return false
 	}
 
 	return *r.AllowComment
+}
+
+// GetAllowSchedule returns the AllowSchedule field.
+//
+// When the provided Repo type is nil, or the field within
+// the type is nil, it returns the zero value for the field.
+func (r *Repo) GetAllowSchedule() bool {
+	// return zero value if Repo type or AllowSchedule field is nil
+	if r == nil || r.AllowSchedule == nil {
+		return false
+	}
+
+	return *r.AllowSchedule
 }
 
 // GetPipelineType returns the PipelineType field.
@@ -681,6 +696,19 @@ func (r *Repo) SetAllowComment(v bool) {
 	r.AllowComment = &v
 }
 
+// SetAllowSchedule sets the AllowSchedule field.
+//
+// When the provided Repo type is nil, it
+// will set nothing and immediately return.
+func (r *Repo) SetAllowSchedule(v bool) {
+	// return if Repo type is nil
+	if r == nil {
+		return
+	}
+
+	r.AllowSchedule = &v
+}
+
 // SetPipelineType sets the PipelineType field.
 //
 // When the provided Repo type is nil, it
@@ -715,6 +743,7 @@ func (r *Repo) String() string {
   AllowDeploy: %t,
   AllowPull: %t,
   AllowPush: %t,
+  AllowSchedule: %t,
   AllowTag: %t,
   Branch: %s,
   BuildLimit: %d,
@@ -739,6 +768,7 @@ func (r *Repo) String() string {
 		r.GetAllowDeploy(),
 		r.GetAllowPull(),
 		r.GetAllowPush(),
+		r.GetAllowSchedule(),
 		r.GetAllowTag(),
 		r.GetBranch(),
 		r.GetBuildLimit(),

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Target Brands, Inc. All rights reserved.
+// Copyright (c) 2023 Target Brands, Inc. All rights reserved.
 //
 // Use of this source code is governed by the LICENSE file in this repository.
 
@@ -18,6 +18,7 @@ func TestLibrary_Repo_Environment(t *testing.T) {
 		"VELA_REPO_ALLOW_DEPLOY":   "false",
 		"VELA_REPO_ALLOW_PULL":     "false",
 		"VELA_REPO_ALLOW_PUSH":     "true",
+		"VELA_REPO_ALLOW_SCHEDULE": "false",
 		"VELA_REPO_ALLOW_TAG":      "false",
 		"VELA_REPO_BRANCH":         "master",
 		"VELA_REPO_TOPICS":         "cloud,security",
@@ -160,6 +161,10 @@ func TestLibrary_Repo_Getters(t *testing.T) {
 			t.Errorf("GetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
 		}
 
+		if test.repo.GetAllowSchedule() != test.want.GetAllowSchedule() {
+			t.Errorf("GetAllowSchedule is %v, want %v", test.repo.GetAllowSchedule(), test.want.GetAllowSchedule())
+		}
+
 		if test.repo.GetPipelineType() != test.want.GetPipelineType() {
 			t.Errorf("GetPipelineType is %v, want %v", test.repo.GetPipelineType(), test.want.GetPipelineType())
 		}
@@ -213,6 +218,7 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 		test.repo.SetAllowDeploy(test.want.GetAllowDeploy())
 		test.repo.SetAllowTag(test.want.GetAllowTag())
 		test.repo.SetAllowComment(test.want.GetAllowComment())
+		test.repo.SetAllowSchedule(test.want.GetAllowSchedule())
 		test.repo.SetPipelineType(test.want.GetPipelineType())
 		test.repo.SetPreviousName(test.want.GetPreviousName())
 
@@ -300,6 +306,10 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 			t.Errorf("SetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
 		}
 
+		if test.repo.GetAllowSchedule() != test.want.GetAllowSchedule() {
+			t.Errorf("SetAllowSchedule is %v, want %v", test.repo.GetAllowSchedule(), test.want.GetAllowSchedule())
+		}
+
 		if test.repo.GetPipelineType() != test.want.GetPipelineType() {
 			t.Errorf("SetPipelineType is %v, want %v", test.repo.GetPipelineType(), test.want.GetPipelineType())
 		}
@@ -320,6 +330,7 @@ func TestLibrary_Repo_String(t *testing.T) {
   AllowDeploy: %t,
   AllowPull: %t,
   AllowPush: %t,
+  AllowSchedule: %t,
   AllowTag: %t,
   Branch: %s,
   BuildLimit: %d,
@@ -344,6 +355,7 @@ func TestLibrary_Repo_String(t *testing.T) {
 		r.GetAllowDeploy(),
 		r.GetAllowPull(),
 		r.GetAllowPush(),
+		r.GetAllowSchedule(),
 		r.GetAllowTag(),
 		r.GetBranch(),
 		r.GetBuildLimit(),
@@ -397,6 +409,7 @@ func testRepo() *Repo {
 	r.SetAllowDeploy(false)
 	r.SetAllowTag(false)
 	r.SetAllowComment(false)
+	r.SetAllowSchedule(false)
 	r.SetPipelineType("")
 	r.SetPreviousName("")
 


### PR DESCRIPTION
xref: https://github.com/go-vela/community/issues/538

Part of https://github.com/go-vela/community/pull/772

Based off of https://github.com/go-vela/types/pull/289

This change add an `AllowSchedule` field to the `Repo{}` object:

https://github.com/go-vela/types/blob/eb7c705a753486439d58ad8d460dcaba75d7991d/database/repo.go#L71

https://github.com/go-vela/types/blob/eb7c705a753486439d58ad8d460dcaba75d7991d/library/repo.go#L38

Similar to the other `Allow*` fields, this will enable users to control if their repo responds to the `schedule` event.

Initially, I didn't plan to add this field since the `Allow*` fields control which `git` based events to respond to.

And `schedules` will be totally controlled by Vela (i.e. not SCM driven), and won't be an event for webhooks.

That being said, I wanted to start with opening this PR to collect feedback on if we should add this or not.

You can find an example of how this field will be used within https://github.com/go-vela/server/pull/846.

> NOTE: Marking this as a breaking change since it adds a new field which will require DB migrations.