### PR TITLE
fix(database): add limit and eviction policy for deployment builds

### DIFF
--- a/constants/limit.go
+++ b/constants/limit.go
@@ -30,4 +30,7 @@ const (
 
 	// TopicsMaxSize defines the maximum size in characters for repo topics. Ex: GitHub has a 20-topic, 50-char limit.
 	TopicsMaxSize = 1020
+
+	// DeployBuildsMaxSize defines the maximum size in characters for deployment builds.
+	DeployBuildsMaxSize = 500
 )


### PR DESCRIPTION
Adding a limit + an eviction policy so we prioritize most recent builds for a given deployment.