### PR TITLE
fix: allow events yaml unmarshal

### DIFF
--- a/library/events.go
+++ b/library/events.go
@@ -3,10 +3,12 @@
 package library
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library/actions"
+	"github.com/go-vela/types/raw"
 )
 
 // Events is the library representation of the various events that generate a
@@ -17,6 +19,29 @@ type Events struct {
 	Deployment  *actions.Deploy   `json:"deployment"`
 	Comment     *actions.Comment  `json:"comment"`
 	Schedule    *actions.Schedule `json:"schedule"`
+}
+
+// UnmarshalYAML implements the Unmarshaler interface for the Events type.
+func (e *Events) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// string slice we try unmarshalling to
+	stringSlice := new(raw.StringSlice)
+
+	// attempt to unmarshal as a string slice type
+	err := unmarshal(stringSlice)
+	if err == nil {
+		// create new events from string slice
+		evs, err := NewEventsFromSlice(*stringSlice)
+		if err != nil {
+			return err
+		}
+
+		// overwrite existing Events
+		*e = *evs
+
+		return nil
+	}
+
+	return errors.New("failed to unmarshal Events")
 }
 
 // NewEventsFromMask is an instatiation function for the Events type that

--- a/library/events.go
+++ b/library/events.go
@@ -3,6 +3,8 @@
 package library
 
 import (
+	"fmt"
+
 	"github.com/go-vela/types/constants"
 	"github.com/go-vela/types/library/actions"
 )
@@ -39,7 +41,7 @@ func NewEventsFromMask(mask int64) *Events {
 
 // NewEventsFromSlice is an instantiation function for the Events type that
 // takes in a slice of event strings and populates the nested Events struct.
-func NewEventsFromSlice(events []string) *Events {
+func NewEventsFromSlice(events []string) (*Events, error) {
 	mask := int64(0)
 
 	// iterate through all events provided
@@ -88,10 +90,13 @@ func NewEventsFromSlice(events []string) *Events {
 		// schedule actions
 		case constants.EventSchedule, constants.EventSchedule + ":" + constants.ActionRun:
 			mask = mask | constants.AllowSchedule
+
+		default:
+			return nil, fmt.Errorf("invalid event provided: %s", event)
 		}
 	}
 
-	return NewEventsFromMask(mask)
+	return NewEventsFromMask(mask), nil
 }
 
 // Allowed determines whether or not an event + action is allowed based on whether

--- a/library/repo.go
+++ b/library/repo.go
@@ -28,10 +28,29 @@ type Repo struct {
 	Private      *bool     `json:"private,omitempty"`
 	Trusted      *bool     `json:"trusted,omitempty"`
 	Active       *bool     `json:"active,omitempty"`
-	AllowEvents  *Events   `json:"allow_events,omitempty"`
+	AllowEvents  *Events   `json:"allow_events,omitempty" yaml:"allow_events"`
 	PipelineType *string   `json:"pipeline_type,omitempty"`
 	PreviousName *string   `json:"previous_name,omitempty"`
 	ApproveBuild *string   `json:"approve_build,omitempty"`
+}
+
+// UnmarshalYAML implements the Unmarshaler interface for the Repo type.
+// This allows custom fields in the Repo type to be read from a YAML file, like AllowEvents.
+func (r *Repo) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// create an alias to perform a normal unmarshal and avoid an infinite loop
+	type jsonRepo Repo
+
+	tmp := &jsonRepo{}
+
+	err := unmarshal(tmp)
+	if err != nil {
+		return err
+	}
+
+	// overwrite existing Repo
+	*r = Repo(*tmp)
+
+	return nil
 }
 
 // Environment returns a list of environment variables

--- a/library/secret.go
+++ b/library/secret.go
@@ -22,13 +22,32 @@ type Secret struct {
 	Value             *string   `json:"value,omitempty"`
 	Type              *string   `json:"type,omitempty"`
 	Images            *[]string `json:"images,omitempty"`
-	AllowEvents       *Events   `json:"allow_events,omitempty"`
+	AllowEvents       *Events   `json:"allow_events,omitempty" yaml:"allow_events"`
 	AllowCommand      *bool     `json:"allow_command,omitempty"`
 	AllowSubstitution *bool     `json:"allow_substitution,omitempty"`
 	CreatedAt         *int64    `json:"created_at,omitempty"`
 	CreatedBy         *string   `json:"created_by,omitempty"`
 	UpdatedAt         *int64    `json:"updated_at,omitempty"`
 	UpdatedBy         *string   `json:"updated_by,omitempty"`
+}
+
+// UnmarshalYAML implements the Unmarshaler interface for the Secret type.
+// This allows custom fields in the Secret type to be read from a YAML file, like AllowEvents.
+func (s *Secret) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	// create an alias to perform a normal unmarshal and avoid an infinite loop
+	type jsonSecret Secret
+
+	tmp := &jsonSecret{}
+
+	err := unmarshal(tmp)
+	if err != nil {
+		return err
+	}
+
+	// overwrite existing secret
+	*s = Secret(*tmp)
+
+	return nil
 }
 
 // Sanitize creates a duplicate of the Secret without the value.


### PR DESCRIPTION
lets `allow_events` be unmarshalled as a string slice in yaml, primarily for the cli to read add/update input from a file.

kudos @wsan3 for spotting the bug
