### PR TITLE
fix: enabling a delete event to be allowed

### DIFF
--- a/library/events.go
+++ b/library/events.go
@@ -67,6 +67,10 @@ func (e *Events) Allowed(event, action string) bool {
 		allowed = e.GetDeployment().GetCreated()
 	case constants.EventSchedule:
 		allowed = e.GetSchedule().GetRun()
+	case constants.EventDelete + ":" + constants.ActionBranch:
+		allowed = e.GetDelete().GetBranch()
+	case constants.EventDelete + ":" + constants.ActionTag:
+		allowed = e.GetDelete().GetTag()
 	}
 
 	return allowed


### PR DESCRIPTION
Goes along with this PR: [https://github.com/go-vela/types/pull/340](https://github.com/go-vela/types/pull/340)

Adding a last piece to enable delete events.