### PR TITLE
fix(swagger): remove old model annotations

### DIFF
--- a/library/build.go
+++ b/library/build.go
@@ -12,6 +12,8 @@ import (
 )
 
 // Build is the library representation of a build for a pipeline.
+//
+// Deprecated: use Build from github.com/go-vela/server/api/types instead.
 type Build struct {
 	ID            *int64              `json:"id,omitempty"`
 	RepoID        *int64              `json:"repo_id,omitempty"`

--- a/library/build.go
+++ b/library/build.go
@@ -12,8 +12,6 @@ import (
 )
 
 // Build is the library representation of a build for a pipeline.
-//
-// swagger:model Build
 type Build struct {
 	ID            *int64              `json:"id,omitempty"`
 	RepoID        *int64              `json:"repo_id,omitempty"`

--- a/library/build_queue.go
+++ b/library/build_queue.go
@@ -7,7 +7,7 @@ import "fmt"
 
 // BuildQueue is the library representation of the builds in the queue.
 //
-// Deprecated: Use QueueBuild from github.com/go-vela/server/api/types instead.
+// Deprecated: use QueueBuild from github.com/go-vela/server/api/types instead.
 //
 // swagger:model BuildQueue
 type BuildQueue struct {

--- a/library/build_queue.go
+++ b/library/build_queue.go
@@ -7,6 +7,8 @@ import "fmt"
 
 // BuildQueue is the library representation of the builds in the queue.
 //
+// Deprecated: Use QueueBuild from github.com/go-vela/server/api/types instead.
+//
 // swagger:model BuildQueue
 type BuildQueue struct {
 	Status   *string `json:"status,omitempty"`

--- a/library/executor.go
+++ b/library/executor.go
@@ -10,6 +10,8 @@ import (
 )
 
 // Executor is the library representation of an executor for a worker.
+//
+// Deprecated: use Executor from github.com/go-vela/server/api/types instead.
 type Executor struct {
 	ID           *int64          `json:"id,omitempty"`
 	Host         *string         `json:"host,omitempty"`

--- a/library/executor.go
+++ b/library/executor.go
@@ -10,8 +10,6 @@ import (
 )
 
 // Executor is the library representation of an executor for a worker.
-//
-// swagger:model Executor
 type Executor struct {
 	ID           *int64          `json:"id,omitempty"`
 	Host         *string         `json:"host,omitempty"`

--- a/library/repo.go
+++ b/library/repo.go
@@ -8,6 +8,8 @@ import (
 )
 
 // Repo is the library representation of a repo.
+//
+// Deprecated: use Repo from github.com/go-vela/server/api/types instead.
 type Repo struct {
 	ID           *int64    `json:"id,omitempty"`
 	UserID       *int64    `json:"user_id,omitempty"`

--- a/library/repo.go
+++ b/library/repo.go
@@ -8,8 +8,6 @@ import (
 )
 
 // Repo is the library representation of a repo.
-//
-// swagger:model Repo
 type Repo struct {
 	ID           *int64    `json:"id,omitempty"`
 	UserID       *int64    `json:"user_id,omitempty"`

--- a/library/schedule.go
+++ b/library/schedule.go
@@ -7,8 +7,6 @@ import (
 )
 
 // Schedule is the API representation of a schedule for a repo.
-//
-// swagger:model Schedule
 type Schedule struct {
 	ID          *int64  `json:"id,omitempty"`
 	RepoID      *int64  `json:"repo_id,omitempty"`

--- a/library/schedule.go
+++ b/library/schedule.go
@@ -7,6 +7,8 @@ import (
 )
 
 // Schedule is the API representation of a schedule for a repo.
+//
+// Deprecated: use Schedule from github.com/go-vela/server/api/types instead.
 type Schedule struct {
 	ID          *int64  `json:"id,omitempty"`
 	RepoID      *int64  `json:"repo_id,omitempty"`

--- a/library/user.go
+++ b/library/user.go
@@ -9,6 +9,8 @@ import (
 )
 
 // User is the library representation of a user.
+//
+// Deprecated: use User from github.com/go-vela/server/api/types instead.
 type User struct {
 	ID           *int64    `json:"id,omitempty"`
 	Name         *string   `json:"name,omitempty"`

--- a/library/user.go
+++ b/library/user.go
@@ -9,8 +9,6 @@ import (
 )
 
 // User is the library representation of a user.
-//
-// swagger:model User
 type User struct {
 	ID           *int64    `json:"id,omitempty"`
 	Name         *string   `json:"name,omitempty"`

--- a/library/worker.go
+++ b/library/worker.go
@@ -7,6 +7,8 @@ import (
 )
 
 // Worker is the library representation of a worker.
+//
+// Deprecated: use Worker from github.com/go-vela/server/api/types instead.
 type Worker struct {
 	ID                  *int64    `json:"id,omitempty"`
 	Hostname            *string   `json:"hostname,omitempty"`

--- a/library/worker.go
+++ b/library/worker.go
@@ -7,8 +7,6 @@ import (
 )
 
 // Worker is the library representation of a worker.
-//
-// swagger:model Worker
 type Worker struct {
 	ID                  *int64    `json:"id,omitempty"`
 	Hostname            *string   `json:"hostname,omitempty"`


### PR DESCRIPTION
the modified model annotations have moved to [go-vela/server/api/types](https://github.com/go-vela/server/blob/main/api/types) where a duplicate of these annotations can be found. this change is needed for accurate swagger doc generation. see
https://github.com/go-vela/server/pull/1159 .

i've replaced the swagger documentation with godoc annotation that marks these structs as deprecated, so we should see warnings anywhere these are used yet.