### PR TITLE
fix(repo_events): add support for reopen

### DIFF
--- a/constants/allow_events.go
+++ b/constants/allow_events.go
@@ -14,7 +14,7 @@ const (
 	_ // AllowPullLabel - Not Implemented
 	_ // AllowPullLocked - Not Implemented
 	_ // AllowPullReady - Not Implemented
-	_ // AllowPullReopen - Not Implemented
+	AllowPullReopen
 	_ // AllowPullReviewRequest - Not Implemented
 	_ // AllowPullClosed - Not Implemented
 	AllowDeployCreate

--- a/library/actions/pull.go
+++ b/library/actions/pull.go
@@ -10,6 +10,7 @@ type Pull struct {
 	Opened      *bool `json:"opened"`
 	Edited      *bool `json:"edited"`
 	Synchronize *bool `json:"synchronize"`
+	Reopened    *bool `json:"reopened"`
 }
 
 // FromMask returns the Pull type resulting from the provided integer mask.
@@ -17,6 +18,7 @@ func (a *Pull) FromMask(mask int64) *Pull {
 	a.SetOpened(mask&constants.AllowPullOpen > 0)
 	a.SetSynchronize(mask&constants.AllowPullSync > 0)
 	a.SetEdited(mask&constants.AllowPullEdit > 0)
+	a.SetReopened(mask&constants.AllowPullReopen > 0)
 
 	return a
 }
@@ -35,6 +37,10 @@ func (a *Pull) ToMask() int64 {
 
 	if a.GetEdited() {
 		mask = mask | constants.AllowPullEdit
+	}
+
+	if a.GetReopened() {
+		mask = mask | constants.AllowPullReopen
 	}
 
 	return mask
@@ -71,6 +77,17 @@ func (a *Pull) GetEdited() bool {
 	}
 
 	return *a.Edited
+}
+
+// GetReopened returns the Reopened field from the provided Pull. If the object is nil,
+// or the field within the object is nil, it returns the zero value instead.
+func (a *Pull) GetReopened() bool {
+	// return zero value if Pull type or Reopened field is nil
+	if a == nil || a.Reopened == nil {
+		return false
+	}
+
+	return *a.Reopened
 }
 
 // SetOpened sets the Pull Opened field.
@@ -110,4 +127,17 @@ func (a *Pull) SetEdited(v bool) {
 	}
 
 	a.Edited = &v
+}
+
+// SetReopened sets the Pull Reopened field.
+//
+// When the provided Pull type is nil, it
+// will set nothing and immediately return.
+func (a *Pull) SetReopened(v bool) {
+	// return if Pull type is nil
+	if a == nil {
+		return
+	}
+
+	a.Reopened = &v
 }

--- a/library/actions/pull_test.go
+++ b/library/actions/pull_test.go
@@ -38,6 +38,10 @@ func TestLibrary_Pull_Getters(t *testing.T) {
 		if test.actions.GetEdited() != test.want.GetEdited() {
 			t.Errorf("GetEdited is %v, want %v", test.actions.GetEdited(), test.want.GetEdited())
 		}
+
+		if test.actions.GetReopened() != test.want.GetReopened() {
+			t.Errorf("GetReopened is %v, want %v", test.actions.GetReopened(), test.want.GetReopened())
+		}
 	}
 }
 
@@ -65,6 +69,7 @@ func TestLibrary_Pull_Setters(t *testing.T) {
 		test.actions.SetOpened(test.want.GetOpened())
 		test.actions.SetSynchronize(test.want.GetSynchronize())
 		test.actions.SetEdited(test.want.GetEdited())
+		test.actions.SetReopened(test.want.GetReopened())
 
 		if test.actions.GetOpened() != test.want.GetOpened() {
 			t.Errorf("SetOpened is %v, want %v", test.actions.GetOpened(), test.want.GetOpened())
@@ -76,6 +81,10 @@ func TestLibrary_Pull_Setters(t *testing.T) {
 
 		if test.actions.GetEdited() != test.want.GetEdited() {
 			t.Errorf("SetEdited is %v, want %v", test.actions.GetEdited(), test.want.GetEdited())
+		}
+
+		if test.actions.GetReopened() != test.want.GetReopened() {
+			t.Errorf("SetReopened is %v, want %v", test.actions.GetReopened(), test.want.GetReopened())
 		}
 	}
 }
@@ -98,7 +107,7 @@ func TestLibrary_Pull_ToMask(t *testing.T) {
 	// setup types
 	actions := testPull()
 
-	want := int64(constants.AllowPullOpen | constants.AllowPullSync)
+	want := int64(constants.AllowPullOpen | constants.AllowPullSync | constants.AllowPullReopen)
 
 	// run test
 	got := actions.ToMask()
@@ -113,6 +122,7 @@ func testPull() *Pull {
 	pr.SetOpened(true)
 	pr.SetSynchronize(true)
 	pr.SetEdited(false)
+	pr.SetReopened(true)
 
 	return pr
 }

--- a/library/actions/push_test.go
+++ b/library/actions/push_test.go
@@ -108,5 +108,13 @@ func testPush() *Push {
 }
 
 func testMask() int64 {
-	return int64(constants.AllowPushBranch | constants.AllowPushTag | constants.AllowPullOpen | constants.AllowPullSync | constants.AllowDeployCreate | constants.AllowCommentCreate)
+	return int64(
+		constants.AllowPushBranch |
+			constants.AllowPushTag |
+			constants.AllowPullOpen |
+			constants.AllowPullSync |
+			constants.AllowPullReopen |
+			constants.AllowDeployCreate |
+			constants.AllowCommentCreate,
+	)
 }

--- a/library/events_test.go
+++ b/library/events_test.go
@@ -106,7 +106,13 @@ func TestLibrary_Events_List(t *testing.T) {
 
 func TestLibrary_Events_NewEventsFromMask(t *testing.T) {
 	// setup mask
-	mask := int64(constants.AllowPushBranch | constants.AllowPushTag | constants.AllowPullOpen | constants.AllowPullSync)
+	mask := int64(
+		constants.AllowPushBranch |
+			constants.AllowPushTag |
+			constants.AllowPullOpen |
+			constants.AllowPullSync |
+			constants.AllowPullReopen,
+	)
 
 	want := testEvents()
 
@@ -125,6 +131,7 @@ func testEvents() *Events {
 	pr.SetOpened(true)
 	pr.SetSynchronize(true)
 	pr.SetEdited(false)
+	pr.SetReopened(true)
 
 	push := new(actions.Push)
 	push.SetBranch(true)

--- a/yaml/ruleset.go
+++ b/yaml/ruleset.go
@@ -146,7 +146,8 @@ func (r *Rules) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 		for _, e := range rules.Event {
 			switch e {
-			// backwards compatibility - pull_request = pull_request:opened + pull_request:synchronize
+			// backwards compatibility
+			// pull_request = pull_request:opened + pull_request:synchronize + pull_request:reopened
 			// comment = comment:created + comment:edited
 			case constants.EventPull:
 				events = append(events,


### PR DESCRIPTION
While I was working on the original PR for this new allow_events remodel, we added support for the [reopening action](https://github.com/go-vela/server/pull/1002). 