### PR TITLE
fix(container): skip "label" rule evaluation in container execution

### DIFF
--- a/pipeline/container.go
+++ b/pipeline/container.go
@@ -152,31 +152,20 @@ func (c *Container) Execute(r *RuleData) (bool, error) {
 	if c == nil {
 		return false, nil
 	}
-	// skip evaluating path in ruleset
+
+	// Skip evaluating path, comment, and label in ruleset,
+	// as the worker lacks necessary rule data.
 	//
-	// the compiler is the component responsible for
-	// choosing whether a container will run based
-	// off the files changed for a build
-	//
-	// the worker doesn't have any record of
-	// what files changed for a build so we
-	// should "skip" evaluating what the
-	// user provided for the path element
+	// The compiler determines whether a container will run based on
+	// these rules.
 	c.Ruleset.If.Path = []string{}
 	c.Ruleset.Unless.Path = []string{}
 
-	// skip evaluating comment in ruleset
-	//
-	// the compiler is the component responsible for
-	// choosing whether a container will run based
-	// off the PR comment matching the pipeline comment
-	//
-	// the worker doesn't have any record of
-	// the PR comment so we
-	// should "skip" evaluating what the
-	// user provided for the PR comment
 	c.Ruleset.If.Comment = []string{}
 	c.Ruleset.Unless.Comment = []string{}
+
+	c.Ruleset.If.Label = []string{}
+	c.Ruleset.Unless.Label = []string{}
 
 	// check if the build is in a running state
 	if strings.EqualFold(r.Status, constants.StatusRunning) {

--- a/pipeline/container_test.go
+++ b/pipeline/container_test.go
@@ -749,6 +749,92 @@ func TestPipeline_Container_Execute(t *testing.T) {
 			},
 			want: true,
 		},
+		{ // pull request labeled success container with build success
+			container: &Container{
+				Name:     "pull-request-labeled",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Branch: []string{"fix/1234"},
+						Event:  []string{constants.EventPull + constants.ActionLabeled},
+						Label:  []string{"enhancement", "documentation"},
+					},
+					Operator: "and",
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "fix/1234",
+				Event:  "pull_request:labeled",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
+		{ // pull request unlabeled success container with build success
+			container: &Container{
+				Name:     "pull-request-unlabeled",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					If: Rules{
+						Event: []string{constants.EventPull + constants.ActionUnlabeled},
+						Label: []string{"enhancement"},
+					},
+					Operator: "and",
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "fix/1234",
+				Event:  "pull_request:unlabeled",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
+		{ // pull request labeled unless ruleset, success container with build success
+			container: &Container{
+				Name:     "pull-request-labeled",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					Unless: Rules{
+						Branch: []string{"fix/1234"},
+						Event:  []string{constants.EventPull + constants.ActionLabeled},
+						Label:  []string{"enhancement", "documentation"},
+					},
+					Operator: "and",
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "fix/1234",
+				Event:  "pull_request:labeled",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
+		{ // pull request unlabeled unless ruleset, success container with build success
+			container: &Container{
+				Name:     "pull-request-unlabeled",
+				Image:    "alpine:latest",
+				Commands: []string{"echo \"Hey Vela\""},
+				Ruleset: Ruleset{
+					Unless: Rules{
+						Event: []string{constants.EventPull + constants.ActionUnlabeled},
+						Label: []string{"enhancement"},
+					},
+					Operator: "and",
+				},
+			},
+			ruleData: &RuleData{
+				Branch: "fix/1234",
+				Event:  "pull_request:unlabeled",
+				Repo:   "foo/bar",
+				Status: "success",
+			},
+			want: true,
+		},
 	}
 
 	// run tests


### PR DESCRIPTION
## Description
Add `label` as another rule to skip when matching during container execution, as worker lacks necessary rule data.

The compiler already determines whether a container will run based on that rule and others.