### PR TITLE
feat: Vela OIDC Provider

### DIFF
--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -52,6 +52,7 @@ type (
 		Volumes     VolumeSlice       `json:"volumes,omitempty"     yaml:"volumes,omitempty"`
 		User        string            `json:"user,omitempty"        yaml:"user,omitempty"`
 		ReportAs    string            `json:"report_as,omitempty" yaml:"report_as,omitempty"`
+		IDRequest   string            `json:"id_request,omitempty" yaml:"id_request,omitempty"`
 	}
 )
 
@@ -135,7 +136,8 @@ func (c *Container) Empty() bool {
 		len(c.Ulimits) == 0 &&
 		len(c.Volumes) == 0 &&
 		len(c.User) == 0 &&
-		len(c.ReportAs) == 0 {
+		len(c.ReportAs) == 0 &&
+		len(c.IDRequest) == 0 {
 		return true
 	}
 

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -932,6 +932,7 @@ func testContainers() *ContainerSlice {
 			Name:        "clone",
 			Number:      2,
 			Pull:        "always",
+			IDRequest:   "yes",
 		},
 		{
 			ID:          "step_github/octocat._1_echo",

--- a/yaml/step.go
+++ b/yaml/step.go
@@ -35,6 +35,7 @@ type (
 		Privileged  bool                   `yaml:"privileged,omitempty"  json:"privileged,omitempty" jsonschema:"description=Run the container with extra privileges.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/#the-privileged-tag"`
 		User        string                 `yaml:"user,omitempty"        json:"user,omitempty" jsonschema:"description=Set the user for the container.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/#the-user-tag"`
 		ReportAs    string                 `yaml:"report_as,omitempty" json:"report_as,omitempty" jsonschema:"description=Set the name of the step to report as.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/#the-report_as-tag"`
+		IDRequest   string                 `yaml:"id_request,omitempty" json:"id_request,omitempty" jsonschema:"description=Request ID Request Token for the step.\nReference: https://go-vela.github.io/docs/reference/yaml/steps/#the-id_request-tag"`
 	}
 )
 
@@ -62,6 +63,7 @@ func (s *StepSlice) ToPipeline() *pipeline.ContainerSlice {
 			Volumes:     *step.Volumes.ToPipeline(),
 			User:        step.User,
 			ReportAs:    step.ReportAs,
+			IDRequest:   step.IDRequest,
 		})
 	}
 

--- a/yaml/step_test.go
+++ b/yaml/step_test.go
@@ -31,6 +31,7 @@ func TestYaml_StepSlice_ToPipeline(t *testing.T) {
 					Privileged:  false,
 					Pull:        "not_present",
 					ReportAs:    "my-step",
+					IDRequest:   "yes",
 					Ruleset: Ruleset{
 						If: Rules{
 							Branch:  []string{"main"},
@@ -88,6 +89,7 @@ func TestYaml_StepSlice_ToPipeline(t *testing.T) {
 					Privileged:  false,
 					Pull:        "not_present",
 					ReportAs:    "my-step",
+					IDRequest:   "yes",
 					Ruleset: pipeline.Ruleset{
 						If: pipeline.Rules{
 							Branch:  []string{"main"},


### PR DESCRIPTION
The majority of this code will be in the server, and there is a branch with the same name there that has the implementation if anyone is curious.

For types specifically, I don't think `VELA_ID_TOKEN_REQUEST_TOKEN`s should be available in _all_ steps. Users should be able to specifically invoke the injection of the token using something like:

```yaml
version: "1"

steps:
  - name: request token
    image: alpine:latest
    id_request: write  # becomes a claim in token `request`
    commands:
      - apk add curl
      - 'curl -H "Authorization: Bearer $VELA_ID_TOKEN_REQUEST_TOKEN" $VELA_ID_TOKEN_REQUEST_URL'
```

The string value for `id_request` just becomes one of the claims in the eventual ID token. I figured that may be useful in some contexts. 