### PR TITLE
fix: title validator handle no parentheses + enforce whitespace

### DIFF
--- a/.github/workflows/pr-title-validate.yml
+++ b/.github/workflows/pr-title-validate.yml
@@ -14,4 +14,4 @@ jobs:
     steps:
     - name: validate title
       run: |
-        echo "${{ github.event.pull_request.title }}" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)\(.*\):.*$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)
+        echo "${{ github.event.pull_request.title }}" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)(\(.*\)|):\s.+$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)


### PR DESCRIPTION
According to our [docs](https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow), we should accept both formats:

Scope:
- feat(scope): cool thing

No Scope:
- feat: scope-less cool thing