### PR TITLE
feat!: protect against stale queue items

### DIFF
--- a/item.go
+++ b/item.go
@@ -22,7 +22,7 @@ type Item struct {
 	Repo     *library.Repo   `json:"repo"`
 	User     *library.User   `json:"user"`
 	// The 0-value is the implicit ItemVersion for queued Items that pre-date adding the field.
-	ItemVersion uint64 `json:"version"`
+	ItemVersion uint64 `json:"item_version"`
 }
 
 // ToItem creates a queue item from a pipeline, build, repo and user.

--- a/item.go
+++ b/item.go
@@ -9,20 +9,29 @@ import (
 	"github.com/go-vela/types/pipeline"
 )
 
+// ItemVersion allows the worker to detect items that were queued before an Vela server
+// upgrade or downgrade, so it can handle such stale data gracefully.
+// For example, the worker could fail a stale build or ask the server to recompile it.
+// This is not a public API and is unrelated to the version key in pipeline yaml.
+const ItemVersion uint64 = 1
+
 // Item is the queue representation of an item to publish to the queue.
 type Item struct {
 	Build    *library.Build  `json:"build"`
 	Pipeline *pipeline.Build `json:"pipeline"`
 	Repo     *library.Repo   `json:"repo"`
 	User     *library.User   `json:"user"`
+	// The 0-value is the implicit ItemVersion for queued Items that pre-date adding the field.
+	ItemVersion uint64 `json:"version"`
 }
 
 // ToItem creates a queue item from a pipeline, build, repo and user.
 func ToItem(p *pipeline.Build, b *library.Build, r *library.Repo, u *library.User) *Item {
 	return &Item{
-		Pipeline: p,
-		Build:    b,
-		Repo:     r,
-		User:     u,
+		Pipeline:    p,
+		Build:       b,
+		Repo:        r,
+		User:        u,
+		ItemVersion: ItemVersion,
 	}
 }

--- a/item_test.go
+++ b/item_test.go
@@ -159,6 +159,7 @@ func TestTypes_ToItem(t *testing.T) {
 			Active: &booL,
 			Admin:  &booL,
 		},
+		ItemVersion: ItemVersion,
 	}
 
 	// run test


### PR DESCRIPTION
Part of https://github.com/go-vela/community/issues/811
Blocks: https://github.com/go-vela/worker/pull/478

This adds an `ItemVersion` field to `Item` with an `ItemVersion` constant  that should be bumped whenever we make significant changes to `Item` or the `pipeline.Build`. This way, the worker can detect any stale builds that were queued before a Vela server upgrade or downgrade, and fail the build.

In the future, we could do something even nicer and ask the server to recompile and requeue the build.