### PR TITLE
fix(secrets): support schedule event

### DIFF
--- a/library/secret.go
+++ b/library/secret.go
@@ -70,7 +70,7 @@ func (s *Secret) Match(from *pipeline.Container) bool {
 	}
 
 	// check incoming events
-	switch from.Environment["BUILD_EVENT"] {
+	switch from.Environment["VELA_BUILD_EVENT"] {
 	case constants.EventPush:
 		eACL = checkEvent(events, constants.EventPush)
 	case constants.EventPull:
@@ -81,6 +81,8 @@ func (s *Secret) Match(from *pipeline.Container) bool {
 		eACL = checkEvent(events, constants.EventDeploy)
 	case constants.EventComment:
 		eACL = checkEvent(events, constants.EventComment)
+	case constants.EventSchedule:
+		eACL = checkEvent(events, constants.EventSchedule)
 	}
 
 	// check images whitelist

--- a/library/secret_test.go
+++ b/library/secret_test.go
@@ -43,7 +43,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{ // test matching secret events
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"push"}},
 			want: true,
@@ -51,7 +51,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "pull_request"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "pull_request"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"pull_request"}},
 			want: true,
@@ -59,7 +59,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "tag"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "tag"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"tag"}},
 			want: true,
@@ -67,7 +67,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "deployment"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "deployment"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"deployment"}},
 			want: true,
@@ -75,7 +75,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "comment"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "comment"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"comment"}},
 			want: true,
@@ -83,7 +83,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "fake_event"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "fake_event"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"push"}},
 			want: false,
@@ -91,16 +91,24 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"push", "pull_request"}},
+			want: true,
+		},
+		{
+			step: &pipeline.Container{
+				Image:       "alpine:latest",
+				Environment: map[string]string{"VELA_BUILD_EVENT": "schedule"},
+			},
+			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{}, Events: &[]string{"push", "pull_request", "schedule"}},
 			want: true,
 		},
 
 		{ // test matching secret images
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine"}, Events: &[]string{}},
 			want: true,
@@ -108,7 +116,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine:latest"}, Events: &[]string{}},
 			want: true,
@@ -116,7 +124,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine:1"}, Events: &[]string{}},
 			want: false,
@@ -124,7 +132,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine", "centos"}, Events: &[]string{}},
 			want: true,
@@ -133,7 +141,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{ // test matching secret events and images
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine"}, Events: &[]string{"push"}},
 			want: true,
@@ -141,7 +149,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine:latest"}, Events: &[]string{"push"}},
 			want: true,
@@ -149,7 +157,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine:1"}, Events: &[]string{"push"}},
 			want: false,
@@ -157,7 +165,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "pull_request"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "pull_request"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine:latest"}, Events: &[]string{"push"}},
 			want: false,
@@ -165,7 +173,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 			},
 			sec:  &Secret{Name: &v, Value: &v, Images: &[]string{"alpine", "centos"}, Events: &[]string{"push"}},
 			want: true,
@@ -174,7 +182,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{ // test build events with image ACLs and rulesets
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 				Ruleset: pipeline.Ruleset{
 					If: pipeline.Rules{
 						Event: []string{"push"},
@@ -187,7 +195,7 @@ func TestLibrary_Secret_Match(t *testing.T) {
 		{
 			step: &pipeline.Container{
 				Image:       "alpine:latest",
-				Environment: map[string]string{"BUILD_EVENT": "push"},
+				Environment: map[string]string{"VELA_BUILD_EVENT": "push"},
 				Ruleset: pipeline.Ruleset{
 					If: pipeline.Rules{
 						Event: []string{"push"},


### PR DESCRIPTION
Secrets were not able to work for schedule events because they weren't passing the `Match` check for injection into containers.

I also decided to discontinue our use of `BUILD_EVENT` as it has been deprecated in favor of `VELA_BUILD_EVENT`