### PR TITLE
fix(revert): use buildkite as yaml parser

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,11 +4,11 @@ go 1.23.1
 
 require (
 	github.com/adhocore/gronx v1.19.0
+	github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3
 	github.com/drone/envsubst v1.0.3
 	github.com/ghodss/yaml v1.0.0
 	github.com/lib/pq v1.10.9
 	github.com/microcosm-cc/bluemonday v1.0.27
-	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/adhocore/gronx v1.19.0 h1:GrEvNMPDwXND+YFadCyFVQPC+/xxoGJaQzu+duNf6aU
 github.com/adhocore/gronx v1.19.0/go.mod h1:7oUY1WAU8rEJWmAxXR2DN0JaO4gi9khSgKjiRypqteg=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3 h1:q+sMKdA6L8LyGVudTkpGoC73h6ak2iWSPFiFo/pFOU8=
+github.com/buildkite/yaml v0.0.0-20181016232759-0caa5f0796e3/go.mod h1:5hCug3EZaHXU3FdCA3gJm0YTNi+V+ooA2qNTiVpky4A=
 github.com/drone/envsubst v1.0.3 h1:PCIBwNDYjs50AsLZPYdfhSATKaRg/FJmDc2D6+C2x8g=
 github.com/drone/envsubst v1.0.3/go.mod h1:N2jZmlMufstn1KEqvbHjw40h1KyTmnVzHcSc9bFiJ2g=
 github.com/ghodss/yaml v1.0.0 h1:wQHKEahhL6wmXdzwWG11gIVCkOv05bNOh+Rxn0yngAk=
@@ -27,5 +29,3 @@ gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogR
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/library/string.go
+++ b/library/string.go
@@ -7,8 +7,8 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/buildkite/yaml"
 	json "github.com/ghodss/yaml"
-	"gopkg.in/yaml.v3"
 )
 
 // ToString is a helper function to convert

--- a/raw/map_test.go
+++ b/raw/map_test.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 )
 
 func TestRaw_StringSliceMap_UnmarshalJSON(t *testing.T) {

--- a/raw/slice_test.go
+++ b/raw/slice_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 )
 
 func TestRaw_StringSlice_UnmarshalJSON(t *testing.T) {

--- a/yaml/build_test.go
+++ b/yaml/build_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/library"
 	"github.com/go-vela/types/raw"
@@ -591,6 +591,72 @@ func TestYaml_Build_UnmarshalYAML(t *testing.T) {
 								Destination: "/bar",
 								AccessMode:  "ro",
 							},
+						},
+					},
+				},
+			},
+		},
+		{
+			file: "testdata/merge_anchor.yml",
+			want: &Build{
+				Version: "1",
+				Metadata: Metadata{
+					Template:    false,
+					Clone:       nil,
+					Environment: []string{"steps", "services", "secrets"},
+				},
+				Services: ServiceSlice{
+					{
+						Name:  "service-a",
+						Ports: []string{"5432:5432"},
+						Environment: raw.StringSliceMap{
+							"REGION": "dev",
+						},
+						Image: "postgres",
+						Pull:  "not_present",
+					},
+				},
+				Steps: StepSlice{
+					{
+						Commands: raw.StringSlice{"echo alpha"},
+						Name:     "alpha",
+						Image:    "alpine:latest",
+						Pull:     "not_present",
+						Ruleset: Ruleset{
+							If: Rules{
+								Event: []string{"push"},
+							},
+							Matcher:  "filepath",
+							Operator: "and",
+						},
+					},
+					{
+						Commands: raw.StringSlice{"echo beta"},
+						Name:     "beta",
+						Image:    "alpine:latest",
+						Pull:     "not_present",
+						Ruleset: Ruleset{
+							If: Rules{
+								Event: []string{"push"},
+							},
+							Matcher:  "filepath",
+							Operator: "and",
+						},
+					},
+					{
+						Commands: raw.StringSlice{"echo gamma"},
+						Name:     "gamma",
+						Image:    "alpine:latest",
+						Pull:     "not_present",
+						Environment: raw.StringSliceMap{
+							"REGION": "dev",
+						},
+						Ruleset: Ruleset{
+							If: Rules{
+								Event: []string{"push"},
+							},
+							Matcher:  "filepath",
+							Operator: "and",
 						},
 					},
 				},

--- a/yaml/ruleset_test.go
+++ b/yaml/ruleset_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/secret_test.go
+++ b/yaml/secret_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/service_test.go
+++ b/yaml/service_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"

--- a/yaml/stage_test.go
+++ b/yaml/stage_test.go
@@ -7,8 +7,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/buildkite/yaml"
 	"github.com/google/go-cmp/cmp"
-	"gopkg.in/yaml.v3"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/step_test.go
+++ b/yaml/step_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 	"github.com/go-vela/types/raw"

--- a/yaml/template_test.go
+++ b/yaml/template_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/library"
 )

--- a/yaml/testdata/merge_anchor.yml
+++ b/yaml/testdata/merge_anchor.yml
@@ -1,0 +1,46 @@
+# test file that uses the non-standard multiple anchor keys in one step to test custom step unmarshaler
+
+version: "1"
+
+aliases:
+  images:
+    alpine: &alpine-image
+      image: alpine:latest
+    postgres: &pg-image
+      image: postgres
+
+  events:
+    push: &event-push
+      ruleset:
+        event:
+          - push
+  env:
+    dev-env: &dev-environment
+      environment:
+        REGION: dev 
+
+services:
+  - name: service-a
+    <<: *pg-image
+    <<: *dev-environment
+    ports:
+      - "5432:5432"
+
+steps:
+  - name: alpha
+    <<: *alpine-image
+    <<: *event-push
+    commands:
+      - echo alpha
+
+  - name: beta
+    <<: [ *alpine-image, *event-push ]
+    commands:
+      - echo beta
+
+  - name: gamma
+    <<: *alpine-image
+    <<: *event-push
+    <<: *dev-environment
+    commands:
+      - echo gamma

--- a/yaml/ulimit_test.go
+++ b/yaml/ulimit_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 )

--- a/yaml/volume_test.go
+++ b/yaml/volume_test.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 	"testing"
 
-	"gopkg.in/yaml.v3"
+	"github.com/buildkite/yaml"
 
 	"github.com/go-vela/types/pipeline"
 )


### PR DESCRIPTION
Due to the breaking changes in `v3` and the accelerated timeline of getting `v0.25.0` out the door, our YAML library change will occur in `v0.26`

Additional context: https://github.com/go-vela/types/pull/391 