### PR TITLE
fix(yaml): add reopened action to default pull_request unmarshal

### DIFF
--- a/constants/action.go
+++ b/constants/action.go
@@ -16,6 +16,9 @@ const (
 	// ActionRenamed defines the action for renaming a repository.
 	ActionRenamed = "renamed"
 
+	// ActionReopened defines the action for re-opening a pull request (or issue).
+	ActionReopened = "reopened"
+
 	// ActionSynchronize defines the action for the synchronizing of pull requests.
 	ActionSynchronize = "synchronize"
 

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -164,7 +164,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -193,7 +193,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -223,7 +223,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "plugins/docker:18.09",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -351,7 +351,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Name:  "install",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -387,7 +387,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Image: "openjdk:latest",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -423,7 +423,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Image: "openjdk:latest",
 								Pull:  "always",
 								Ruleset: Ruleset{
-									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+									If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 									Matcher:  "filepath",
 									Operator: "and",
 								},
@@ -467,7 +467,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Name:  "install",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -496,7 +496,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -525,7 +525,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Image: "openjdk:latest",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},
@@ -573,7 +573,7 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Name:  "install",
 						Pull:  "always",
 						Ruleset: Ruleset{
-							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize"}},
+							If:       Rules{Event: []string{"push", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened"}},
 							Matcher:  "filepath",
 							Operator: "and",
 						},

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -151,7 +151,8 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 			case constants.EventPull:
 				events = append(events,
 					constants.EventPull+":"+constants.ActionOpened,
-					constants.EventPull+":"+constants.ActionSynchronize)
+					constants.EventPull+":"+constants.ActionSynchronize,
+					constants.EventPull+":"+constants.ActionReopened)
 			case constants.EventComment:
 				events = append(events,
 					constants.EventComment+":"+constants.ActionCreated,

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -114,7 +114,7 @@ func TestYaml_Ruleset_UnmarshalYAML(t *testing.T) {
 					Tag:    []string{"^refs/tags/(\\d+\\.)+\\d+$"},
 				},
 				Unless: Rules{
-					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronize", "comment:created", "comment:edited", "schedule"},
+					Event: []string{"deployment", "pull_request:opened", "pull_request:synchronize", "pull_request:reopened", "comment:created", "comment:edited", "schedule"},
 					Path:  []string{"foo.txt", "/foo/bar.txt"},
 				},
 				Matcher:  "regexp",


### PR DESCRIPTION
Found a bug (?) where users were expecting a Vela pull request build to launch when they re-opened a pull request, much like there is one when a user opens a pull request. 

If we are to support `reopened` as a pull_request action, I believe it should also be a default in this custom unmarshal value for `pull_request`.