### PR TITLE
fix(yaml): remediate insecure/archived buildkite lib in favor of go-yaml v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.21.9
 
 require (
 	github.com/adhocore/gronx v1.8.1
-	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/drone/envsubst v1.0.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/lib/pq v1.10.9
 	github.com/microcosm-cc/bluemonday v1.0.26
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,6 @@ github.com/adhocore/gronx v1.8.1 h1:F2mLTG5sB11z7vplwD4iydz3YCEjstSfYmCrdSm3t6A=
 github.com/adhocore/gronx v1.8.1/go.mod h1:7oUY1WAU8rEJWmAxXR2DN0JaO4gi9khSgKjiRypqteg=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
-github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
-github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -29,3 +27,5 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/library/string.go
+++ b/library/string.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/buildkite/yaml"
 	json "github.com/ghodss/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 // ToString is a helper function to convert

--- a/raw/map_test.go
+++ b/raw/map_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRaw_StringSliceMap_UnmarshalJSON(t *testing.T) {

--- a/raw/slice_test.go
+++ b/raw/slice_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 )
 
 func TestRaw_StringSlice_UnmarshalJSON(t *testing.T) {

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/raw"

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/service_test.go
+++ b/yaml/service_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -7,7 +7,8 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"github.com/google/go-cmp/cmp"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )
@@ -287,8 +288,8 @@ func TestYaml_StageSlice_UnmarshalYAML(t *testing.T) {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}
 
-		if !reflect.DeepEqual(got, test.want) {
-			t.Errorf("UnmarshalYAML is %v, want %v", got, test.want)
+		if diff := cmp.Diff(test.want, got); diff != "" {
+			t.Errorf("(Unmarshal mismatch: -want +got):\n%s", diff)
 		}
 	}
 }
@@ -413,8 +414,8 @@ func TestYaml_StageSlice_MarshalYAML(t *testing.T) {
 			t.Errorf("UnmarshalYAML returned err: %v", err)
 		}
 
-		if !reflect.DeepEqual(got2, test.want) {
-			t.Errorf("MarshalYAML is %v, want %v", got2, test.want)
+		if diff := cmp.Diff(got2, test.want); diff != "" {
+			t.Errorf("(Marshal mismatch: -got +want):\n%s", diff)
 		}
 	}
 }

--- a/yaml/step_test.go
+++ b/yaml/step_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"

--- a/yaml/template_test.go
+++ b/yaml/template_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/library"
 )

--- a/yaml/ulimit_test.go
+++ b/yaml/ulimit_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/volume_test.go
+++ b/yaml/volume_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/buildkite/yaml"
+	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )


### PR DESCRIPTION
Use `yaml.Node` to create our own `MapSlice` type that we were relying on with the buildkite/go-yamlV2 implementation. However, now anchors will work with stages, as is made obvious by the passing tests that came from https://github.com/go-vela/types/pull/12.