### PR TITLE
chore: delete legacy allow event fields and methods

### DIFF
--- a/database/repo.go
+++ b/database/repo.go
@@ -61,11 +61,6 @@ type Repo struct {
 	Private      sql.NullBool   `sql:"private"`
 	Trusted      sql.NullBool   `sql:"trusted"`
 	Active       sql.NullBool   `sql:"active"`
-	AllowPull    sql.NullBool   `sql:"allow_pull"`
-	AllowPush    sql.NullBool   `sql:"allow_push"`
-	AllowDeploy  sql.NullBool   `sql:"allow_deploy"`
-	AllowTag     sql.NullBool   `sql:"allow_tag"`
-	AllowComment sql.NullBool   `sql:"allow_comment"`
 	AllowEvents  sql.NullInt64  `sql:"allow_events"`
 	PipelineType sql.NullString `sql:"pipeline_type"`
 	PreviousName sql.NullString `sql:"previous_name"`
@@ -235,11 +230,6 @@ func (r *Repo) ToLibrary() *library.Repo {
 	repo.SetPrivate(r.Private.Bool)
 	repo.SetTrusted(r.Trusted.Bool)
 	repo.SetActive(r.Active.Bool)
-	repo.SetAllowPull(r.AllowPull.Bool)
-	repo.SetAllowPush(r.AllowPush.Bool)
-	repo.SetAllowDeploy(r.AllowDeploy.Bool)
-	repo.SetAllowTag(r.AllowTag.Bool)
-	repo.SetAllowComment(r.AllowComment.Bool)
 	repo.SetAllowEvents(library.NewEventsFromMask(r.AllowEvents.Int64))
 	repo.SetPipelineType(r.PipelineType.String)
 	repo.SetPreviousName(r.PreviousName.String)
@@ -332,11 +322,6 @@ func RepoFromLibrary(r *library.Repo) *Repo {
 		Private:      sql.NullBool{Bool: r.GetPrivate(), Valid: true},
 		Trusted:      sql.NullBool{Bool: r.GetTrusted(), Valid: true},
 		Active:       sql.NullBool{Bool: r.GetActive(), Valid: true},
-		AllowPull:    sql.NullBool{Bool: r.GetAllowPull(), Valid: true},
-		AllowPush:    sql.NullBool{Bool: r.GetAllowPush(), Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: r.GetAllowDeploy(), Valid: true},
-		AllowTag:     sql.NullBool{Bool: r.GetAllowTag(), Valid: true},
-		AllowComment: sql.NullBool{Bool: r.GetAllowComment(), Valid: true},
 		AllowEvents:  sql.NullInt64{Int64: r.GetAllowEvents().ToDatabase(), Valid: true},
 		PipelineType: sql.NullString{String: r.GetPipelineType(), Valid: true},
 		PreviousName: sql.NullString{String: r.GetPreviousName(), Valid: true},

--- a/database/repo_test.go
+++ b/database/repo_test.go
@@ -175,11 +175,6 @@ func TestDatabase_Repo_ToLibrary(t *testing.T) {
 	want.SetPrivate(false)
 	want.SetTrusted(false)
 	want.SetActive(true)
-	want.SetAllowPull(false)
-	want.SetAllowPush(true)
-	want.SetAllowDeploy(false)
-	want.SetAllowTag(false)
-	want.SetAllowComment(false)
 	want.SetAllowEvents(e)
 	want.SetPipelineType("yaml")
 	want.SetPreviousName("oldName")
@@ -332,11 +327,6 @@ func TestDatabase_RepoFromLibrary(t *testing.T) {
 	r.SetPrivate(false)
 	r.SetTrusted(false)
 	r.SetActive(true)
-	r.SetAllowPull(false)
-	r.SetAllowPush(true)
-	r.SetAllowDeploy(false)
-	r.SetAllowTag(false)
-	r.SetAllowComment(false)
 	r.SetAllowEvents(e)
 	r.SetPipelineType("yaml")
 	r.SetPreviousName("oldName")
@@ -373,11 +363,6 @@ func testRepo() *Repo {
 		Private:      sql.NullBool{Bool: false, Valid: true},
 		Trusted:      sql.NullBool{Bool: false, Valid: true},
 		Active:       sql.NullBool{Bool: true, Valid: true},
-		AllowPull:    sql.NullBool{Bool: false, Valid: true},
-		AllowPush:    sql.NullBool{Bool: true, Valid: true},
-		AllowDeploy:  sql.NullBool{Bool: false, Valid: true},
-		AllowTag:     sql.NullBool{Bool: false, Valid: true},
-		AllowComment: sql.NullBool{Bool: false, Valid: true},
 		AllowEvents:  sql.NullInt64{Int64: 1, Valid: true},
 		PipelineType: sql.NullString{String: "yaml", Valid: true},
 		PreviousName: sql.NullString{String: "oldName", Valid: true},

--- a/database/secret.go
+++ b/database/secret.go
@@ -50,7 +50,6 @@ type Secret struct {
 	Value             sql.NullString `sql:"value"`
 	Type              sql.NullString `sql:"type"`
 	Images            pq.StringArray `sql:"images" gorm:"type:varchar(1000)"`
-	Events            pq.StringArray `sql:"events" gorm:"type:varchar(1000)"`
 	AllowEvents       sql.NullInt64  `sql:"allow_events"`
 	AllowCommand      sql.NullBool   `sql:"allow_command"`
 	AllowSubstitution sql.NullBool   `sql:"allow_substitution"`
@@ -194,7 +193,6 @@ func (s *Secret) ToLibrary() *library.Secret {
 	secret.SetValue(s.Value.String)
 	secret.SetType(s.Type.String)
 	secret.SetImages(s.Images)
-	secret.SetEvents(s.Events)
 	secret.SetAllowEvents(library.NewEventsFromMask(s.AllowEvents.Int64))
 	secret.SetAllowCommand(s.AllowCommand.Bool)
 	secret.SetAllowSubstitution(s.AllowSubstitution.Bool)
@@ -261,12 +259,6 @@ func (s *Secret) Validate() error {
 		s.Images[i] = sanitize(v)
 	}
 
-	// ensure that all Events are sanitized
-	// to avoid unsafe HTML content
-	for i, v := range s.Events {
-		s.Events[i] = sanitize(v)
-	}
-
 	return nil
 }
 
@@ -282,7 +274,6 @@ func SecretFromLibrary(s *library.Secret) *Secret {
 		Value:             sql.NullString{String: s.GetValue(), Valid: true},
 		Type:              sql.NullString{String: s.GetType(), Valid: true},
 		Images:            pq.StringArray(s.GetImages()),
-		Events:            pq.StringArray(s.GetEvents()),
 		AllowEvents:       sql.NullInt64{Int64: s.GetAllowEvents().ToDatabase(), Valid: true},
 		AllowCommand:      sql.NullBool{Bool: s.GetAllowCommand(), Valid: true},
 		AllowSubstitution: sql.NullBool{Bool: s.GetAllowSubstitution(), Valid: true},

--- a/database/secret_test.go
+++ b/database/secret_test.go
@@ -168,7 +168,6 @@ func TestDatabase_Secret_ToLibrary(t *testing.T) {
 	want.SetValue("bar")
 	want.SetType("repo")
 	want.SetImages([]string{"alpine"})
-	want.SetEvents([]string{"push", "tag", "deployment"})
 	want.SetAllowEvents(library.NewEventsFromMask(1))
 	want.SetAllowCommand(true)
 	want.SetAllowSubstitution(true)
@@ -293,7 +292,6 @@ func TestDatabase_SecretFromLibrary(t *testing.T) {
 	s.SetValue("bar")
 	s.SetType("repo")
 	s.SetImages([]string{"alpine"})
-	s.SetEvents([]string{"push", "tag", "deployment"})
 	s.SetAllowEvents(library.NewEventsFromMask(1))
 	s.SetAllowCommand(true)
 	s.SetAllowSubstitution(true)
@@ -324,7 +322,6 @@ func testSecret() *Secret {
 		Value:             sql.NullString{String: "bar", Valid: true},
 		Type:              sql.NullString{String: "repo", Valid: true},
 		Images:            []string{"alpine"},
-		Events:            []string{"push", "tag", "deployment"},
 		AllowEvents:       sql.NullInt64{Int64: 1, Valid: true},
 		AllowCommand:      sql.NullBool{Bool: true, Valid: true},
 		AllowSubstitution: sql.NullBool{Bool: true, Valid: true},

--- a/item_test.go
+++ b/item_test.go
@@ -55,10 +55,6 @@ func TestTypes_ToItem(t *testing.T) {
 		Private:     &booL,
 		Trusted:     &booL,
 		Active:      &booL,
-		AllowPull:   &booL,
-		AllowPush:   &booL,
-		AllowDeploy: &booL,
-		AllowTag:    &booL,
 		AllowEvents: e,
 	}
 	u := &library.User{
@@ -107,10 +103,6 @@ func TestTypes_ToItem(t *testing.T) {
 			Private:     &booL,
 			Trusted:     &booL,
 			Active:      &booL,
-			AllowPull:   &booL,
-			AllowPush:   &booL,
-			AllowDeploy: &booL,
-			AllowTag:    &booL,
 			AllowEvents: e,
 		},
 		User: &library.User{

--- a/library/repo.go
+++ b/library/repo.go
@@ -28,11 +28,6 @@ type Repo struct {
 	Private      *bool     `json:"private,omitempty"`
 	Trusted      *bool     `json:"trusted,omitempty"`
 	Active       *bool     `json:"active,omitempty"`
-	AllowPull    *bool     `json:"allow_pull,omitempty"`
-	AllowPush    *bool     `json:"allow_push,omitempty"`
-	AllowDeploy  *bool     `json:"allow_deploy,omitempty"`
-	AllowTag     *bool     `json:"allow_tag,omitempty"`
-	AllowComment *bool     `json:"allow_comment,omitempty"`
 	AllowEvents  *Events   `json:"allow_events,omitempty"`
 	PipelineType *string   `json:"pipeline_type,omitempty"`
 	PreviousName *string   `json:"previous_name,omitempty"`
@@ -44,11 +39,6 @@ type Repo struct {
 func (r *Repo) Environment() map[string]string {
 	return map[string]string{
 		"VELA_REPO_ACTIVE":        ToString(r.GetActive()),
-		"VELA_REPO_ALLOW_COMMENT": ToString(r.GetAllowComment()),
-		"VELA_REPO_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
-		"VELA_REPO_ALLOW_PULL":    ToString(r.GetAllowPull()),
-		"VELA_REPO_ALLOW_PUSH":    ToString(r.GetAllowPush()),
-		"VELA_REPO_ALLOW_TAG":     ToString(r.GetAllowTag()),
 		"VELA_REPO_ALLOW_EVENTS":  strings.Join(r.GetAllowEvents().List()[:], ","),
 		"VELA_REPO_BRANCH":        ToString(r.GetBranch()),
 		"VELA_REPO_TOPICS":        strings.Join(r.GetTopics()[:], ","),
@@ -66,23 +56,18 @@ func (r *Repo) Environment() map[string]string {
 		"VELA_REPO_APPROVE_BUILD": ToString(r.GetApproveBuild()),
 
 		// deprecated environment variables
-		"REPOSITORY_ACTIVE":        ToString(r.GetActive()),
-		"REPOSITORY_ALLOW_COMMENT": ToString(r.GetAllowComment()),
-		"REPOSITORY_ALLOW_DEPLOY":  ToString(r.GetAllowDeploy()),
-		"REPOSITORY_ALLOW_PULL":    ToString(r.GetAllowPull()),
-		"REPOSITORY_ALLOW_PUSH":    ToString(r.GetAllowPush()),
-		"REPOSITORY_ALLOW_TAG":     ToString(r.GetAllowTag()),
-		"REPOSITORY_ALLOW_EVENTS":  strings.Join(r.GetAllowEvents().List()[:], ","),
-		"REPOSITORY_BRANCH":        ToString(r.GetBranch()),
-		"REPOSITORY_CLONE":         ToString(r.GetClone()),
-		"REPOSITORY_FULL_NAME":     ToString(r.GetFullName()),
-		"REPOSITORY_LINK":          ToString(r.GetLink()),
-		"REPOSITORY_NAME":          ToString(r.GetName()),
-		"REPOSITORY_ORG":           ToString(r.GetOrg()),
-		"REPOSITORY_PRIVATE":       ToString(r.GetPrivate()),
-		"REPOSITORY_TIMEOUT":       ToString(r.GetTimeout()),
-		"REPOSITORY_TRUSTED":       ToString(r.GetTrusted()),
-		"REPOSITORY_VISIBILITY":    ToString(r.GetVisibility()),
+		"REPOSITORY_ACTIVE":       ToString(r.GetActive()),
+		"REPOSITORY_ALLOW_EVENTS": strings.Join(r.GetAllowEvents().List()[:], ","),
+		"REPOSITORY_BRANCH":       ToString(r.GetBranch()),
+		"REPOSITORY_CLONE":        ToString(r.GetClone()),
+		"REPOSITORY_FULL_NAME":    ToString(r.GetFullName()),
+		"REPOSITORY_LINK":         ToString(r.GetLink()),
+		"REPOSITORY_NAME":         ToString(r.GetName()),
+		"REPOSITORY_ORG":          ToString(r.GetOrg()),
+		"REPOSITORY_PRIVATE":      ToString(r.GetPrivate()),
+		"REPOSITORY_TIMEOUT":      ToString(r.GetTimeout()),
+		"REPOSITORY_TRUSTED":      ToString(r.GetTrusted()),
+		"REPOSITORY_VISIBILITY":   ToString(r.GetVisibility()),
 	}
 }
 
@@ -305,71 +290,6 @@ func (r *Repo) GetActive() bool {
 	}
 
 	return *r.Active
-}
-
-// GetAllowPull returns the AllowPull field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetAllowPull() bool {
-	// return zero value if Repo type or AllowPull field is nil
-	if r == nil || r.AllowPull == nil {
-		return false
-	}
-
-	return *r.AllowPull
-}
-
-// GetAllowPush returns the AllowPush field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetAllowPush() bool {
-	// return zero value if Repo type or AllowPush field is nil
-	if r == nil || r.AllowPush == nil {
-		return false
-	}
-
-	return *r.AllowPush
-}
-
-// GetAllowDeploy returns the AllowDeploy field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetAllowDeploy() bool {
-	// return zero value if Repo type or AllowDeploy field is nil
-	if r == nil || r.AllowDeploy == nil {
-		return false
-	}
-
-	return *r.AllowDeploy
-}
-
-// GetAllowTag returns the AllowTag field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetAllowTag() bool {
-	// return zero value if Repo type or AllowTag field is nil
-	if r == nil || r.AllowTag == nil {
-		return false
-	}
-
-	return *r.AllowTag
-}
-
-// GetAllowComment returns the AllowComment field.
-//
-// When the provided Repo type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (r *Repo) GetAllowComment() bool {
-	// return zero value if Repo type or AllowComment field is nil
-	if r == nil || r.AllowComment == nil {
-		return false
-	}
-
-	return *r.AllowComment
 }
 
 // GetAllowEvents returns the AllowEvents field.
@@ -645,71 +565,6 @@ func (r *Repo) SetActive(v bool) {
 	r.Active = &v
 }
 
-// SetAllowPull sets the AllowPull field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetAllowPull(v bool) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.AllowPull = &v
-}
-
-// SetAllowPush sets the AllowPush field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetAllowPush(v bool) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.AllowPush = &v
-}
-
-// SetAllowDeploy sets the AllowDeploy field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetAllowDeploy(v bool) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.AllowDeploy = &v
-}
-
-// SetAllowTag sets the AllowTag field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetAllowTag(v bool) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.AllowTag = &v
-}
-
-// SetAllowComment sets the AllowComment field.
-//
-// When the provided Repo type is nil, it
-// will set nothing and immediately return.
-func (r *Repo) SetAllowComment(v bool) {
-	// return if Repo type is nil
-	if r == nil {
-		return
-	}
-
-	r.AllowComment = &v
-}
-
 // SetAllowEvents sets the AllowEvents field.
 //
 // When the provided Repo type is nil, it
@@ -768,11 +623,6 @@ func (r *Repo) SetApproveBuild(v string) {
 func (r *Repo) String() string {
 	return fmt.Sprintf(`{
   Active: %t,
-  AllowComment: %t,
-  AllowDeploy: %t,
-  AllowPull: %t,
-  AllowPush: %t,
-  AllowTag: %t,
   AllowEvents: %s,
   ApproveBuild: %s,
   Branch: %s,
@@ -794,11 +644,6 @@ func (r *Repo) String() string {
   Visibility: %s,
 }`,
 		r.GetActive(),
-		r.GetAllowComment(),
-		r.GetAllowDeploy(),
-		r.GetAllowPull(),
-		r.GetAllowPush(),
-		r.GetAllowTag(),
 		r.GetAllowEvents().List(),
 		r.GetApproveBuild(),
 		r.GetBranch(),

--- a/library/repo_test.go
+++ b/library/repo_test.go
@@ -14,44 +14,34 @@ import (
 func TestLibrary_Repo_Environment(t *testing.T) {
 	// setup types
 	want := map[string]string{
-		"VELA_REPO_ACTIVE":         "true",
-		"VELA_REPO_ALLOW_COMMENT":  "false",
-		"VELA_REPO_ALLOW_DEPLOY":   "false",
-		"VELA_REPO_ALLOW_PULL":     "false",
-		"VELA_REPO_ALLOW_PUSH":     "true",
-		"VELA_REPO_ALLOW_TAG":      "false",
-		"VELA_REPO_ALLOW_EVENTS":   "push,pull_request:opened,pull_request:synchronize,pull_request:reopened,tag,comment:created,schedule,delete:branch",
-		"VELA_REPO_BRANCH":         "main",
-		"VELA_REPO_TOPICS":         "cloud,security",
-		"VELA_REPO_BUILD_LIMIT":    "10",
-		"VELA_REPO_CLONE":          "https://github.com/github/octocat.git",
-		"VELA_REPO_FULL_NAME":      "github/octocat",
-		"VELA_REPO_LINK":           "https://github.com/github/octocat",
-		"VELA_REPO_NAME":           "octocat",
-		"VELA_REPO_ORG":            "github",
-		"VELA_REPO_PRIVATE":        "false",
-		"VELA_REPO_TIMEOUT":        "30",
-		"VELA_REPO_TRUSTED":        "false",
-		"VELA_REPO_VISIBILITY":     "public",
-		"VELA_REPO_PIPELINE_TYPE":  "",
-		"VELA_REPO_APPROVE_BUILD":  "never",
-		"REPOSITORY_ACTIVE":        "true",
-		"REPOSITORY_ALLOW_COMMENT": "false",
-		"REPOSITORY_ALLOW_DEPLOY":  "false",
-		"REPOSITORY_ALLOW_PULL":    "false",
-		"REPOSITORY_ALLOW_PUSH":    "true",
-		"REPOSITORY_ALLOW_TAG":     "false",
-		"REPOSITORY_ALLOW_EVENTS":  "push,pull_request:opened,pull_request:synchronize,pull_request:reopened,tag,comment:created,schedule,delete:branch",
-		"REPOSITORY_BRANCH":        "main",
-		"REPOSITORY_CLONE":         "https://github.com/github/octocat.git",
-		"REPOSITORY_FULL_NAME":     "github/octocat",
-		"REPOSITORY_LINK":          "https://github.com/github/octocat",
-		"REPOSITORY_NAME":          "octocat",
-		"REPOSITORY_ORG":           "github",
-		"REPOSITORY_PRIVATE":       "false",
-		"REPOSITORY_TIMEOUT":       "30",
-		"REPOSITORY_TRUSTED":       "false",
-		"REPOSITORY_VISIBILITY":    "public",
+		"VELA_REPO_ACTIVE":        "true",
+		"VELA_REPO_ALLOW_EVENTS":  "push,pull_request:opened,pull_request:synchronize,pull_request:reopened,tag,comment:created,schedule,delete:branch",
+		"VELA_REPO_BRANCH":        "main",
+		"VELA_REPO_TOPICS":        "cloud,security",
+		"VELA_REPO_BUILD_LIMIT":   "10",
+		"VELA_REPO_CLONE":         "https://github.com/github/octocat.git",
+		"VELA_REPO_FULL_NAME":     "github/octocat",
+		"VELA_REPO_LINK":          "https://github.com/github/octocat",
+		"VELA_REPO_NAME":          "octocat",
+		"VELA_REPO_ORG":           "github",
+		"VELA_REPO_PRIVATE":       "false",
+		"VELA_REPO_TIMEOUT":       "30",
+		"VELA_REPO_TRUSTED":       "false",
+		"VELA_REPO_VISIBILITY":    "public",
+		"VELA_REPO_PIPELINE_TYPE": "",
+		"VELA_REPO_APPROVE_BUILD": "never",
+		"REPOSITORY_ACTIVE":       "true",
+		"REPOSITORY_ALLOW_EVENTS": "push,pull_request:opened,pull_request:synchronize,pull_request:reopened,tag,comment:created,schedule,delete:branch",
+		"REPOSITORY_BRANCH":       "main",
+		"REPOSITORY_CLONE":        "https://github.com/github/octocat.git",
+		"REPOSITORY_FULL_NAME":    "github/octocat",
+		"REPOSITORY_LINK":         "https://github.com/github/octocat",
+		"REPOSITORY_NAME":         "octocat",
+		"REPOSITORY_ORG":          "github",
+		"REPOSITORY_PRIVATE":      "false",
+		"REPOSITORY_TIMEOUT":      "30",
+		"REPOSITORY_TRUSTED":      "false",
+		"REPOSITORY_VISIBILITY":   "public",
 	}
 
 	// run test
@@ -144,26 +134,6 @@ func TestLibrary_Repo_Getters(t *testing.T) {
 			t.Errorf("GetActive is %v, want %v", test.repo.GetActive(), test.want.GetActive())
 		}
 
-		if test.repo.GetAllowPull() != test.want.GetAllowPull() {
-			t.Errorf("GetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
-		}
-
-		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
-			t.Errorf("GetAllowPush is %v, want %v", test.repo.GetAllowPush(), test.want.GetAllowPush())
-		}
-
-		if test.repo.GetAllowDeploy() != test.want.GetAllowDeploy() {
-			t.Errorf("GetAllowDeploy is %v, want %v", test.repo.GetAllowDeploy(), test.want.GetAllowDeploy())
-		}
-
-		if test.repo.GetAllowTag() != test.want.GetAllowTag() {
-			t.Errorf("GetAllowTag is %v, want %v", test.repo.GetAllowTag(), test.want.GetAllowTag())
-		}
-
-		if test.repo.GetAllowComment() != test.want.GetAllowComment() {
-			t.Errorf("GetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
-		}
-
 		if !reflect.DeepEqual(test.repo.GetAllowEvents(), test.want.GetAllowEvents()) {
 			t.Errorf("GetRepo is %v, want %v", test.repo.GetAllowEvents(), test.want.GetAllowEvents())
 		}
@@ -220,11 +190,6 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 		test.repo.SetPrivate(test.want.GetPrivate())
 		test.repo.SetTrusted(test.want.GetTrusted())
 		test.repo.SetActive(test.want.GetActive())
-		test.repo.SetAllowPull(test.want.GetAllowPull())
-		test.repo.SetAllowPush(test.want.GetAllowPush())
-		test.repo.SetAllowDeploy(test.want.GetAllowDeploy())
-		test.repo.SetAllowTag(test.want.GetAllowTag())
-		test.repo.SetAllowComment(test.want.GetAllowComment())
 		test.repo.SetAllowEvents(test.want.GetAllowEvents())
 		test.repo.SetPipelineType(test.want.GetPipelineType())
 		test.repo.SetPreviousName(test.want.GetPreviousName())
@@ -294,26 +259,6 @@ func TestLibrary_Repo_Setters(t *testing.T) {
 			t.Errorf("SetActive is %v, want %v", test.repo.GetActive(), test.want.GetActive())
 		}
 
-		if test.repo.GetAllowPull() != test.want.GetAllowPull() {
-			t.Errorf("SetAllowPull is %v, want %v", test.repo.GetAllowPull(), test.want.GetAllowPull())
-		}
-
-		if test.repo.GetAllowPush() != test.want.GetAllowPush() {
-			t.Errorf("SetAllowPush is %v, want %v", test.repo.GetAllowPush(), test.want.GetAllowPush())
-		}
-
-		if test.repo.GetAllowDeploy() != test.want.GetAllowDeploy() {
-			t.Errorf("SetAllowDeploy is %v, want %v", test.repo.GetAllowDeploy(), test.want.GetAllowDeploy())
-		}
-
-		if test.repo.GetAllowTag() != test.want.GetAllowTag() {
-			t.Errorf("SetAllowTag is %v, want %v", test.repo.GetAllowTag(), test.want.GetAllowTag())
-		}
-
-		if test.repo.GetAllowComment() != test.want.GetAllowComment() {
-			t.Errorf("SetAllowComment is %v, want %v", test.repo.GetAllowComment(), test.want.GetAllowComment())
-		}
-
 		if !reflect.DeepEqual(test.repo.GetAllowEvents(), test.want.GetAllowEvents()) {
 			t.Errorf("GetRepo is %v, want %v", test.repo.GetAllowEvents(), test.want.GetAllowEvents())
 		}
@@ -338,11 +283,6 @@ func TestLibrary_Repo_String(t *testing.T) {
 
 	want := fmt.Sprintf(`{
   Active: %t,
-  AllowComment: %t,
-  AllowDeploy: %t,
-  AllowPull: %t,
-  AllowPush: %t,
-  AllowTag: %t,
   AllowEvents: %s,
   ApproveBuild: %s,
   Branch: %s,
@@ -364,11 +304,6 @@ func TestLibrary_Repo_String(t *testing.T) {
   Visibility: %s,
 }`,
 		r.GetActive(),
-		r.GetAllowComment(),
-		r.GetAllowDeploy(),
-		r.GetAllowPull(),
-		r.GetAllowPush(),
-		r.GetAllowTag(),
 		r.GetAllowEvents().List(),
 		r.GetApproveBuild(),
 		r.GetBranch(),
@@ -420,11 +355,6 @@ func testRepo() *Repo {
 	r.SetPrivate(false)
 	r.SetTrusted(false)
 	r.SetActive(true)
-	r.SetAllowPull(false)
-	r.SetAllowPush(true)
-	r.SetAllowDeploy(false)
-	r.SetAllowTag(false)
-	r.SetAllowComment(false)
 	r.SetAllowEvents(e)
 	r.SetPipelineType("")
 	r.SetPreviousName("")

--- a/library/secret.go
+++ b/library/secret.go
@@ -22,7 +22,6 @@ type Secret struct {
 	Value             *string   `json:"value,omitempty"`
 	Type              *string   `json:"type,omitempty"`
 	Images            *[]string `json:"images,omitempty"`
-	Events            *[]string `json:"events,omitempty"`
 	AllowEvents       *Events   `json:"allow_events,omitempty"`
 	AllowCommand      *bool     `json:"allow_command,omitempty"`
 	AllowSubstitution *bool     `json:"allow_substitution,omitempty"`
@@ -48,7 +47,6 @@ func (s *Secret) Sanitize() *Secret {
 		Value:             &value,
 		Type:              s.Type,
 		Images:            s.Images,
-		Events:            s.Events,
 		AllowEvents:       s.AllowEvents,
 		AllowCommand:      s.AllowCommand,
 		AllowSubstitution: s.AllowSubstitution,
@@ -203,19 +201,6 @@ func (s *Secret) GetImages() []string {
 	}
 
 	return *s.Images
-}
-
-// GetEvents returns the Events field.
-//
-// When the provided Secret type is nil, or the field within
-// the type is nil, it returns the zero value for the field.
-func (s *Secret) GetEvents() []string {
-	// return zero value if Secret type or Events field is nil
-	if s == nil || s.Events == nil {
-		return []string{}
-	}
-
-	return *s.Events
 }
 
 // GetAllowEvents returns the AllowEvents field.
@@ -413,19 +398,6 @@ func (s *Secret) SetImages(v []string) {
 	s.Images = &v
 }
 
-// SetEvents sets the Events field.
-//
-// When the provided Secret type is nil, it
-// will set nothing and immediately return.
-func (s *Secret) SetEvents(v []string) {
-	// return if Secret type is nil
-	if s == nil {
-		return
-	}
-
-	s.Events = &v
-}
-
 // SetAllowEvents sets the AllowEvents field.
 //
 // When the provided Secret type is nil, it
@@ -523,7 +495,6 @@ func (s *Secret) String() string {
 	AllowCommand: %t,
 	AllowEvents: %s,
 	AllowSubstitution: %t,
-	Events: %s,
 	ID: %d,
 	Images: %s,
 	Name: %s,
@@ -540,7 +511,6 @@ func (s *Secret) String() string {
 		s.GetAllowCommand(),
 		s.GetAllowEvents().List(),
 		s.GetAllowSubstitution(),
-		s.GetEvents(),
 		s.GetID(),
 		s.GetImages(),
 		s.GetName(),

--- a/library/secret_test.go
+++ b/library/secret_test.go
@@ -437,10 +437,6 @@ func TestLibrary_Secret_Getters(t *testing.T) {
 			t.Errorf("GetImages is %v, want %v", test.secret.GetImages(), test.want.GetImages())
 		}
 
-		if !reflect.DeepEqual(test.secret.GetEvents(), test.want.GetEvents()) {
-			t.Errorf("GetEvents is %v, want %v", test.secret.GetEvents(), test.want.GetEvents())
-		}
-
 		if !reflect.DeepEqual(test.secret.GetAllowEvents(), test.want.GetAllowEvents()) {
 			t.Errorf("GetAllowEvents is %v, want %v", test.secret.GetAllowEvents(), test.want.GetAllowEvents())
 		}
@@ -500,7 +496,6 @@ func TestLibrary_Secret_Setters(t *testing.T) {
 		test.secret.SetValue(test.want.GetValue())
 		test.secret.SetType(test.want.GetType())
 		test.secret.SetImages(test.want.GetImages())
-		test.secret.SetEvents(test.want.GetEvents())
 		test.secret.SetAllowEvents(test.want.GetAllowEvents())
 		test.secret.SetAllowCommand(test.want.GetAllowCommand())
 		test.secret.SetAllowSubstitution(test.want.GetAllowSubstitution())
@@ -541,10 +536,6 @@ func TestLibrary_Secret_Setters(t *testing.T) {
 			t.Errorf("SetImages is %v, want %v", test.secret.GetImages(), test.want.GetImages())
 		}
 
-		if !reflect.DeepEqual(test.secret.GetEvents(), test.want.GetEvents()) {
-			t.Errorf("SetEvents is %v, want %v", test.secret.GetEvents(), test.want.GetEvents())
-		}
-
 		if !reflect.DeepEqual(test.secret.GetAllowEvents(), test.want.GetAllowEvents()) {
 			t.Errorf("SetAllowEvents is %v, want %v", test.secret.GetAllowEvents(), test.want.GetAllowEvents())
 		}
@@ -583,7 +574,6 @@ func TestLibrary_Secret_String(t *testing.T) {
 	AllowCommand: %t,
 	AllowEvents: %v,
 	AllowSubstitution: %t,
-	Events: %s,
 	ID: %d,
 	Images: %s,
 	Name: %s,
@@ -600,7 +590,6 @@ func TestLibrary_Secret_String(t *testing.T) {
 		s.GetAllowCommand(),
 		s.GetAllowEvents().List(),
 		s.GetAllowSubstitution(),
-		s.GetEvents(),
 		s.GetID(),
 		s.GetImages(),
 		s.GetName(),
@@ -639,7 +628,6 @@ func testSecret() *Secret {
 	s.SetValue("bar")
 	s.SetType("repo")
 	s.SetImages([]string{"alpine"})
-	s.SetEvents([]string{"push", "tag", "deployment"})
 	s.SetAllowEvents(NewEventsFromMask(1))
 	s.SetAllowCommand(true)
 	s.SetAllowSubstitution(true)


### PR DESCRIPTION
`v0.23` kept these fields around in case of need for reverting. With `v0.24` slotted as our next release, we can pursue removing these unused fields