### PR TITLE
fix(ci): use intermediate env variable for PR title validator

### DIFF
--- a/.github/workflows/pr-title-validate.yml
+++ b/.github/workflows/pr-title-validate.yml
@@ -13,5 +13,7 @@ jobs:
     
     steps:
     - name: validate title
+      env:
+        TITLE: ${{ github.event.pull_request.title }}
       run: |
-        echo "${{ github.event.pull_request.title }}" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)(\(.*\)|):\s.+$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)
+        echo "$TITLE" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)(\(.*\)|):\s.+$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)

--- a/.github/workflows/pr-title-validate.yml
+++ b/.github/workflows/pr-title-validate.yml
@@ -16,4 +16,4 @@ jobs:
       env:
         TITLE: ${{ github.event.pull_request.title }}
       run: |
-        echo "$TITLE" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)(\(.*\)|):\s.+$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)
+        echo "$TITLE" | grep -Eq '^(feat|fix|chore|refactor|enhance|test|docs)(\(.*\)|)!?:\s.+$' && (echo "Pass"; exit 0) || (echo "Incorrect Format. Please see https://go-vela.github.io/docs/community/contributing_guidelines/#development-workflow"; exit 1)


### PR DESCRIPTION
We have workflow approval settings properly configured, but this is best practice.

See: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable