### PR TITLE
enhance(secrets): uppercase secret target

### DIFF
--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -246,11 +246,11 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 						Secrets: StepSecretSlice{
 							{
 								Source: "docker_username",
-								Target: "plugin_username",
+								Target: "PLUGIN_USERNAME",
 							},
 							{
 								Source: "docker_password",
-								Target: "plugin_password",
+								Target: "PLUGIN_PASSWORD",
 							},
 						},
 					},
@@ -308,11 +308,11 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 							Secrets: StepSecretSlice{
 								{
 									Source: "docker_username",
-									Target: "docker_username",
+									Target: "DOCKER_USERNAME",
 								},
 								{
 									Source: "docker_password",
-									Target: "docker_password",
+									Target: "DOCKER_PASSWORD",
 								},
 							},
 						},

--- a/yaml/secret.go
+++ b/yaml/secret.go
@@ -239,7 +239,7 @@ func (s *StepSecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error
 			// append the element to the step secret slice
 			*s = append(*s, &StepSecret{
 				Source: secret,
-				Target: secret,
+				Target: strings.ToUpper(secret),
 			})
 		}
 
@@ -257,6 +257,8 @@ func (s *StepSecretSlice) UnmarshalYAML(unmarshal func(interface{}) error) error
 			if len(secret.Source) == 0 || len(secret.Target) == 0 {
 				return fmt.Errorf("no secret source or target found")
 			}
+
+			secret.Target = strings.ToUpper(secret.Target)
 		}
 
 		// overwrite existing StepSecretSlice

--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -264,11 +264,11 @@ func TestYaml_SecretSlice_UnmarshalYAML(t *testing.T) {
 						Secrets: StepSecretSlice{
 							{
 								Source: "foo",
-								Target: "foo",
+								Target: "FOO",
 							},
 							{
 								Source: "foobar",
-								Target: "foobar",
+								Target: "FOOBAR",
 							},
 						},
 					},
@@ -296,11 +296,11 @@ func TestYaml_SecretSlice_UnmarshalYAML(t *testing.T) {
 						Secrets: StepSecretSlice{
 							{
 								Source: "foo",
-								Target: "foo",
+								Target: "FOO",
 							},
 							{
 								Source: "foobar",
-								Target: "foobar",
+								Target: "FOOBAR",
 							},
 						},
 					},
@@ -390,11 +390,11 @@ func TestYaml_StepSecretSlice_UnmarshalYAML(t *testing.T) {
 			want: &StepSecretSlice{
 				{
 					Source: "foo",
-					Target: "bar",
+					Target: "BAR",
 				},
 				{
 					Source: "hello",
-					Target: "world",
+					Target: "WORLD",
 				},
 			},
 		},
@@ -404,11 +404,11 @@ func TestYaml_StepSecretSlice_UnmarshalYAML(t *testing.T) {
 			want: &StepSecretSlice{
 				{
 					Source: "foo",
-					Target: "foo",
+					Target: "FOO",
 				},
 				{
 					Source: "hello",
-					Target: "hello",
+					Target: "HELLO",
 				},
 			},
 		},


### PR DESCRIPTION
Since we [already inject secrets in uppercase no matter what](https://github.com/go-vela/worker/blob/dd70412c168c4fc137490d01354991e3cc3d4380/executor/linux/secret.go#L352), we might as well be honest during parsing and capitalize the secret `target`