### PR TITLE
fix(yaml): support collapsing of multiple anchor keys in step

### DIFF
--- a/yaml/testdata/merge_anchor_step.yml
+++ b/yaml/testdata/merge_anchor_step.yml
@@ -1,0 +1,46 @@
+# test file that uses the non-standard multiple anchor keys in one step to test custom step unmarshaler
+
+version: "1"
+
+aliases:
+  images:
+    alpine: &alpine-image
+      image: alpine:latest
+    postgres: &pg-image
+      image: postgres
+    
+  events:
+    push: &event-push
+      ruleset:
+        event:
+          - push
+  env:
+    dev-env: &dev-environment
+      environment:
+        REGION: dev 
+
+services:
+  - name: service-a
+    <<: *pg-image
+    <<: *dev-environment
+    ports:
+      - "5432:5432"
+
+steps:
+  - name: alpha
+    <<: *alpine-image
+    <<: *event-push
+    commands:
+      - echo alpha
+
+  - name: beta
+    <<: [ *alpine-image, *event-push ]
+    commands:
+      - echo beta
+
+  - name: gamma
+    <<: *alpine-image
+    <<: *event-push
+    <<: *dev-environment
+    commands:
+      - echo gamma


### PR DESCRIPTION
https://github.com/go-vela/types/pull/386 introduced a regression(?) where the following step configurations were no longer valid:

```yaml
  - name: alpha
    <<: *alpine-image
    <<: *event-push
    commands:
      - echo alpha
```

`go-yaml` asserts that the proper usage of multiple anchors in a single map is to list them:

```yaml
  - name: beta
    <<: [ *alpine-image, *event-push ]
    commands:
      - echo beta
```

Given how many current users leverage the first configuration, this PR aims to support that format even with the upgrade to go-yaml v3.