### PR TITLE
feat(schedule): show schedule errors

### DIFF
--- a/database/schedule.go
+++ b/database/schedule.go
@@ -37,6 +37,7 @@ type Schedule struct {
 	UpdatedBy   sql.NullString `sql:"updated_by"`
 	ScheduledAt sql.NullInt64  `sql:"scheduled_at"`
 	Branch      sql.NullString `sql:"branch"`
+	Error       sql.NullString `sql:"error"`
 }
 
 // ScheduleFromLibrary converts the library.Schedule type to a database Schedule type.
@@ -53,6 +54,7 @@ func ScheduleFromLibrary(s *library.Schedule) *Schedule {
 		UpdatedBy:   sql.NullString{String: s.GetUpdatedBy(), Valid: true},
 		ScheduledAt: sql.NullInt64{Int64: s.GetScheduledAt(), Valid: true},
 		Branch:      sql.NullString{String: s.GetBranch(), Valid: true},
+		Error:       sql.NullString{String: s.GetError(), Valid: true},
 	}
 
 	return schedule.Nullify()
@@ -89,6 +91,8 @@ func (s *Schedule) Nullify() *Schedule {
 	s.ScheduledAt.Valid = s.ScheduledAt.Int64 != 0
 	// check if the Branch field should be valid
 	s.Branch.Valid = len(s.Branch.String) != 0
+	// check if the Error field should be valid
+	s.Error.Valid = len(s.Error.String) != 0
 
 	return s
 }
@@ -107,6 +111,7 @@ func (s *Schedule) ToLibrary() *library.Schedule {
 		UpdatedBy:   &s.UpdatedBy.String,
 		ScheduledAt: &s.ScheduledAt.Int64,
 		Branch:      &s.Branch.String,
+		Error:       &s.Error.String,
 	}
 }
 

--- a/database/schedule_test.go
+++ b/database/schedule_test.go
@@ -24,7 +24,7 @@ func TestDatabase_ScheduleFromLibrary(t *testing.T) {
 	s.SetUpdatedBy("user2")
 	s.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	s.SetBranch("main")
-	s.SetError("failed to execute")
+	s.SetError("unable to trigger build for schedule nightly: unknown character")
 
 	want := testSchedule()
 
@@ -92,7 +92,7 @@ func TestDatabase_Schedule_ToLibrary(t *testing.T) {
 	want.SetUpdatedBy("user2")
 	want.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	want.SetBranch("main")
-	want.SetError("failed to execute")
+	want.SetError("unable to trigger build for schedule nightly: unknown character")
 
 	got := testSchedule().ToLibrary()
 	if !reflect.DeepEqual(got, want) {
@@ -182,6 +182,6 @@ func testSchedule() *Schedule {
 		UpdatedBy:   sql.NullString{String: "user2", Valid: true},
 		ScheduledAt: sql.NullInt64{Int64: time.Now().Add(time.Hour * 2).UTC().Unix(), Valid: true},
 		Branch:      sql.NullString{String: "main", Valid: true},
-		Error:       sql.NullString{String: "failed to execute", Valid: true},
+		Error:       sql.NullString{String: "unable to trigger build for schedule nightly: unknown character", Valid: true},
 	}
 }

--- a/database/schedule_test.go
+++ b/database/schedule_test.go
@@ -24,6 +24,7 @@ func TestDatabase_ScheduleFromLibrary(t *testing.T) {
 	s.SetUpdatedBy("user2")
 	s.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	s.SetBranch("main")
+	s.SetError("failed to execute")
 
 	want := testSchedule()
 
@@ -91,6 +92,7 @@ func TestDatabase_Schedule_ToLibrary(t *testing.T) {
 	want.SetUpdatedBy("user2")
 	want.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	want.SetBranch("main")
+	want.SetError("failed to execute")
 
 	got := testSchedule().ToLibrary()
 	if !reflect.DeepEqual(got, want) {
@@ -180,5 +182,6 @@ func testSchedule() *Schedule {
 		UpdatedBy:   sql.NullString{String: "user2", Valid: true},
 		ScheduledAt: sql.NullInt64{Int64: time.Now().Add(time.Hour * 2).UTC().Unix(), Valid: true},
 		Branch:      sql.NullString{String: "main", Valid: true},
+		Error:       sql.NullString{String: "failed to execute", Valid: true},
 	}
 }

--- a/library/schedule.go
+++ b/library/schedule.go
@@ -21,6 +21,7 @@ type Schedule struct {
 	UpdatedBy   *string `json:"updated_by,omitempty"`
 	ScheduledAt *int64  `json:"scheduled_at,omitempty"`
 	Branch      *string `json:"branch,omitempty"`
+	Error       *string `json:"error,omitempty"`
 }
 
 // GetID returns the ID field from the provided Schedule. If the object is nil,
@@ -144,6 +145,17 @@ func (s *Schedule) GetBranch() string {
 	return *s.Branch
 }
 
+// GetError returns the Error field from the provided Schedule. If the object is nil,
+// or the field within the object is nil, it returns the zero value instead.
+func (s *Schedule) GetError() string {
+	// return zero value if Schedule type or Error field is nil
+	if s == nil || s.Error == nil {
+		return ""
+	}
+
+	return *s.Error
+}
+
 // SetID sets the ID field in the provided Schedule. If the object is nil,
 // it will set nothing and immediately return making this a no-op.
 func (s *Schedule) SetID(id int64) {
@@ -265,6 +277,17 @@ func (s *Schedule) SetBranch(branch string) {
 	s.Branch = &branch
 }
 
+// SetError sets the Error field in the provided Schedule. If the object is nil,
+// it will set nothing and immediately return making this a no-op.
+func (s *Schedule) SetError(err string) {
+	// return if Schedule type is nil
+	if s == nil {
+		return
+	}
+
+	s.Error = &err
+}
+
 // String implements the Stringer interface for the Schedule type.
 func (s *Schedule) String() string {
 	return fmt.Sprintf(`{
@@ -279,6 +302,7 @@ func (s *Schedule) String() string {
   UpdatedAt: %d,
   UpdatedBy: %s,
   Branch: %s,
+  Error: %s,
 }`,
 		s.GetActive(),
 		s.GetCreatedAt(),
@@ -291,5 +315,6 @@ func (s *Schedule) String() string {
 		s.GetUpdatedAt(),
 		s.GetUpdatedBy(),
 		s.GetBranch(),
+		s.GetError(),
 	)
 }

--- a/library/schedule_test.go
+++ b/library/schedule_test.go
@@ -77,6 +77,10 @@ func TestLibrary_Schedule_Getters(t *testing.T) {
 			if test.schedule.GetBranch() != test.want.GetBranch() {
 				t.Errorf("GetBranch is %v, want %v", test.schedule.GetBranch(), test.want.GetBranch())
 			}
+
+			if test.schedule.GetError() != test.want.GetError() {
+				t.Errorf("GetError is %v, want %v", test.schedule.GetError(), test.want.GetError())
+			}
 		})
 	}
 }
@@ -118,6 +122,7 @@ func TestLibrary_Schedule_Setters(t *testing.T) {
 			test.schedule.SetUpdatedBy(test.want.GetUpdatedBy())
 			test.schedule.SetScheduledAt(test.want.GetScheduledAt())
 			test.schedule.SetBranch(test.want.GetBranch())
+			test.schedule.SetError(test.want.GetError())
 
 			if test.schedule.GetID() != test.want.GetID() {
 				t.Errorf("SetID is %v, want %v", test.schedule.GetID(), test.want.GetID())
@@ -162,6 +167,10 @@ func TestLibrary_Schedule_Setters(t *testing.T) {
 			if test.schedule.GetBranch() != test.want.GetBranch() {
 				t.Errorf("SetBranch is %v, want %v", test.schedule.GetBranch(), test.want.GetBranch())
 			}
+
+			if test.schedule.GetError() != test.want.GetError() {
+				t.Errorf("SetError is %v, want %v", test.schedule.GetError(), test.want.GetError())
+			}
 		})
 	}
 }
@@ -181,6 +190,7 @@ func TestLibrary_Schedule_String(t *testing.T) {
   UpdatedAt: %d,
   UpdatedBy: %s,
   Branch: %s,
+  Error: %s,
 }`,
 		s.GetActive(),
 		s.GetCreatedAt(),
@@ -193,6 +203,7 @@ func TestLibrary_Schedule_String(t *testing.T) {
 		s.GetUpdatedAt(),
 		s.GetUpdatedBy(),
 		s.GetBranch(),
+		s.GetError(),
 	)
 
 	got := s.String()
@@ -215,6 +226,7 @@ func testSchedule() *Schedule {
 	s.SetUpdatedBy("user2")
 	s.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	s.SetBranch("main")
+	s.SetError("failed to execute")
 
 	return s
 }

--- a/library/schedule_test.go
+++ b/library/schedule_test.go
@@ -226,7 +226,7 @@ func testSchedule() *Schedule {
 	s.SetUpdatedBy("user2")
 	s.SetScheduledAt(time.Now().Add(time.Hour * 2).UTC().Unix())
 	s.SetBranch("main")
-	s.SetError("failed to execute")
+	s.SetError("unable to trigger build for schedule nightly: unknown character")
 
 	return s
 }


### PR DESCRIPTION
### Description
Whenever a user has a YAML bug in their pipeline, or any other build-breaking error that short-circuits pipeline execution, they can usually find these error in the Audit tab, where we populate the hook with the error message.

This is currently not available for schedules. Instead, the error is just logged.

### Related
https://github.com/go-vela/community/issues/872