### PR TITLE
fix(log): add brackets to secret mask

### DIFF
--- a/library/log.go
+++ b/library/log.go
@@ -54,7 +54,7 @@ func (l *Log) MaskData(secrets []string) {
 		// create regexp to match secrets in the log data surrounded by regexp metacharacters
 		//
 		// https://pkg.go.dev/regexp#MustCompile
-		buffer := `(\s|^|=|"|\?|:|'|\.|,|&|$|;)`
+		buffer := `(\s|^|=|"|\?|:|'|\.|,|&|$|;|\[|\])`
 		re := regexp.MustCompile((buffer + escaped + buffer))
 
 		// create a mask for the secret

--- a/library/log_test.go
+++ b/library/log_test.go
@@ -54,6 +54,8 @@ func TestLibrary_Log_MaskData(t *testing.T) {
 	s4Masked := "SOME_SECRET=***"
 	s5 := "www.example.com?username=secret&password=extrasecret"
 	s5Masked := "www.example.com?username=***&password=***"
+	s6 := "[token: extrasecret]"
+	s6Masked := "[token: ***]"
 
 	tests := []struct {
 		want    []byte
@@ -83,6 +85,11 @@ func TestLibrary_Log_MaskData(t *testing.T) {
 		{ // secret baked in URL query params
 			want:    []byte(s5Masked),
 			log:     []byte(s5),
+			secrets: sVals,
+		},
+		{ // secret in verbose brackets
+			want:    []byte(s6Masked),
+			log:     []byte(s6),
 			secrets: sVals,
 		},
 		{ // empty secrets slice


### PR DESCRIPTION
Had a case where the verbose flag in a cURL request logged a secret by accident. Adding some brackets to the mask buffer